### PR TITLE
fix(OMN-8724): coerce dict payload into typed handler model at dispatch boundary + SkillRoutingError envelope

### DIFF
--- a/src/omnibase_infra/cli/cli_node.py
+++ b/src/omnibase_infra/cli/cli_node.py
@@ -15,6 +15,7 @@ See ``docs/plans/2026-04-16-prove-core-runtime-standalone.md`` § Task 3.
 from __future__ import annotations
 
 import importlib.util
+import json
 import logging
 import sys
 from importlib.metadata import entry_points
@@ -22,6 +23,7 @@ from pathlib import Path
 
 import click
 
+from omnibase_core.enums.enum_workflow_result import EnumWorkflowResult
 from omnibase_core.models.errors.model_onex_error import ModelOnexError
 from omnibase_infra.cli.receipt_mode import (
     default_emit_socket_path,
@@ -29,6 +31,31 @@ from omnibase_infra.cli.receipt_mode import (
 )
 from omnibase_infra.runtime.runtime_local import RuntimeLocal, parse_backend_overrides
 from omnibase_infra.utils.util_error_sanitization import sanitize_error_message
+
+
+def _emit_skill_routing_error(
+    node_id: str,
+    result: EnumWorkflowResult,
+    last_error: str | None,
+) -> None:
+    """Emit the documented ``SkillRoutingError`` JSON envelope to stdout.
+
+    Skill shells (e.g. ``golden_chain_sweep``) dispatch via ``onex node`` and
+    document that a non-zero exit surfaces a ``SkillRoutingError`` JSON envelope
+    rather than a raw traceback (OMN-8724). The default (non-receipt) path
+    previously left only the runtime's stderr traceback, so callers had no
+    machine-readable envelope to surface. This emits the same envelope shape as
+    ``omnibase_core.cli.cli_run_node._emit_error`` so both dispatch surfaces are
+    consistent.
+    """
+    envelope: dict[str, str] = {
+        "error_type": "SkillRoutingError",
+        "message": last_error
+        or f"Node '{node_id}' run did not complete (result={result.value}).",
+        "node_id": node_id,
+        "result": result.value,
+    }
+    click.echo(json.dumps(envelope, indent=2))
 
 
 def _resolve_packaged_contract(node_name: str) -> Path:
@@ -220,5 +247,7 @@ def run_node_by_name(
         input_path=input_path,
         timeout=timeout,
     )
-    runtime.run()
+    result = runtime.run()
+    if result is not EnumWorkflowResult.COMPLETED:
+        _emit_skill_routing_error(node_name, result, runtime.last_error)
     sys.exit(runtime.exit_code)

--- a/src/omnibase_infra/runtime/runtime_local.py
+++ b/src/omnibase_infra/runtime/runtime_local.py
@@ -1505,6 +1505,16 @@ class RuntimeLocal:
         return _exit_code_for(self._result)
 
     @property
+    def last_error(self) -> str | None:
+        """Human-readable description of the failure that ended the run, if any.
+
+        Set when a wired handler fails or a routing/boot error aborts the run;
+        ``None`` on a clean completion. Consumed by the ``onex node`` CLI to
+        populate the ``SkillRoutingError`` envelope on non-zero exit (OMN-8724).
+        """
+        return self._last_error
+
+    @property
     def handler_result(self) -> object | None:
         """The terminal handler's result object, if the run produced one.
 

--- a/src/omnibase_infra/runtime/runtime_local_adapter.py
+++ b/src/omnibase_infra/runtime/runtime_local_adapter.py
@@ -175,6 +175,16 @@ def _invoke_handle_method(
     raw decoded dict for operation_match entries that declare no payload model
     (OMN-13141). Keyword-fanout uses ``model_dump`` for models and the dict
     directly; single-model-parameter handlers receive the object itself.
+
+    When the handler's sole positional parameter is annotated with a concrete
+    ``BaseModel`` subclass but ``input_payload`` is still the raw decoded dict
+    (the operation_match case — no contract-declared event model to validate
+    against upstream), the dict is validated into that annotated type here
+    before the call (OMN-8724). Without this coercion a typed single-parameter
+    handler such as ``handle(self, request: GoldenChainSweepRequest)`` receives
+    a bare ``dict`` and crashes on the first attribute access. This is the
+    systemic fix for the dict-not-typed dispatch-boundary class (same family as
+    OMN-13141 / the savings_estimation ``.get()`` bug).
     """
     kwargs: dict[str, object] = (
         input_payload.model_dump(mode="json")
@@ -183,10 +193,20 @@ def _invoke_handle_method(
         if isinstance(input_payload, dict)
         else {}
     )
+    # eval_str=True resolves PEP 563 string annotations (``from __future__ import
+    # annotations`` is used by every node handler, so without this the parameter
+    # annotation is the literal string "GoldenChainSweepRequest" and the
+    # BaseModel-subclass check below never matches — the OMN-8724 root cause).
     try:
-        signature = inspect.signature(handle_method)
-    except (TypeError, ValueError):
-        return handle_method(input_payload)
+        signature = inspect.signature(handle_method, eval_str=True)
+    except (TypeError, ValueError, NameError):
+        # NameError: an annotation referenced a name not importable in the
+        # handler module globals. Fall back to unevaluated annotations rather
+        # than aborting dispatch.
+        try:
+            signature = inspect.signature(handle_method)
+        except (TypeError, ValueError):
+            return handle_method(input_payload)
 
     parameters = tuple(signature.parameters.values())
     if any(param.kind is inspect.Parameter.VAR_KEYWORD for param in parameters):
@@ -204,20 +224,52 @@ def _invoke_handle_method(
     if len(positional_parameters) == 0:
         return handle_method()
 
-    if len(positional_parameters) == 1 and _parameter_expects_model(
-        positional_parameters[0],
-        input_payload,
-    ):
-        return handle_method(input_payload)
+    if len(positional_parameters) == 1:
+        model_type = _coercion_target_model_type(
+            positional_parameters[0],
+            input_payload,
+        )
+        if model_type is not None:
+            # Annotation is a concrete BaseModel subclass and the payload is a
+            # raw dict: validate the dict into the declared type before calling.
+            return handle_method(model_type.model_validate(input_payload))
+        if _parameter_expects_model(positional_parameters[0], input_payload):
+            return handle_method(input_payload)
 
     return handle_method(**kwargs)
+
+
+def _coercion_target_model_type(
+    parameter: inspect.Parameter,
+    input_payload: object,
+) -> type[BaseModel] | None:
+    """Return the annotated ``BaseModel`` subclass to coerce a raw dict payload into.
+
+    Returns ``None`` unless ``input_payload`` is a raw ``dict`` and the
+    parameter's annotation is a concrete ``BaseModel`` subclass. This is the only
+    coercion trigger (OMN-8724): a real annotation, not a parameter-name
+    heuristic, drives it — so a model-typed single-parameter handler reached via
+    ``operation_match`` (no upstream event-model validation) gets a validated
+    model instead of the raw dict that previously crashed it.
+    """
+    if not isinstance(input_payload, dict):
+        return None
+    annotation = parameter.annotation
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        return annotation
+    return None
 
 
 def _parameter_expects_model(
     parameter: inspect.Parameter,
     input_payload: object,
 ) -> bool:
-    """Return True when a single handle parameter expects the whole request object."""
+    """Return True when a single handle parameter should receive the payload object.
+
+    Only reached after dict→model coercion has been considered
+    (``_coercion_target_model_type``), so this governs the already-a-model and
+    name-heuristic pass-through paths that pre-date OMN-8724.
+    """
     if parameter.name in {"request", "payload", "event", "input_model"}:
         return True
 

--- a/tests/unit/cli/test_cli_node.py
+++ b/tests/unit/cli/test_cli_node.py
@@ -14,6 +14,7 @@ Covers the 5 CLI migration branches:
 from __future__ import annotations
 
 import importlib.util
+import json
 from importlib.machinery import ModuleSpec
 from importlib.metadata import entry_points
 from pathlib import Path
@@ -174,6 +175,55 @@ def test_packaged_contract_resolution_does_not_import_node_module(
 
     assert contract == fake_pkg / "contract.yaml"
     find_spec.assert_called_once_with("fake_pkg")
+
+
+def test_default_mode_failure_emits_skill_routing_error_envelope(
+    tmp_path: Path,
+) -> None:
+    """A non-zero default-mode run emits a ``SkillRoutingError`` JSON envelope.
+
+    The ``golden_chain_sweep`` skill (and others) document that ``onex node``
+    surfaces a ``SkillRoutingError`` JSON envelope on non-zero exit rather than a
+    raw traceback (OMN-8724). This drives a FAILED run via a bogus handler module
+    and asserts the documented envelope is on stdout with the expected keys.
+    """
+    node_name = _first_resolvable_packaged_node_name()
+    if node_name is None:
+        pytest.skip("No resolvable onex.nodes packaged contract registered in this env")
+
+    override = tmp_path / "custom_contract.yaml"
+    override.write_text(
+        "---\n"
+        "name: custom\n"
+        "node_type: compute\n"
+        "handler:\n"
+        "  module: does.not.exist.anywhere_zzzqqq\n"
+        "  class: Nope\n",
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        run_node_by_name,
+        [
+            node_name,
+            "--contract",
+            str(override),
+            "--state-root",
+            str(tmp_path / "state"),
+            "--timeout",
+            "5",
+        ],
+    )
+
+    assert result.exit_code == 1
+    # The last JSON object in stdout is the SkillRoutingError envelope.
+    start = result.output.rfind("{")
+    assert start != -1, f"no JSON envelope in output: {result.output!r}"
+    envelope = json.loads(result.output[start:])
+    assert envelope["error_type"] == "SkillRoutingError"
+    assert envelope["node_id"] == node_name
+    assert envelope["result"] == "failed"
+    assert envelope["message"]
 
 
 def test_input_file_not_found_surfaces_cli_error(tmp_path: Path) -> None:

--- a/tests/unit/runtime/test_runtime_local_operation_match_typed_handler.py
+++ b/tests/unit/runtime/test_runtime_local_operation_match_typed_handler.py
@@ -1,0 +1,194 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Real-dispatch-path coverage for typed single-model-parameter handlers reached
+via ``operation_match`` routing (OMN-8724).
+
+``operation_match`` routing entries declare no event model, so the runtime wires
+the adapter with ``input_model_cls=None`` and forwards the raw decoded dict
+(OMN-13141). When such a handler declares a single positional parameter annotated
+with a concrete ``BaseModel`` subclass — e.g. ``handle(self, request:
+GoldenChainSweepRequest)`` — the adapter must validate the dict into that type
+before calling. Before OMN-8724 it forwarded the bare dict and the handler
+crashed on the first attribute access (``AttributeError: 'dict' object has no
+attribute '<field>'``) the moment it ran through ``onex node`` / RuntimeLocal,
+even though the module ``__main__`` entrypoint (which builds the model itself)
+worked.
+
+These tests boot the real ``RuntimeLocal._run_event_driven`` path end-to-end —
+not the handler in isolation — so they would have caught the dispatch-boundary
+crash. Handler-isolation tests pass while the live ``onex node`` path fails;
+this is the regression guard for the live path.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.enum_workflow_result import EnumWorkflowResult
+from omnibase_infra.runtime.runtime_local import RuntimeLocal
+from omnibase_infra.runtime.runtime_local_adapter import _invoke_handle_method
+
+# ---------------------------------------------------------------------------
+# Typed request/result models + a single-model-parameter handler that mirrors
+# NodeGoldenChainSweep.handle(self, request: GoldenChainSweepRequest).
+# ---------------------------------------------------------------------------
+
+
+class _TypedRequest(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    correlation_id: str = ""
+    items: list[str] = Field(default_factory=list)
+
+
+class _TypedResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    correlation_id: str = ""
+    item_count: int = 0
+    status: str = "success"
+
+
+class _TypedRequestHandler:
+    """Sync handler whose sole positional parameter is a concrete BaseModel.
+
+    Accesses an attribute on the request immediately — the exact shape that
+    crashed in node_golden_chain_sweep when handed a raw dict.
+    """
+
+    def handle(self, request: _TypedRequest) -> _TypedResult:
+        return _TypedResult(
+            correlation_id=request.correlation_id,
+            item_count=len(request.items),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Unit-level: _invoke_handle_method coerces a dict into the annotated model.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_invoke_coerces_dict_into_single_model_parameter() -> None:
+    """A raw dict payload is validated into the handler's annotated BaseModel."""
+    handler = _TypedRequestHandler()
+    payload = {"correlation_id": "cid-coerce", "items": ["a", "b", "c"]}
+
+    result = _invoke_handle_method(handler.handle, payload)
+
+    assert isinstance(result, _TypedResult)
+    assert result.correlation_id == "cid-coerce"
+    assert result.item_count == 3
+
+
+@pytest.mark.unit
+def test_invoke_does_not_double_wrap_model_payload() -> None:
+    """When the payload is already the model instance, it is passed through."""
+    handler = _TypedRequestHandler()
+    request = _TypedRequest(correlation_id="cid-model", items=["x"])
+
+    result = _invoke_handle_method(handler.handle, request)
+
+    assert isinstance(result, _TypedResult)
+    assert result.correlation_id == "cid-model"
+    assert result.item_count == 1
+
+
+@pytest.mark.unit
+def test_invoke_dict_coercion_raises_on_invalid_payload() -> None:
+    """An invalid dict surfaces a pydantic ValidationError, not AttributeError.
+
+    Fail-fast: bad data must fail validation at the boundary, not silently slip
+    a malformed object into the handler.
+    """
+    from pydantic import ValidationError
+
+    handler = _TypedRequestHandler()
+    # extra="forbid" rejects unknown keys → ValidationError (not AttributeError).
+    with pytest.raises(ValidationError):
+        _invoke_handle_method(handler.handle, {"unexpected_field": 1})
+
+
+# ---------------------------------------------------------------------------
+# Real-dispatch-path: boot an operation_match contract whose handler takes a
+# single typed-model parameter, through RuntimeLocal.run_async().
+# ---------------------------------------------------------------------------
+
+
+_CMD_TOPIC = "onex.cmd.test.typed-operation-match-start.v1"
+_EVT_TOPIC = "onex.evt.test.typed-operation-match-completed.v1"
+
+
+def _typed_operation_match_contract() -> str:
+    return (
+        "name: test_typed_operation_match\n"
+        "contract_version: {major: 1, minor: 0, patch: 0}\n"
+        "node_type: compute\n"
+        "description: operation_match handler with a single typed-model parameter\n"
+        "terminal_event: " + _EVT_TOPIC + "\n"
+        "event_bus:\n"
+        "  subscribe_topics:\n"
+        "    - " + _CMD_TOPIC + "\n"
+        "  publish_topics:\n"
+        "    - " + _EVT_TOPIC + "\n"
+        "handler_routing:\n"
+        "  routing_strategy: operation_match\n"
+        "  handlers:\n"
+        "    - operation: run_typed\n"
+        "      handler:\n"
+        "        name: _TypedRequestHandler\n"
+        "        module: _test_typed_op_match_handler\n"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_operation_match_typed_handler_boots_via_run_async(
+    tmp_path: Path,
+) -> None:
+    """A typed single-model-parameter handler completes via the real dispatch path.
+
+    Regression guard for OMN-8724: before the fix, the adapter forwarded the raw
+    decoded dict to ``handle(self, request: _TypedRequest)`` and the run ended
+    FAILED with ``AttributeError: 'dict' object has no attribute ...``. The fix
+    validates the dict into ``_TypedRequest`` first, so the run COMPLETES and the
+    terminal event carries the handler's result.
+    """
+    mod = types.ModuleType("_test_typed_op_match_handler")
+    mod._TypedRequestHandler = _TypedRequestHandler  # type: ignore[attr-defined]
+    sys.modules["_test_typed_op_match_handler"] = mod
+
+    try:
+        contract = tmp_path / "contract.yaml"
+        contract.write_text(_typed_operation_match_contract())
+
+        runtime = RuntimeLocal(
+            workflow_path=contract,
+            state_root=tmp_path / "state",
+            timeout=10,
+        )
+        result = await runtime.run_async()
+
+        assert result == EnumWorkflowResult.COMPLETED, (
+            f"typed operation_match handler did not complete: "
+            f"result={result.value} last_error={runtime.last_error!r}"
+        )
+        assert runtime.last_error is None
+
+        state_data = json.loads(
+            (tmp_path / "state" / "workflow_result.json").read_text()
+        )
+        assert state_data["result"] == "completed"
+        assert state_data["exit_code"] == 0
+        # Terminal payload carries the handler's typed result, proving the dict
+        # was validated into _TypedRequest and processed.
+        assert state_data["terminal_payload"]["status"] == "success"
+    finally:
+        sys.modules.pop("_test_typed_op_match_handler", None)


### PR DESCRIPTION
## OMN-8724 — coerce dict payload into typed handler model at the dispatch boundary

Fixes the confirmed `node_golden_chain_sweep` crash via the canonical `onex node` path (BUG A in the integration-tooling triage): `AttributeError: 'dict' object has no attribute 'chains'` at `handler_golden_chain_sweep.py` because `runtime_local_adapter._invoke_handle_method` handed the raw decoded dict to `handle(self, request: GoldenChainSweepRequest)` instead of the typed model.

### Layer decision — A1 (systemic), not A2 (narrow)
Chose **A1**: coerce the dict into the handler's declared input type inside `omnibase_infra.runtime.runtime_local_adapter`, fixing the whole dict-not-typed dispatch-boundary class (same family as OMN-13141 / the savings_estimation `.get()` bug) — not a per-node `model_validate` band-aid. Blast radius is bounded and regression-free: coercion fires **only** when (a) the payload is a raw `dict` AND (b) the handler's single positional parameter is annotated with a concrete `BaseModel` subclass. That combination previously **always crashed**, so the only behavior change is crash → success. All pre-existing pass-through paths (already-a-model, name-heuristic, kwargs-fanout, zero/var-keyword params) are unchanged.

### Root cause completion — PEP 563 string annotations
Every node handler uses `from __future__ import annotations`, so `inspect.signature(...).parameters[0].annotation` was the literal string `"GoldenChainSweepRequest"`, and the `issubclass(annotation, BaseModel)` check never matched. Fixed by resolving forward refs with `inspect.signature(handle_method, eval_str=True)` (graceful fallback to unevaluated on `NameError`).

### Step 3 — SkillRoutingError envelope
`cli_node` default (non-receipt) mode now emits the documented `SkillRoutingError` JSON envelope to stdout on non-zero exit instead of leaving only a stderr traceback. The `golden_chain_sweep` SKILL.md documents this contract ("Non-zero exit emits a `SkillRoutingError` JSON envelope — surface it verbatim"). Envelope shape matches `omnibase_core.cli.cli_run_node._emit_error`. `RuntimeLocal` gains a public `last_error` property to populate `message`.

### CI gate — real dispatch path
`tests/unit/runtime/test_runtime_local_operation_match_typed_handler.py` boots a typed single-model-parameter handler through `RuntimeLocal.run_async()` (the real `operation_match` dispatch path) and asserts the run COMPLETES. This is the test that "would have caught this" — handler-isolation tests pass while the live path crashed. Plus `cli_node` test asserting the `SkillRoutingError` envelope on a failed default-mode run.

### Verification (local, in worktree)
- `uv run ruff format` / `ruff check --fix` on changed files — clean
- `uv run mypy src/omnibase_infra/runtime/runtime_local_adapter.py src/omnibase_infra/runtime/runtime_local.py src/omnibase_infra/cli/cli_node.py --strict` — Success, 3 files
- New test: FAILS (`AttributeError: 'dict' object has no attribute 'correlation_id'`) on origin/dev, PASSES with fix
- `uv run pytest tests/unit/runtime/ tests/unit/cli/` — 5157 passed (the only failures are an env-artifact skip-test that requires omnimarket installed, and a load-sensitive perf stress test that passes in isolation — both pre-existing, unrelated)
- `pre-commit run` on changed files — all hooks pass (incl. union budget gate)
- **End-to-end proof:** `uv run onex node node_golden_chain_sweep` → `result=completed` (was `result=failed` + traceback on origin/dev). `.onex_state/workflow_result.json` terminal_payload `status: pass`.

### Companion PR
omnimarket `jonah/omn-8724-golden-chain-sweep-downgrade-claim` adds the runtime-injected `correlation_id` field to `GoldenChainSweepRequest` and downgrades the node/skill evidence claim (the node is pure compute over caller-supplied rows — never live evidence). Both land independently on dev.

### dod_evidence / OCC pairing
Paired OCC receipt PR in onex_change_control carries `contracts/OMN-8724.yaml` + PASS receipts under `drift/dod_receipts/OMN-8724/`.

Evidence-Source: OCC#2626
Evidence-Ticket: OMN-8724

Closes OMN-8724 (crash + SkillRoutingError halves). Parent: OMN-8718.
