### PR TITLE
fix(OMN-13150): vendor agent_routing_decisions per-node migration to omnidash_analytics (FIX-1)

### DIFF
--- a/docker/migrations/forward/nodes/node_projection_routing_decision/0021_create_agent_routing_decisions.sql
+++ b/docker/migrations/forward/nodes/node_projection_routing_decision/0021_create_agent_routing_decisions.sql
@@ -1,0 +1,58 @@
+-- OMN-13150 (FIX-1): agent_routing_decisions projection table in omnidash_analytics.
+-- Target DB: omnidash_analytics (omnibase_infra postgres on .201:5436)
+-- Node: omnimarket.nodes.node_projection_routing_decision (DDL owner for the
+--       omnidash_analytics copy of agent_routing_decisions).
+-- Source topic: onex.evt.omniclaude.routing-decision.v1
+-- Idempotency: INSERT ... ON CONFLICT (id) DO NOTHING (append-only observability).
+--
+-- WHY THIS MIGRATION EXISTS
+-- The projection node's contract declares db_io.db_tables[0].database: omnidash_analytics,
+-- and the runtime DB resolution (ModelProjectionRuntimeBinding.from_legacy_settings and the
+-- projection-api _projection_database_binding_from_settings) both resolve
+-- omnidash_analytics_db_url FIRST. The contract-declared AND runtime-resolved target is
+-- therefore omnidash_analytics. But the base DDL
+-- (omnibase_infra docker/migrations/forward/021_create_agent_routing_decisions_table.sql)
+-- is applied by the flat infra forward set to the omnibase_infra DB only, so
+-- agent_routing_decisions never landed in omnidash_analytics. All sibling projection tables
+-- (session_outcomes, llm_call_metrics, pattern_learning_artifacts, llm_routing_decisions,
+-- node_service_registry, savings_estimates, ...) live in omnidash_analytics via per-node
+-- migrations under <node>/migrations/, vendored into
+-- omnibase_infra/docker/migrations/forward/nodes/<node>/ and applied to $NODE_PGDB
+-- (omnidash_analytics) by run-forward-migrations.sh. node_projection_routing_decision was
+-- the only projection node missing its per-node migration; this file closes the gap.
+--
+-- This node-owned migration is SELF-CONTAINED and idempotent: every statement is
+-- IF NOT EXISTS, so applying it to omnidash_analytics is independent of the flat infra 021
+-- (which targets a different DB). Schema is identical to the flat infra 021 table
+-- (id PK + the OMN-2057 project-context columns absorbed from omniclaude).
+
+CREATE TABLE IF NOT EXISTS agent_routing_decisions (
+    -- Identity
+    id UUID PRIMARY KEY,
+    correlation_id UUID,
+
+    -- Routing decision
+    selected_agent VARCHAR(255),
+    confidence_score DECIMAL(5, 4),
+
+    -- Audit (TTL keys off created_at)
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- Request context
+    request_type VARCHAR(100),
+    alternatives JSONB,
+    routing_reason TEXT,
+    domain VARCHAR(255),
+    metadata JSONB,
+
+    -- Project context (absorbed from omniclaude - OMN-2057)
+    project_path TEXT,
+    project_name VARCHAR(255),
+    claude_session_id VARCHAR(255)
+);
+
+-- Minimal indexing for write-heavy workload - only TTL cleanup index.
+CREATE INDEX IF NOT EXISTS idx_agent_routing_decisions_created_at
+    ON agent_routing_decisions (created_at);
+
+COMMENT ON TABLE agent_routing_decisions IS 'Agent routing decisions from polymorphic router (OMN-1743). Append-only observability projection (node_projection_routing_decision, omnidash_analytics).';


### PR DESCRIPTION
## OMN-13150 (FIX-1) — vendor agent_routing_decisions per-node migration (omnidash_analytics)

Companion to **omnimarket PR #1218** (the source-of-truth contract repoint + 3-part dev-lane runtime proof).

This PR vendors the per-node forward migration that creates `agent_routing_decisions` in the canonical projection DB (`omnidash_analytics`):
- `docker/migrations/forward/nodes/node_projection_routing_decision/0021_create_agent_routing_decisions.sql` — vendored 1:1 from `omnimarket/src/omnimarket/nodes/node_projection_routing_decision/migrations/0021_create_agent_routing_decisions.sql` via `scripts/sync-node-migrations.sh`.
- Applied to `$NODE_PGDB`=omnidash_analytics by `run-forward-migrations.sh` (node pass), tracked in `schema_migrations` as `node:node_projection_routing_decision:0021_create_agent_routing_decisions.sql`.
- DDL identical to flat infra `021_create_agent_routing_decisions_table.sql`; all statements `IF NOT EXISTS`, idempotent, different DB.

### Why
The projection node's runtime DSN (`from_legacy_settings` + projection-API reader) resolves `omnidash_analytics` first, but the table never existed there (only in `omnibase_infra`). All sibling projection tables live in omnidash_analytics. omnimarket #1218 repoints the contract to omnidash_analytics; this vendored migration makes the table exist there on a clean deploy.

### Cross-repo ordering (blocker)
The vendored-tree drift gate (`tests/unit/migrations/test_node_migration_discovery.py::test_sync_check_reports_in_sync`) resolves omnimarket via `$OMNI_HOME/omnimarket` (canonical clone @ dev). **This PR must merge AFTER omnimarket #1218 is on dev and the canonical clone is synced**, or the drift gate reports OUT OF SYNC. Locally the gate PASSES when `OMNIMARKET_SRC` points at the #1218 branch (vendored == source).

### dod_evidence
- omnimarket #1218 3-part dev-lane runtime triple (write/read-back/projection-API) — `docs/evidence/2026-06-14-post-closeout/OMN-13150-routing-decision-db-repoint-runtime-proof.md` (omni_home).
- `tests/unit/migrations/test_node_migration_discovery.py` (15 passed against the #1218 branch source).

### OCC PR-binding receipt
The PR-binding PASS receipt for this PR is `drift/dod_receipts/OMN-13150/dod-infra-pr/command.yaml` (`status: PASS`, `commit_sha: 60016ddd46b36c673b0fc6954c74a5641e37f9c7` = this PR's head, `pr_number: 1985`), merged on onex_change_control dev via OCC #2634. Evidence-Source below is repointed from OCC #2632 (`979d9b79`, which predated the infra receipt) to OCC #2634's merge commit so the Receipt Gate resolves the OCC tree that contains `dod-infra-pr`.

Evidence-Source: 6d4213f321372a009a23ce6aad2119ee605c6a4f
Evidence-Ticket: OMN-13150
