### PR TITLE
feat(OMN-13161): drop hardcoded delegate max_tokens constant; resolve from routing contract

### DIFF
--- a/src/omnibase_infra/cli/cli_delegate.py
+++ b/src/omnibase_infra/cli/cli_delegate.py
@@ -50,7 +50,6 @@ from omnibase_infra.cli.receipt_mode import (
 __all__ = [
     "DELEGATE_NODE_NAME",
     "DELEGATE_SOURCE",
-    "DEFAULT_MAX_TOKENS",
     "DEFAULT_TASK_TYPE",
     "TASK_TYPE_CHOICES",
     "classify_task_type",
@@ -64,10 +63,6 @@ DELEGATE_NODE_NAME = "node_delegate_skill_orchestrator"
 
 # Registered adapter source for ``ModelDelegateSkillRequest`` (Literal field).
 DELEGATE_SOURCE = "claude-code"
-
-# Default response budget when ``--max-tokens`` is omitted. Matches the
-# historical delegate-shim default; the node enforces its own hard ceiling.
-DEFAULT_MAX_TOKENS = 2048
 
 # Fallback classification when no keyword matches (the prompt.md default).
 DEFAULT_TASK_TYPE = "research"
@@ -115,7 +110,12 @@ def classify_task_type(prompt: str) -> str:
 
 
 def _write_payload(
-    *, prompt: str, task_type: str, max_tokens: int, state_root: Path, run_id: uuid.UUID
+    *,
+    prompt: str,
+    task_type: str,
+    max_tokens: int | None,
+    state_root: Path,
+    run_id: uuid.UUID,
 ) -> Path:
     """Write the delegation input payload to run_id-suffixed scratch.
 
@@ -123,19 +123,24 @@ def _write_payload(
     ``feedback_no_tmp_use_workspace``). The payload validates against the
     delegate node's input model (``ModelDelegateSkillRequest``); only the
     fields the consumer supplies are set.
+
+    When ``max_tokens`` is ``None`` (no explicit ``--max-tokens`` override) the
+    key is omitted from the payload entirely, so the delegate node resolves the
+    response budget per-backend from its routing contract rather than from a
+    CLI-side default.
     """
     tmp_dir = state_root / "tmp"
     tmp_dir.mkdir(parents=True, exist_ok=True)
     payload_path = tmp_dir / f"delegate-input-{run_id}.json"
+    payload: dict[str, object] = {
+        "prompt": prompt,
+        "task_type": task_type,
+        "source": DELEGATE_SOURCE,
+    }
+    if max_tokens is not None:
+        payload["max_tokens"] = max_tokens
     payload_path.write_text(
-        json.dumps(
-            {
-                "prompt": prompt,
-                "task_type": task_type,
-                "source": DELEGATE_SOURCE,
-                "max_tokens": max_tokens,
-            }
-        ),
+        json.dumps(payload),
         encoding="utf-8",
     )
     return payload_path
@@ -157,9 +162,12 @@ def _write_payload(
     "--max-tokens",
     "max_tokens",
     type=click.IntRange(min=1),
-    default=DEFAULT_MAX_TOKENS,
-    show_default=True,
-    help="Maximum tokens for the delegated LLM response.",
+    default=None,
+    help=(
+        "Optional explicit override for the delegated LLM response budget. "
+        "Omit to let the delegate node resolve max_tokens per-backend from its "
+        "routing contract (no CLI-side default)."
+    ),
 )
 @click.option(
     "--state-root",
@@ -196,7 +204,7 @@ def _write_payload(
 def delegate_command(
     prompt: str,
     task_type: str | None,
-    max_tokens: int,
+    max_tokens: int | None,
     state_root: Path,
     timeout: int,
     verbose: bool,
@@ -232,7 +240,7 @@ def run_delegate(
     *,
     prompt: str,
     task_type: str | None,
-    max_tokens: int,
+    max_tokens: int | None,
     state_root: Path,
     timeout: int,
     verbose: bool,

--- a/src/omnibase_infra/cli/skill_mapping.yaml
+++ b/src/omnibase_infra/cli/skill_mapping.yaml
@@ -241,7 +241,10 @@ skills:
     args:
       - {name: prompt, payload_field: prompt, arg_type: string, positional: true, required: true}
       - {name: task-type, payload_field: task_type, arg_type: string}
-      - {name: max-tokens, payload_field: max_tokens, arg_type: integer, default: 2048}
+      # No default: when --max-tokens is omitted the field is left out of the
+      # payload so the delegate node resolves it per-backend from its routing
+      # contract (OMN-13161). Pass --max-tokens only as an explicit override.
+      - {name: max-tokens, payload_field: max_tokens, arg_type: integer}
     classifiers:
       - target_field: task_type
         source_field: prompt

--- a/tests/unit/cli/test_cli_delegate.py
+++ b/tests/unit/cli/test_cli_delegate.py
@@ -10,7 +10,10 @@ The acceptance probe is STRUCTURAL (no size assertions, plan Phase 2 item 1):
 - ``run_delegate`` writes its scratch payload under ``<state-root>/tmp/`` with
   a run_id-suffixed name — never ``/tmp`` (``feedback_no_tmp_use_workspace``);
 - the payload validates against the delegate node's input model
-  (``ModelDelegateSkillRequest``) — prompt, task_type, source, max_tokens;
+  (``ModelDelegateSkillRequest``) — prompt, task_type, source, and
+  ``max_tokens`` ONLY when an explicit ``--max-tokens`` override is supplied
+  (omitted otherwise so the node resolves it per-backend from the routing
+  contract, OMN-13161);
 - the command dispatches through receipt mode so stdout is exactly ONE
   ``ModelSkillResult`` JSON with zero RuntimeLocal log leakage.
 
@@ -33,7 +36,6 @@ from click.testing import CliRunner
 from omnibase_core.models.dispatch.model_skill_result import ModelSkillResult
 from omnibase_infra.cli import cli_delegate
 from omnibase_infra.cli.cli_delegate import (
-    DEFAULT_MAX_TOKENS,
     DEFAULT_TASK_TYPE,
     DELEGATE_SOURCE,
     classify_task_type,
@@ -108,7 +110,7 @@ class TestPayloadScratch:
         run_delegate(
             prompt="implement an HTTP server",
             task_type=None,
-            max_tokens=DEFAULT_MAX_TOKENS,
+            max_tokens=None,
             state_root=state_root,
             timeout=60,
             verbose=False,
@@ -121,6 +123,11 @@ class TestPayloadScratch:
         assert len(payloads) == 1, "exactly one run_id-suffixed scratch payload"
         # No scratch leaked to the system temp dir.
         assert not list(Path(tempfile.gettempdir()).glob("delegate-input-*.json"))
+        # With no explicit --max-tokens override, the key is omitted entirely so
+        # the delegate node resolves it per-backend from its routing contract
+        # (OMN-13161 — no CLI-side default).
+        payload = json.loads(payloads[0].read_text(encoding="utf-8"))
+        assert "max_tokens" not in payload
 
     def test_payload_validates_against_delegate_request_model(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -147,11 +154,13 @@ class TestPayloadScratch:
 
         payload_path = next((state_root / "tmp").glob("delegate-input-*.json"))
         payload = json.loads(payload_path.read_text(encoding="utf-8"))
-        # The payload carries exactly the fields the delegate node's input
-        # model (ModelDelegateSkillRequest) requires from a consumer: prompt,
-        # task_type, source, max_tokens. omnibase_infra does NOT depend on
-        # omnimarket (layering), so the node owns model validation at dispatch;
-        # the CLI's contract here is the payload shape.
+        # With an EXPLICIT --max-tokens override the payload carries exactly the
+        # fields the delegate node's input model (ModelDelegateSkillRequest)
+        # requires from a consumer: prompt, task_type, source, max_tokens.
+        # omnibase_infra does NOT depend on omnimarket (layering), so the node
+        # owns model validation at dispatch; the CLI's contract here is the
+        # payload shape. (When no override is supplied, max_tokens is omitted —
+        # see test_payload_written_under_state_root_tmp_not_slash_tmp, OMN-13161.)
         assert payload == {
             "prompt": "refactor the loop",
             "task_type": "refactor",
@@ -176,7 +185,7 @@ class TestPayloadScratch:
         run_delegate(
             prompt="write an HTTP server",
             task_type="research",
-            max_tokens=DEFAULT_MAX_TOKENS,
+            max_tokens=None,
             state_root=state_root,
             timeout=60,
             verbose=False,

--- a/tests/unit/cli/test_cli_skill.py
+++ b/tests/unit/cli/test_cli_skill.py
@@ -309,7 +309,10 @@ def test_delegate_mapping_classifies_and_builds_payload() -> None:
     _apply_classifiers(delegate, payload)
     assert payload["prompt"] == "write a unit test for the parser"
     assert payload["source"] == "claude-code"
-    assert payload["max_tokens"] == 2048
+    # No --max-tokens override supplied: the field is omitted from the payload so
+    # the delegate node resolves it per-backend from its routing contract
+    # (OMN-13161 — no hardcoded CLI-side default).
+    assert "max_tokens" not in payload
     # "unit test" / "test" keyword group wins.
     assert payload["task_type"] == "test"
 


### PR DESCRIPTION
## OMN-13161 — drop hardcoded delegate `max_tokens` constant (CLI side)

Ticket: OMN-13161 — "Delegation max_tokens belongs in the routing contract (per-backend, overlay-overridable) — not a CLI constant".
Companion PR (omnimarket, routing-authority resolution + per-backend `bifrost_delegation.yaml` `max_tokens` + node contract): https://github.com/OmniNode-ai/omnimarket/pull/1230

This PR implements **ticket item 4** (the `cli_delegate.py` CLI side) plus the
parallel `skill_mapping.yaml` delegate entry that carried the same hardcoded
default.

### Problem
`onex delegate` injected a hardcoded `DEFAULT_MAX_TOKENS = 2048` into the
dispatch payload, and the declarative `onex skill delegate` route carried a
hardcoded `default: 2048` in `skill_mapping.yaml`. The token budget is
*configuration* and belongs on the selected backend in the routing contract
(per-backend, overlay-overridable), resolved by the delegate node *after*
backend selection — not as a CLI constant. The 2048 cap truncated long outputs
(a LinkedList suite was cut off) far below the local model's 128k window.

### Change
- `src/omnibase_infra/cli/cli_delegate.py`
  - Removed `DEFAULT_MAX_TOKENS = 2048` (and its `__all__` entry).
  - `--max-tokens` default → `None` (no `show_default`); help text updated to
    "optional explicit override; omit to let the delegate node resolve
    per-backend from its routing contract".
  - `_write_payload` now **omits** the `max_tokens` key entirely when it is
    `None`, so the node resolves the budget per-backend (relies on the
    omnimarket #1230 resolution seam). Signatures widened to `int | None`.
  - Docstring/comments updated to drop the "historical delegate-shim default"
    reference; documented the omit-on-None behavior.
- `src/omnibase_infra/cli/skill_mapping.yaml`
  - Delegate `max-tokens` arg loses `default: 2048`. Per `ModelSkillArgSpec`, a
    `None` default means the field is omitted from the payload so the node
    supplies its own — same per-backend resolution path.
- Tests updated for the new None-default / omitted-key behavior; the explicit
  `--max-tokens` override path still asserts the key is present in the payload.

`--max-tokens` remains an optional explicit override: when passed, the value is
included in the payload exactly as before.

### Verification (run in the worktree off `origin/dev`)

```
$ uv run ruff format src/ tests/ && uv run ruff check --fix src/ tests/
4112 files left unchanged
All checks passed!

$ uv run mypy src/omnibase_infra/ --strict
Success: no issues found in 2441 source files

$ uv run pytest tests/unit/cli/test_cli_delegate.py tests/unit/cli/test_cli_skill.py \
    tests/unit/validation/test_validator_defaults.py::TestUnionCountRegressionGuard -q
42 passed in 3.67s

$ uv run pytest tests/unit -n auto -q
20489 passed, 15 skipped  (after fix)
# 2 pre-existing/env-only failures NOT introduced by this PR:
#  - test_validation/test_validator_defaults union-count guard: fixed in this PR
#    (typed payload dict as dict[str, object] instead of an inline str | int union).
#  - tests/unit/verification/test_cli.py::TestCLIMain::test_registration_only:
#    fails identically on origin/dev baseline; it asserts exit 1/2 when no runtime
#    DB is configured, but this dev machine reaches the .201 LAN Postgres so the
#    check succeeds (exit 0). Environment-only; passes in CI. Untouched by this PR.

$ pre-commit run --files <changed files>
All hooks Passed (no failures)
```

The full `tests/` run (serial) exceeds the local 10-minute harness window; the
unit suite was run in parallel (`-n auto`) and is green except for the
documented env-only verification-CLI test. CI is the authority for the full
green gate.

### dod_evidence (OMN-13161)
DoD per the ticket: zero hardcoded `max_tokens` constants in the CLI; `--max-tokens`
default `None` (omitted = routing authority decides); optional explicit override
only; no env var introduced. This PR satisfies the CLI-side DoD items:
- `DEFAULT_MAX_TOKENS = 2048` removed from `cli_delegate.py` (grep-verified: no
  remaining `DEFAULT_MAX_TOKENS` reference in `cli_delegate.py`).
- `--max-tokens` default is now `None`; the key is omitted from the dispatch
  payload when no override is supplied (unit-test asserted, both routes).
- `skill_mapping.yaml` delegate `max-tokens` `default: 2048` removed.
- No env var introduced for the limit.

The per-backend resolution seam (`bifrost_delegation.yaml` `max_tokens` +
node_delegate_skill_orchestrator dispatch resolution) is the companion omnimarket
PR #1230 (ticket items 1-3, 5). This CLI PR relies on that seam: when the CLI
omits `max_tokens`, the node resolves it per-backend.

### Receipt Gate / Evidence-Source
This PR pairs with the OCC evidence record for OMN-13161, authored once the
companion omnimarket PR #1230 is green (the standard cross-repo OCC pairing for
this ticket family — cf. OMN-13159 / OCC#2647 which bound omnimarket #1228 +
omnibase_infra #1989). The `Evidence-Source: OCC#<num>` line will be added when
the OCC evidence PR is minted. Not faking an OCC number here.

---

Evidence-Ticket: OMN-13161
Evidence-Source: OCC#2651