### PR TITLE
fix(OMN-13159): render reads endpoint_url_env (complete URL, verbatim) not base_url_env

### DIFF
--- a/src/omnibase_infra/runtime/render_bifrost_delegation_contract.py
+++ b/src/omnibase_infra/runtime/render_bifrost_delegation_contract.py
@@ -3,10 +3,12 @@
 """Render the deployed Bifrost delegation contract for runtime boot.
 
 The source ``bifrost_delegation.yaml`` intentionally keeps ``endpoint_url``
-empty. Runtime deployments provide endpoint locations through the provider
-backend named by each backend's ``base_url_env`` field. This module materializes
-the deployed contract once at container startup so delegation code reads a
-contract artifact, not scattered environment variables.
+empty. Runtime deployments provide the COMPLETE endpoint URL (incl. the full
+/v1/chat/completions path, OMN-12815) through the env var named by each backend's
+``endpoint_url_env`` field. This module materializes the deployed contract once
+at container startup so delegation code reads a contract artifact, not scattered
+environment variables. The env value is used VERBATIM — there is no base+path
+construction (OMN-13159).
 
 OMN-12864 — committed overlay authority
     BIFROST_LOCAL_*_ENDPOINT_URL values are now committed deployment bindings
@@ -173,7 +175,7 @@ def _populate_backend_endpoint(
     existing_url = backend.get("endpoint_url", "")
     endpoint_url = existing_url.strip() if isinstance(existing_url, str) else ""
 
-    env_key = backend.get("base_url_env")
+    env_key = backend.get("endpoint_url_env")
     if not endpoint_url and isinstance(env_key, str) and env_key.strip():
         endpoint_url = env.get(env_key, "").strip()
 
@@ -202,7 +204,7 @@ def _populate_backend_endpoint(
     return True
 
 
-_RENDER_HINT_FIELDS = frozenset({"required", "base_url_env"})
+_RENDER_HINT_FIELDS = frozenset({"required", "endpoint_url_env"})
 
 
 def _endpoint_url_completeness_errors(
@@ -421,7 +423,7 @@ def _target_satisfies_declared_env_backends(
             continue
 
         backend_id = source_backend.get("backend_id")
-        env_key = source_backend.get("base_url_env")
+        env_key = source_backend.get("endpoint_url_env")
         if not (
             isinstance(backend_id, str)
             and backend_id.strip()
@@ -639,7 +641,7 @@ def render_bifrost_delegation_contract(
     for backend in backends:
         if isinstance(backend, dict):
             backend.pop("required", None)
-            backend.pop("base_url_env", None)
+            backend.pop("endpoint_url_env", None)
 
     target.parent.mkdir(parents=True, exist_ok=True)
     staged_target = target.with_suffix(f"{target.suffix}.tmp")

--- a/tests/integration/test_volume_config_drift_provenance_e2e.py
+++ b/tests/integration/test_volume_config_drift_provenance_e2e.py
@@ -44,7 +44,7 @@ _SOURCE_CONTRACT: dict[str, object] = {
             "backend_id": "local-primary",
             "model_name": "qwen3-coder",
             "endpoint_url": "",
-            "base_url_env": "OMN_INT_DRIFT_PRIMARY_URL",
+            "endpoint_url_env": "OMN_INT_DRIFT_PRIMARY_URL",
             "required": True,
         }
     ],

--- a/tests/unit/runtime/test_render_bifrost_delegation_contract.py
+++ b/tests/unit/runtime/test_render_bifrost_delegation_contract.py
@@ -30,14 +30,14 @@ def _base_http_url(authority: str) -> str:
 def _backend(
     *,
     backend_id: str,
-    base_url_env: str,
+    endpoint_url_env: str,
     model_name: str,
     capabilities: list[str],
     required: bool = False,
 ) -> dict[str, object]:
     return {
         "backend_id": backend_id,
-        "base_url_env": base_url_env,
+        "endpoint_url_env": endpoint_url_env,
         "required": required,
         "endpoint_url": "",
         "model_name": model_name,
@@ -99,7 +99,7 @@ def _source_contract(path: Path, *, required: bool = False) -> Path:
             [
                 _backend(
                     backend_id="local-qwen-coder-30b",
-                    base_url_env="LLM_CODER_URL",
+                    endpoint_url_env="LLM_CODER_URL",
                     required=required,
                     model_name="qwen-test",
                     capabilities=["code_generation"],
@@ -116,14 +116,14 @@ def _source_contract_with_optional_backend(path: Path) -> Path:
             [
                 _backend(
                     backend_id="local-qwen-coder-30b",
-                    base_url_env="LLM_CODER_URL",
+                    endpoint_url_env="LLM_CODER_URL",
                     required=True,
                     model_name="qwen-test",
                     capabilities=["code_generation"],
                 ),
                 _backend(
                     backend_id="local-deepseek-r1-14b",
-                    base_url_env="LLM_DEEPSEEK_R1_URL",
+                    endpoint_url_env="LLM_DEEPSEEK_R1_URL",
                     model_name="deepseek-test",
                     capabilities=["research"],
                 ),
@@ -218,7 +218,7 @@ def test_existing_cloud_populated_target_rerenders_declared_local_env_backends(
 ) -> None:
     source_backend = _backend(
         backend_id="local-qwen-coder-30b",
-        base_url_env="LLM_CODER_URL",
+        endpoint_url_env="LLM_CODER_URL",
         required=False,
         model_name="qwen-test",
         capabilities=["code_generation"],
@@ -256,7 +256,7 @@ def test_existing_cloud_populated_target_rerenders_declared_local_env_backends(
     )
     assert local_backend["endpoint_url"] == _http_url("fresh.local:8000")
     assert local_backend["model_name"] == "qwen-test"
-    assert "base_url_env" not in local_backend
+    assert "endpoint_url_env" not in local_backend
     assert "required" not in local_backend
 
 


### PR DESCRIPTION
## OMN-13159 — render reads `endpoint_url_env` (complete URL, verbatim) not `base_url_env`

Sibling of omnimarket PR for OMN-13159. The deployed bifrost delegation contract
renderer resolved local backend endpoints from a `base_url_env` field, implying
base+path construction. Per OMN-12815 doctrine every endpoint is the COMPLETE URL
(incl. the full `/v1/chat/completions` path) used **verbatim** — there is no
construction.

### Change
- `render_bifrost_delegation_contract`: rename the render-hint field
  `base_url_env` -> `endpoint_url_env` everywhere it is read, stripped, and
  matched (`_populate_backend_endpoint`, `_RENDER_HINT_FIELDS`,
  `_target_satisfies_declared_env_backends`, final hint-strip). The env value is
  materialized into `endpoint_url` verbatim; no base+path concat.
- Module docstring updated to state the env var holds the COMPLETE URL used
  verbatim.
- Tests: `test_render_bifrost_delegation_contract` and the volume-config-drift
  provenance e2e updated to the renamed field.

No DDL, no migration, no live deploy, no .201 mutation by this PR.

### dod_evidence (OMN-13159)
Ledger `docs/evidence/2026-06-15-delegation-complete-urls/` (omni_home).
Live proof: `onex delegate` returned real tests from **Qwen3.6-35B-A3B**,
correlation_id **929d85ff-6f76-4558-aba6-c68a6fa4d484**.

### Verification
- `uv run ruff format src/ tests/` — clean; `ruff check --fix src/ tests/` — All checks passed.
- `uv run mypy src/omnibase_infra/runtime/render_bifrost_delegation_contract.py --strict` — Success.
- `uv run pytest tests/unit/runtime/test_render_bifrost_delegation_contract.py tests/integration/test_volume_config_drift_provenance_e2e.py -v` — 25 passed.
- `uv run pytest tests/unit/ -m "not slow"` (broad unit suite, NO `-k`) —
  20477 passed, 1 failed, 15 skipped. The single failure
  (`tests/unit/verification/test_cli.py::TestCLIMain::test_registration_only`,
  asserts a CLI exit code) **reproduces identically on the clean `dev` base with
  this change stashed** — it is a pre-existing failure on dev, unrelated to this
  change's blast radius (the verification CLI imports nothing this PR touches).
  The full integration suite is not runnable locally (needs the .201 Kafka/PG
  stack); CI runs it against real infra.
- `pre-commit run` on the changed files — all hooks pass. (`--all-files` surfaces
  pre-existing `runtime_profiles` / `yamlfmt` / SPDX drift in unrelated contract
  files NOT in this change set.)

### Receipt Gate
Evidence-Source: OCC#2647
Evidence-Ticket: OMN-13159
