### PR TITLE
fix(OMN-13158): accept all per-service db_io.database identities in auto-wiring (F3)

### DIFF
--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -863,9 +863,19 @@ def _normalize_handler_result(
 
 _TABLE_NAME_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 
+# Authoritative source: docs/patterns/db_url_contract.md "Per-Service Database
+# URL Contract" — each OmniNode service owns its own PostgreSQL database and a
+# dedicated *_DB_URL env var. This map MUST stay in parity with that table; a
+# missing row makes the DB-injection auto-wiring reject a contract whose
+# db_io.database names a real per-service DB (e.g. F3/OMN-13158:
+# node_dispatch_outcome_bridge_effect -> database omniintelligence).
 _DB_URL_ENV_MAP: dict[str, str] = {
-    "omnidash_analytics": "OMNIDASH_ANALYTICS_DB_URL",
     "omnibase_infra": "OMNIBASE_INFRA_DB_URL",
+    "omniintelligence": "OMNIINTELLIGENCE_DB_URL",
+    "omniclaude": "OMNICLAUDE_DB_URL",
+    "omnimemory": "OMNIMEMORY_DB_URL",
+    "omninode_cloud": "OMNINODE_CLOUD_DB_URL",
+    "omnidash_analytics": "OMNIDASH_ANALYTICS_DB_URL",
 }
 
 _OPTIONAL_PROJECTION_DATABASES: frozenset[str] = frozenset({"omnidash_analytics"})

--- a/tests/unit/runtime/auto_wiring/test_handler_wiring_db_injection.py
+++ b/tests/unit/runtime/auto_wiring/test_handler_wiring_db_injection.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from omnibase_infra.runtime.auto_wiring.handler_wiring import (
+    _DB_URL_ENV_MAP,
     _build_sync_db_adapter,
     _make_dispatch_callback,
     _make_projection_dispatch_callback,
@@ -651,3 +652,73 @@ def test_projection_callback_terminal_event_publish_failure_does_not_propagate(
 
     assert result is None
     assert any("projection terminal event" in r.message.lower() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Tests: _DB_URL_ENV_MAP parity with the Per-Service Database URL Contract
+# (docs/patterns/db_url_contract.md). OMN-13158 / F3.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_db_url_env_map_matches_per_service_db_url_contract() -> None:
+    """_DB_URL_ENV_MAP must mirror docs/patterns/db_url_contract.md table.
+
+    The canonical contract lists six per-service databases, each owning its own
+    database, dedicated role, and single ``*_DB_URL`` env var. A stale subset
+    here makes auto-wiring reject contracts that name a real per-service DB.
+    """
+    assert _DB_URL_ENV_MAP == {
+        "omnibase_infra": "OMNIBASE_INFRA_DB_URL",
+        "omniintelligence": "OMNIINTELLIGENCE_DB_URL",
+        "omniclaude": "OMNICLAUDE_DB_URL",
+        "omnimemory": "OMNIMEMORY_DB_URL",
+        "omninode_cloud": "OMNINODE_CLOUD_DB_URL",
+        "omnidash_analytics": "OMNIDASH_ANALYTICS_DB_URL",
+    }
+
+
+@pytest.mark.unit
+def test_omniintelligence_is_accepted_db_identity_per_db_url_contract() -> None:
+    """omniintelligence resolves to OMNIINTELLIGENCE_DB_URL.
+
+    Authoritative evidence: docs/patterns/db_url_contract.md line 14 names
+    env OMNIINTELLIGENCE_DB_URL -> database omniintelligence ->
+    role role_omniintelligence. node_dispatch_outcome_bridge_effect declares
+    db_io.db_tables[0].database == omniintelligence; building its projection
+    dispatch callback must not raise (regression guard for OMN-13158 F3).
+    """
+    assert _DB_URL_ENV_MAP["omniintelligence"] == "OMNIINTELLIGENCE_DB_URL"
+
+    received: list[dict] = []
+
+    class FakeHandler:
+        def handle(self, input_data: dict) -> dict:
+            received.append(dict(input_data))
+            return {"rows_upserted": 1}
+
+    db_tables = [{"name": "dispatch_eval_results", "database": "omniintelligence"}]
+    callback = _make_projection_dispatch_callback(
+        FakeHandler(),
+        db_tables,
+        ("onex.evt.omniintelligence.dispatch-outcome.v1",),
+    )
+
+    envelope = MagicMock()
+    envelope.topic = "onex.evt.omniintelligence.dispatch-outcome.v1"
+    envelope.payload = {"correlation_id": "corr-1"}
+    fake_adapter = MagicMock()
+
+    captured_env: list[str] = []
+
+    def _env_get(key: str, default: object = None) -> object:
+        captured_env.append(key)
+        return "postgresql://role_omniintelligence:pw@host:5432/omniintelligence"
+
+    with patch(_PATCH_ENVIRON_GET, side_effect=_env_get):
+        with patch(_PATCH_BUILD_ADAPTER, return_value=fake_adapter):
+            asyncio.run(callback(envelope))
+
+    assert "OMNIINTELLIGENCE_DB_URL" in captured_env
+    assert len(received) == 1
+    assert received[0]["_db"] is fake_adapter


### PR DESCRIPTION
## OMN-13158 — Effects-lane auto-wiring repair (F3)

This is **1 of 2 PRs** for OMN-13158. The companion PR is **omnimarket #1239** (contract/node side). This PR is the omnibase_infra runtime auto-wiring fix.

### Root failure
On the `.201` dev effects lane, runtime auto-wiring rejected `node_dispatch_outcome_bridge_effect` with **`Unknown database 'omniintelligence'`**. The DB-injection auto-wiring in `handler_wiring.py` carried a 2-entry `_DB_URL_ENV_MAP` (`omnibase_infra`, `omnidash_analytics`) and treated any other `db_io.database` identity as unknown, failing closed. Per the per-service database contract, each OmniNode service owns its own PostgreSQL DB and a dedicated `*_DB_URL` env var, so a contract naming `database: omniintelligence` is legitimate and must be injectable.

### Fix (additive only)
`src/omnibase_infra/runtime/auto_wiring/handler_wiring.py` — expand `_DB_URL_ENV_MAP` from 2 -> 6 entries to cover every per-service database identity in the contract table (`omniintelligence:OMNIINTELLIGENCE_DB_URL`, `omniclaude:OMNICLAUDE_DB_URL`, `omnimemory:OMNIMEMORY_DB_URL`, `omninode_cloud:OMNINODE_CLOUD_DB_URL`), with an authority comment citing `docs/patterns/db_url_contract.md` "Per-Service Database URL Contract" and OMN-13158/F3. No rows removed, no behavior changed for existing identities.

`tests/unit/runtime/auto_wiring/test_handler_wiring_db_injection.py` — 2 new tests covering the newly-accepted per-service identities.

### Authority
`docs/patterns/db_url_contract.md` — Per-Service Database URL Contract. The `_DB_URL_ENV_MAP` must stay in parity with that table; a missing row is the defect this PR closes.

### dod_evidence
- `uv run ruff format src/ tests/` + `ruff check --fix`: clean
- `uv run mypy src/omnibase_infra/runtime/auto_wiring/handler_wiring.py --strict`: `Success: no issues found`
- `uv run pytest tests/unit/runtime/auto_wiring/ -q`: **270 passed**
- Full unit suite (`tests/unit/ -m "not slow and not heavy"`): **20482 passed**, 15 skipped; 2 pre-existing unrelated failures (`test_runtime_scheduler_valkey` flaky-under-xdist, passes in isolation; `verification/test_cli::test_registration_only` deterministic assertion in verification module) — neither references `auto_wiring`/`handler_wiring`/`_DB_URL_ENV_MAP`, both unchanged by this branch.
- `pre-commit run` on the two committed files: all hooks Passed (including deploy-gate skip-token guard, architecture/contract/naming validators).

### End-to-end acceptance artifact (gated)
The `.201` dev **effects-lane redeploy showing `Auto-wiring failed=0`** is the end-to-end acceptance artifact for OMN-13158. That redeploy is gated and will be captured against the merged code; this PR lands the code change that the redeploy verifies.

OMN-13158


Evidence-Ticket: OMN-13158
Evidence-Source: OCC#2677


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation tests for database URL mappings and configuration contracts.

* **Chores**
  * Updated database configuration support for new services (omniintelligence, omniclaude, omnimemory, omninode_cloud).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
