### PR TITLE
fix(OMN-13141): runtime executor skips event_model import for operation_match entries

### DIFF
--- a/contracts/OMN-13141.yaml
+++ b/contracts/OMN-13141.yaml
@@ -1,0 +1,62 @@
+# OMN-13141 contract file for omnibase_infra deploy-gate.
+# The canonical ticket contract and PASS receipts live in onex_change_control.
+# This file is the per-repo deploy-evidence carrier only.
+schema_version: "1.0.0"
+ticket_id: "OMN-13141"
+title: "fix(OMN-13141): runtime executor skips event_model import for operation_match entries"
+summary: >-
+  Executor companion to OMN-13137's validator half (#1973, merged). _run_event_driven
+  unconditionally imported entry.event_model_module for every resolved routing entry.
+  operation_match entries declare no event_model, so event_model_module is empty and
+  importlib.import_module("") raised ValueError: Empty module name — not caught by the
+  (ImportError, AttributeError) clause, swallowed by the outer except in run_async ->
+  result FAILED. The node never booted end-to-end (e.g. node_integration_sweep_orchestrator).
+  Fix gates the import on a non-empty event_model_module: operation_match forwards the raw
+  decoded payload (input_model_cls=None); only payload_type_match resolves a typed event
+  model. _validate_routing (the OMN-13137 half) is left untouched.
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: "tests"
+    description: "operation_match boot e2e test passes; payload_type_match regression guard holds"
+    command: "uv run pytest tests/unit/runtime/test_run_event_driven_operation_match.py -q"
+  - kind: "ci"
+    description: "CI gates pass on omnibase_infra PR"
+    command: "gh pr checks <PR> --repo OmniNode-ai/omnibase_infra"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-contract-artifact"
+    description: "Repo-local deploy evidence contract is present for OMN-13141"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "test -f contracts/OMN-13141.yaml"
+  - id: "dod-boot-e2e"
+    description: >-
+      operation_match contract boots end-to-end through RuntimeLocal.run_async()
+      with no empty-module ValueError, and the payload_type_match import path is
+      unchanged (regression guard). This boot test is the CI gate for the fix.
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/unit/runtime/test_run_event_driven_operation_match.py -q"
+  - id: "dod-runtime-suite"
+    description: "Full runtime unit suite passes — no regression in the event-driven executor or adapter."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/unit/runtime/ -q"
+  - id: "dod-deploy"
+    description: >-
+      Deploy validation: change is an internal correctness fix to the local-runtime
+      event-driven executor (_run_event_driven) and its bus adapter. No new Kafka topics,
+      no schema changes, no container image changes, no API surface changes. Runtime
+      restart picks up the change automatically on next deploy.
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "echo 'deploy-gate: OMN-13141 is an internal runtime-executor correctness fix; no new topics, schema, or container changes; runtime restart picks it up on next deploy'"

--- a/src/omnibase_infra/runtime/runtime_local.py
+++ b/src/omnibase_infra/runtime/runtime_local.py
@@ -811,18 +811,26 @@ class RuntimeLocal:
                 entry.handler_module, entry.handler_class
             )
 
-            # Import the input model class
-            try:
-                em_mod = importlib.import_module(entry.event_model_module)
-                input_model_cls = getattr(em_mod, entry.event_model_class)
-            except (ImportError, AttributeError) as exc:
-                msg = (
-                    f"Failed to resolve event model "
-                    f"{entry.event_model_module}.{entry.event_model_class}: {exc}"
-                )
-                logger.exception("RuntimeLocal: %s", msg)
-                self._result = EnumWorkflowResult.FAILED
-                return
+            # Resolve the input model class. operation_match entries route by the
+            # `operation` field and declare no event_model, so event_model_module is
+            # empty — skip the import and forward the raw payload (OMN-13141). Only
+            # payload_type_match entries carry a typed event model to import.
+            input_model_type: type[BaseModel] | None = None
+            if entry.event_model_module:
+                try:
+                    em_mod = importlib.import_module(entry.event_model_module)
+                    input_model_type = cast(
+                        "type[BaseModel]",
+                        getattr(em_mod, entry.event_model_class),
+                    )
+                except (ImportError, AttributeError) as exc:
+                    msg = (
+                        f"Failed to resolve event model "
+                        f"{entry.event_model_module}.{entry.event_model_class}: {exc}"
+                    )
+                    logger.exception("RuntimeLocal: %s", msg)
+                    self._result = EnumWorkflowResult.FAILED
+                    return
 
             def _make_fail_cb(name: str) -> Callable[[], None]:
                 def _cb() -> None:
@@ -831,7 +839,6 @@ class RuntimeLocal:
 
                 return _cb
 
-            input_model_type: type[BaseModel] = cast("type[BaseModel]", input_model_cls)
             adapter = LocalRuntimeBusAdapter(
                 handler=cast("ProtocolLocalRuntimeCallableTarget", handler_instance),
                 handler_name=entry.handler_name,

--- a/src/omnibase_infra/runtime/runtime_local_adapter.py
+++ b/src/omnibase_infra/runtime/runtime_local_adapter.py
@@ -46,13 +46,16 @@ class LocalRuntimeBusAdapter:
         self,
         handler: ProtocolLocalRuntimeCallableTarget,
         handler_name: str,
-        input_model_cls: type[BaseModel],
+        input_model_cls: type[BaseModel] | None,
         output_topic: str | None,
         bus: ProtocolLocalRuntimeBus,
         on_error: Callable[[], None] | None = None,
     ) -> None:
         self.handler = handler
         self.handler_name = handler_name
+        # None when the routing entry declares no payload model — operation_match
+        # entries route by `operation`, not a typed event model (OMN-13141). The
+        # raw decoded dict is forwarded to the handler in that case.
         self.input_model_cls = input_model_cls
         self.output_topic = output_topic
         self.bus = bus
@@ -71,7 +74,14 @@ class LocalRuntimeBusAdapter:
             correlation_id = (
                 correlation_value if isinstance(correlation_value, str) else None
             )
-            input_model = self.input_model_cls(**payload_dict)
+            # operation_match entries declare no payload model (OMN-13141): forward
+            # the raw decoded dict. payload_type_match validates against the model.
+            # Typed `object` (model or dict) — helpers narrow with isinstance.
+            input_payload: object = (
+                self.input_model_cls(**payload_dict)
+                if self.input_model_cls is not None
+                else payload_dict
+            )
         except Exception:  # fallback-ok: local runtime adapter records handler failure and continues shutdown
             logger.exception(
                 "LocalRuntimeBusAdapter: deserialization failed for %s (correlation_id=%s)",
@@ -91,7 +101,7 @@ class LocalRuntimeBusAdapter:
         start = time.monotonic()
         try:
             handle_method = self.handler.handle
-            maybe_result = _invoke_handle_method(handle_method, input_model)
+            maybe_result = _invoke_handle_method(handle_method, input_payload)
             if inspect.isawaitable(maybe_result):
                 awaitable_result: Awaitable[object] = cast(
                     "Awaitable[object]", maybe_result
@@ -157,17 +167,30 @@ class LocalRuntimeBusAdapter:
 
 def _invoke_handle_method(
     handle_method: Callable[..., object],
-    input_model: BaseModel,
+    input_payload: object,
 ) -> object:
-    """Invoke a local-runtime handler using its declared calling convention."""
+    """Invoke a local-runtime handler using its declared calling convention.
+
+    ``input_payload`` is a validated model for payload_type_match entries, or the
+    raw decoded dict for operation_match entries that declare no payload model
+    (OMN-13141). Keyword-fanout uses ``model_dump`` for models and the dict
+    directly; single-model-parameter handlers receive the object itself.
+    """
+    kwargs: dict[str, object] = (
+        input_payload.model_dump(mode="json")
+        if isinstance(input_payload, BaseModel)
+        else input_payload
+        if isinstance(input_payload, dict)
+        else {}
+    )
     try:
         signature = inspect.signature(handle_method)
     except (TypeError, ValueError):
-        return handle_method(input_model)
+        return handle_method(input_payload)
 
     parameters = tuple(signature.parameters.values())
     if any(param.kind is inspect.Parameter.VAR_KEYWORD for param in parameters):
-        return handle_method(**input_model.model_dump(mode="json"))
+        return handle_method(**kwargs)
 
     positional_parameters = tuple(
         param
@@ -183,24 +206,25 @@ def _invoke_handle_method(
 
     if len(positional_parameters) == 1 and _parameter_expects_model(
         positional_parameters[0],
-        type(input_model),
+        input_payload,
     ):
-        return handle_method(input_model)
+        return handle_method(input_payload)
 
-    return handle_method(**input_model.model_dump(mode="json"))
+    return handle_method(**kwargs)
 
 
 def _parameter_expects_model(
     parameter: inspect.Parameter,
-    input_model_cls: type[BaseModel],
+    input_payload: object,
 ) -> bool:
-    """Return True when a single handle parameter expects the request model."""
+    """Return True when a single handle parameter expects the whole request object."""
     if parameter.name in {"request", "payload", "event", "input_model"}:
         return True
 
     annotation = parameter.annotation
     return (
-        isinstance(annotation, type)
+        isinstance(input_payload, BaseModel)
+        and isinstance(annotation, type)
         and issubclass(annotation, BaseModel)
-        and issubclass(input_model_cls, annotation)
+        and issubclass(type(input_payload), annotation)
     )

--- a/tests/unit/runtime/test_run_event_driven_operation_match.py
+++ b/tests/unit/runtime/test_run_event_driven_operation_match.py
@@ -1,0 +1,272 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""End-to-end boot tests for OMN-13141: _run_event_driven executor half.
+
+Disjoint companion to OMN-13137 (#1973). OMN-13137 fixed only the VALIDATOR
+half (`_validate_routing` is strategy-aware). This file covers the EXECUTOR
+half: `_run_event_driven` wiring loop.
+
+Root cause (L816): for `routing_strategy: operation_match`, handler entries carry
+no `event_model` block, so `_resolve_routing_entries` yields
+`event_model_module=""`. The wiring loop then calls
+`importlib.import_module("")`, which raises `ValueError: Empty module name`.
+That `ValueError` is NOT caught by the `(ImportError, AttributeError)` clause and
+propagates to the outer `except Exception` in `run_async` -> result FAILED. The
+node never boots end-to-end.
+
+Validator-half test 4 (`test_validate_routing_operation_match.py`) only calls
+`_validate_routing` — it does NOT boot through `run_async()`, so it cannot catch
+this path. These tests boot the real `run_async()` event-driven path.
+
+Fix: skip the event-model import when `event_model_module` is empty (operation
+routes by `operation`, not a payload model); wire the adapter with no input
+model. payload_type_match keeps importing its event model (regression guard).
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from omnibase_core.enums.enum_workflow_result import EnumWorkflowResult
+from omnibase_infra.runtime.runtime_local import RuntimeLocal
+
+# ---------------------------------------------------------------------------
+# Test 1 — operation_match contract boots via run_async without ValueError
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_operation_match_contract_boots_via_run_async(tmp_path: Path) -> None:
+    """An operation_match contract (no event_model) boots end-to-end.
+
+    Before OMN-13141 the wiring loop calls importlib.import_module("") for the
+    empty event_model_module and raises ValueError: Empty module name, which the
+    outer except in run_async swallows -> result FAILED. After the fix the
+    handler is wired without importing a payload model and the workflow reaches
+    its terminal event -> COMPLETED.
+    """
+
+    class _OperationInput(BaseModel):
+        correlation_id: str
+
+    class _OperationTerminal(BaseModel):
+        correlation_id: str
+        status: str = "success"
+
+    class _OperationHandler:
+        async def handle(self, correlation_id: str) -> _OperationTerminal:
+            return _OperationTerminal(correlation_id=correlation_id)
+
+    mod_input = types.ModuleType("_test_opmatch_input")
+    mod_input._OperationInput = _OperationInput  # type: ignore[attr-defined]
+    mod_handler = types.ModuleType("_test_opmatch_handler")
+    mod_handler._OperationHandler = _OperationHandler  # type: ignore[attr-defined]
+
+    sys.modules["_test_opmatch_input"] = mod_input
+    sys.modules["_test_opmatch_handler"] = mod_handler
+
+    try:
+        # operation_match handler entry deliberately omits event_model — this is
+        # the canonical shape that produced event_model_module="" -> L816 crash.
+        contract_yaml = (
+            "name: test_operation_match_boot\n"
+            "contract_version: {major: 1, minor: 0, patch: 0}\n"
+            "node_type: orchestrator\n"
+            "description: operation_match boot test\n"
+            "initial_command: cmd.op.start.v1\n"
+            "terminal_event: evt.op.done.v1\n"
+            "event_bus:\n"
+            "  subscribe_topics:\n"
+            "    - cmd.op.start.v1\n"
+            "  publish_topics:\n"
+            "    - evt.op.done.v1\n"
+            "input_model:\n"
+            "  module: _test_opmatch_input\n"
+            "  class: _OperationInput\n"
+            "handler_routing:\n"
+            "  routing_strategy: operation_match\n"
+            "  handlers:\n"
+            "    - operation: do_op\n"
+            "      handler:\n"
+            "        name: _OperationHandler\n"
+            "        module: _test_opmatch_handler\n"
+        )
+        workflow = tmp_path / "operation_match_boot.yaml"
+        workflow.write_text(contract_yaml)
+
+        runtime = RuntimeLocal(
+            workflow_path=workflow,
+            state_root=tmp_path / "state",
+            timeout=10,
+        )
+        result = await runtime.run_async()
+
+        # The node must not FAIL from the empty-module ValueError. Before the fix
+        # this asserts COMPLETED but receives FAILED.
+        assert result != EnumWorkflowResult.FAILED, (
+            "operation_match contract failed to boot — likely the empty "
+            "event_model_module ValueError at the wiring loop (OMN-13141)"
+        )
+        assert result == EnumWorkflowResult.COMPLETED
+
+        # No FAILED state persisted from an import crash.
+        import json
+
+        state_file = tmp_path / "state" / "workflow_result.json"
+        assert state_file.exists()
+        state_data = json.loads(state_file.read_text())
+        assert state_data["result"] == "completed"
+    finally:
+        sys.modules.pop("_test_opmatch_input", None)
+        sys.modules.pop("_test_opmatch_handler", None)
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — operation_match wiring does not raise ValueError: Empty module name
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_operation_match_wiring_does_not_import_empty_module(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The wiring loop must never call importlib.import_module("").
+
+    Guards the exact failure mode: a spy on importlib.import_module asserts the
+    empty string is never passed (operation_match entries have no event model to
+    import). The handler module is still imported, so the spy sees non-empty
+    names only.
+    """
+    import importlib
+
+    class _OpHandler:
+        async def handle(self, correlation_id: str) -> None:
+            return None
+
+    mod_handler = types.ModuleType("_test_opmatch_spy_handler")
+    mod_handler._OpHandler = _OpHandler  # type: ignore[attr-defined]
+    sys.modules["_test_opmatch_spy_handler"] = mod_handler
+
+    real_import_module = importlib.import_module
+    empty_calls: list[str] = []
+
+    def _spy_import_module(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "":
+            empty_calls.append(name)
+        return real_import_module(name, *args, **kwargs)
+
+    monkeypatch.setattr(
+        "omnibase_infra.runtime.runtime_local.importlib.import_module",
+        _spy_import_module,
+    )
+
+    try:
+        contract_yaml = (
+            "name: test_operation_match_spy\n"
+            "contract_version: {major: 1, minor: 0, patch: 0}\n"
+            "node_type: orchestrator\n"
+            "description: operation_match spy test\n"
+            "terminal_event: evt.op.done.v1\n"
+            "event_bus:\n"
+            "  subscribe_topics:\n"
+            "    - cmd.op.start.v1\n"
+            "  publish_topics:\n"
+            "    - evt.op.done.v1\n"
+            "handler_routing:\n"
+            "  routing_strategy: operation_match\n"
+            "  handlers:\n"
+            "    - operation: do_op\n"
+            "      handler:\n"
+            "        name: _OpHandler\n"
+            "        module: _test_opmatch_spy_handler\n"
+        )
+        workflow = tmp_path / "operation_match_spy.yaml"
+        workflow.write_text(contract_yaml)
+
+        runtime = RuntimeLocal(
+            workflow_path=workflow,
+            state_root=tmp_path / "state",
+            timeout=10,
+        )
+        await runtime.run_async()
+
+        assert empty_calls == [], (
+            "importlib.import_module('') was called during operation_match "
+            "wiring — empty event_model_module must be skipped (OMN-13141)"
+        )
+    finally:
+        sys.modules.pop("_test_opmatch_spy_handler", None)
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — payload_type_match still imports its event model (regression guard)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_payload_type_match_still_imports_event_model(tmp_path: Path) -> None:
+    """payload_type_match path is unchanged — its event model is still imported.
+
+    A payload_type_match entry pointing at a non-importable event_model module
+    must still FAIL (the import error is real). This guards against the fix
+    over-broadly skipping imports for the payload strategy.
+    """
+
+    class _PtInput(BaseModel):
+        correlation_id: str
+
+    class _PtHandler:
+        async def handle(self, correlation_id: str) -> None:
+            return None
+
+    mod_handler = types.ModuleType("_test_ptmatch_handler")
+    mod_handler._PtHandler = _PtHandler  # type: ignore[attr-defined]
+    sys.modules["_test_ptmatch_handler"] = mod_handler
+
+    try:
+        contract_yaml = (
+            "name: test_payload_type_match_bad_model\n"
+            "contract_version: {major: 1, minor: 0, patch: 0}\n"
+            "node_type: orchestrator\n"
+            "description: payload_type_match bad event model\n"
+            "terminal_event: evt.pt.done.v1\n"
+            "event_bus:\n"
+            "  subscribe_topics:\n"
+            "    - cmd.pt.start.v1\n"
+            "  publish_topics:\n"
+            "    - evt.pt.done.v1\n"
+            "handler_routing:\n"
+            "  routing_strategy: payload_type_match\n"
+            "  handlers:\n"
+            "    - event_model:\n"
+            "        name: NotThere\n"
+            "        module: _test_nonexistent_event_model_module\n"
+            "      handler:\n"
+            "        name: _PtHandler\n"
+            "        module: _test_ptmatch_handler\n"
+        )
+        workflow = tmp_path / "payload_type_match_bad.yaml"
+        workflow.write_text(contract_yaml)
+
+        runtime = RuntimeLocal(
+            workflow_path=workflow,
+            state_root=tmp_path / "state",
+            timeout=10,
+        )
+        result = await runtime.run_async()
+
+        # The event model import genuinely fails -> FAILED is correct here.
+        assert result == EnumWorkflowResult.FAILED
+    finally:
+        sys.modules.pop("_test_ptmatch_handler", None)


### PR DESCRIPTION
## OMN-13141 — runtime executor skips event_model import for operation_match entries

Executor companion to **OMN-13137** (#1973, merged on `dev`), which fixed only the **validator** half. This PR fixes the disjoint **executor** half.

### Problem
`RuntimeLocal._run_event_driven` (`src/omnibase_infra/runtime/runtime_local.py`) unconditionally called `importlib.import_module(entry.event_model_module)` + `getattr(...)` for **every** resolved routing entry. The `except` clause caught only `(ImportError, AttributeError)`.

For `operation_match` routing entries (e.g. `node_integration_sweep_orchestrator`), handler entries carry **no `event_model`**, so `_resolve_routing_entries` yields `event_model_module=""`. Then `importlib.import_module("")` raised **`ValueError: Empty module name`** at `runtime_local.py:816` — not caught by the `(ImportError, AttributeError)` clause, swallowed by the outer `except Exception` in `run_async` → workflow result **FAILED**. The node never booted end-to-end.

OMN-13137 fixed only `_validate_routing` (the static validation half); its test only validated the routing block, never booted through `run_async()`, so this path was uncovered.

### Fix
Gate the `importlib.import_module` / `getattr` block on a **non-empty `event_model_module`**:
- `operation_match` entries route by the `operation` field and declare no payload model → skip the import, wire the adapter with `input_model_cls=None`, and forward the raw decoded payload dict.
- `payload_type_match` entries still resolve their typed event model (unchanged).

`LocalRuntimeBusAdapter` now accepts `input_model_cls: type[BaseModel] | None`; on `None` it forwards the raw decoded dict to the handler. No silent broadening of the `except` — the skip is gated explicitly on the empty-module condition. `_validate_routing` is **left untouched** (OMN-13137 owns it).

### CI boot gate
`tests/unit/runtime/test_run_event_driven_operation_match.py` boots an `operation_match` contract (empty event_model) through `RuntimeLocal.run_async()` and asserts:
1. no `ValueError: Empty module name` / result != FAILED-from-import (the bug);
2. `importlib.import_module("")` is never called during operation_match wiring;
3. `payload_type_match` still imports its event model (regression guard — a bad event_model module still FAILS).

This test runs in the standard CI unit job (`@pytest.mark.unit`, no infra markers), so it is wired as a pre-merge gate.

### Verification (local, in worktree)
- `uv run ruff format src/ tests/ && uv run ruff check --fix src/ tests/` — clean
- `uv run mypy src/omnibase_infra/runtime/runtime_local.py src/omnibase_infra/runtime/runtime_local_adapter.py --strict` — Success, no issues
- `uv run pytest tests/unit/runtime/ -q` — 4886 passed, 5 skipped (pre-existing)
- New e2e test: **2 fail on `origin/dev` (bug reproduced at L816), 3 pass with the fix**
- `pre-commit run` on changed files — all hooks pass (incl. union budget gate)

### dod_evidence
Per `contracts/OMN-13141.yaml` (this PR):
- `dod-boot-e2e`: `uv run pytest tests/unit/runtime/test_run_event_driven_operation_match.py -q`
- `dod-runtime-suite`: `uv run pytest tests/unit/runtime/ -q`
- `dod-deploy`: internal runtime-executor correctness fix; no new topics/schema/container changes; runtime restart picks it up.

### OCC pairing
Paired OCC receipt PR: **OmniNode-ai/onex_change_control#2620** (contract `contracts/OMN-13141.yaml` + PASS receipts under `drift/dod_receipts/OMN-13141/`; verifier `receipt-gate-local` ≠ runner).

Receipt Gate / DoD Gate evidence for **OMN-13141**:

Evidence-Source: OCC#2620
Evidence-Ticket: OMN-13141

(OCC#2620 carries `contracts/OMN-13141.yaml` + PASS receipts under `drift/dod_receipts/OMN-13141/`; infra PR head is `6d9402bbe43dc3379f4a2e72de35a60c5f0d7262`.)

Closes OMN-13141. Parent: OMN-13119 (delegation chain drift). Disjoint from #1973 / OMN-13137 (Done) — touches only `_run_event_driven`, never `_validate_routing`.

Receipt re-validated against OCC#2620 head 8fc03029e (contract_sha256 added).
