### PR TITLE
chore(OMN-13190): remove 3 zero-consumer TOPIC_* constants from topic_constants.py

### DIFF
--- a/contracts/OMN-13190.yaml
+++ b/contracts/OMN-13190.yaml
@@ -1,0 +1,67 @@
+# OMN-13190 contract file for omnibase_infra deploy-gate.
+# The canonical ticket contract and PASS receipts live in onex_change_control.
+# This file is the per-repo deploy-evidence carrier only.
+schema_version: "1.0.0"
+ticket_id: "OMN-13190"
+title: "chore(OMN-13190): remove 3 zero-consumer TOPIC_* constants from topic_constants.py"
+summary: >-
+  Platform-debt cleanup (epic OMN-13188). The plan listed 6 candidate dead TOPIC_*
+  constants; verification refuted one (TOPIC_SESSION_COORDINATION_SIGNAL has a live
+  omnimarket emit_daemon consumer). During the build a second pair was also found NOT
+  dead: TOPIC_DELEGATE_SKILL_COMPLETED / TOPIC_DELEGATE_SKILL_FAILED are the
+  TopicEnumGenerator (OMN-2964) source for EnumOmnimarketTopic.EVT_DELEGATE_SKILL_*_V1,
+  which runtime/service_kernel.py:2045-2048 consumes to wire the delegate-skill terminal
+  result applier (OMN-11996). Deleting them dropped the generated enum members and broke
+  bootstrap() (caught by tests/unit/runtime/test_kernel.py). They were restored. Only the
+  3 genuinely-dead constants are removed: TOPIC_DLQ_QUARANTINE (constant-only; the
+  quarantine topic itself stays live via build_dlq_topic("quarantine")),
+  TOPIC_EVAL_COMPLETED, and TOPIC_SESSION_STATUS_CHANGED. The 16 DLQ builder/format
+  helpers are untouched. Generated topic enums were regenerated from source so the
+  Topic Enum Drift Check passes (only EVT_EVAL_COMPLETED_V1 and EVT_SESSION_STATUS_CHANGED_V1
+  drop, both with zero consumers).
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: tests
+    description: >-
+      Topic-constant, DLQ-replay, session-registry projector, delegation-topic, and
+      topic-registry-integration unit suites pass; full unit suite green (20436 passed,
+      kernel suite 56/56 serially) with the deleted constants gone and no new failures.
+    command: "uv run pytest tests/unit/event_bus/ tests/unit/topics/ tests/unit/nodes/node_dlq_replay_effect/test_handler_dlq_replay.py tests/unit/services/session_registry/test_session_registry_projector.py tests/unit/runtime/test_kernel.py -q"
+  - kind: ci
+    description: >-
+      Both topic gates green: no-hardcoded-topics pre-commit hook + check_topic_literals.py
+      arch-invariant, plus the Topic Enum Drift Check (generate_topic_enums.py --check).
+    command: "uv run python scripts/validation/check_topic_literals.py && uv run python scripts/generate_topic_enums.py --check"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: dod-zero-consumer-grep
+    description: >-
+      Grep proves zero production AND zero test references to the 3 removed constants
+      (TOPIC_DLQ_QUARANTINE, TOPIC_EVAL_COMPLETED, TOPIC_SESSION_STATUS_CHANGED) and to the
+      2 dropped generated enum members (EVT_EVAL_COMPLETED_V1, EVT_SESSION_STATUS_CHANGED_V1)
+      across omnibase_infra, omnibase_core, and omnimarket.
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "! grep -rn -e 'TOPIC_DLQ_QUARANTINE' -e 'TOPIC_EVAL_COMPLETED' -e 'TOPIC_SESSION_STATUS_CHANGED' -e 'EVT_EVAL_COMPLETED_V1' -e 'EVT_SESSION_STATUS_CHANGED_V1' --include='*.py' src/ tests/"
+  - id: dod-topic-gates
+    description: >-
+      Topic literal arch-invariant and Topic Enum Drift Check both pass after deletion +
+      enum regeneration.
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "uv run python scripts/validation/check_topic_literals.py && uv run python scripts/generate_topic_enums.py --check"
+  - id: dod-focused-tests
+    description: >-
+      Topic + DLQ + session-registry + kernel unit suites pass, proving the removed
+      constants had no live consumer and the kept delegate-skill enum members remain wired.
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "uv run pytest tests/unit/event_bus/ tests/unit/topics/ tests/unit/nodes/node_dlq_replay_effect/test_handler_dlq_replay.py tests/unit/services/session_registry/test_session_registry_projector.py tests/unit/runtime/test_kernel.py -q"

--- a/src/omnibase_infra/enums/generated/enum_omnibase_infra_topic.py
+++ b/src/omnibase_infra/enums/generated/enum_omnibase_infra_topic.py
@@ -53,7 +53,6 @@ class EnumOmnibaseInfraTopic(str, Enum):
     EVT_DB_ERROR_V1 = "onex.evt.omnibase-infra.db-error.v1"  # onex.evt.omnibase-infra.db-error.v1
     EVT_DELEGATION_COMPLETED_V1 = "onex.evt.omnibase-infra.delegation-completed.v1"  # onex.evt.omnibase-infra.delegation-completed.v1
     EVT_DELEGATION_FAILED_V1 = "onex.evt.omnibase-infra.delegation-failed.v1"  # onex.evt.omnibase-infra.delegation-failed.v1
-    EVT_EVAL_COMPLETED_V1 = "onex.evt.omnibase-infra.eval-completed.v1"  # onex.evt.omnibase-infra.eval-completed.v1
     EVT_EVENT_FORWARDED_V1 = "onex.evt.omnibase-infra.event-forwarded.v1"  # onex.evt.omnibase-infra.event-forwarded.v1
     EVT_GATEWAY_HEARTBEAT_V1 = "onex.evt.omnibase-infra.gateway-heartbeat.v1"  # onex.evt.omnibase-infra.gateway-heartbeat.v1
     EVT_GMAIL_INTENT_RECEIVED_V1 = "onex.evt.omnibase-infra.gmail-intent-received.v1"  # onex.evt.omnibase-infra.gmail-intent-received.v1

--- a/src/omnibase_infra/enums/generated/enum_omniclaude_topic.py
+++ b/src/omnibase_infra/enums/generated/enum_omniclaude_topic.py
@@ -21,5 +21,4 @@ class EnumOmniclaudeTopic(str, Enum):
     EVT_CONTEXT_AUDIT_DLQ_V1 = "onex.evt.omniclaude.context-audit-dlq.v1"  # onex.evt.omniclaude.context-audit-dlq.v1
     EVT_SESSION_COORDINATION_SIGNAL_V1 = "onex.evt.omniclaude.session-coordination-signal.v1"  # onex.evt.omniclaude.session-coordination-signal.v1
     EVT_SESSION_ENDED_V1 = "onex.evt.omniclaude.session-ended.v1"  # onex.evt.omniclaude.session-ended.v1
-    EVT_SESSION_STATUS_CHANGED_V1 = "onex.evt.omniclaude.session-status-changed.v1"  # onex.evt.omniclaude.session-status-changed.v1
     EVT_TASK_DELEGATED_V1 = "onex.evt.omniclaude.task-delegated.v1"  # onex.evt.omniclaude.task-delegated.v1

--- a/src/omnibase_infra/event_bus/topic_constants.py
+++ b/src/omnibase_infra/event_bus/topic_constants.py
@@ -92,22 +92,6 @@ DLQ_COMMAND_TOPIC_SUFFIX: Final[str] = (
 """DLQ topic suffix for permanently failed commands: 'dlq.omnibase-infra.commands.v1'"""
 
 # ==============================================================================
-# DLQ Quarantine Topic (OMN-12619)
-# ==============================================================================
-# Quarantine is the terminal landing topic for DLQ messages that the replay node
-# determined are NOT replayable (max-retry-exceeded, non-retryable error type,
-# or out-of-filter). It exists to END SILENT MESSAGE LOSS: the previous
-# skip-and-drop path discarded these messages (and, with tracking off, did not
-# even record them). Quarantine durably retains them for human/automated
-# reclassification. Ownership and re-entry semantics are authored in the DLQ
-# replay node contract and docs/operations/DLQ_QUARANTINE_OWNERSHIP.md.
-
-TOPIC_DLQ_QUARANTINE: Final[str] = (
-    f"{_DLQ_PREFIX}.{DLQ_DOMAIN}.{DLQ_PRODUCER}.quarantine.{DLQ_TOPIC_VERSION}"
-)
-"""Fully-qualified DLQ quarantine topic: 'onex.dlq.omnibase-infra.quarantine.v1'."""
-
-# ==============================================================================
 # Category-to-Suffix Mapping
 # ==============================================================================
 
@@ -463,26 +447,6 @@ TOPIC_SESSION_COORDINATION_SIGNAL: Final[str] = (
 )
 """Topic for session coordination signals between concurrent sessions."""
 
-TOPIC_SESSION_STATUS_CHANGED: Final[str] = (
-    "onex.evt.omniclaude.session-status-changed.v1"
-)
-"""Topic for session status change notifications."""
-
-# ---------------------------------------------------------------------------
-# Eval Pipeline Topics (OMN-6798)
-# ---------------------------------------------------------------------------
-
-TOPIC_EVAL_COMPLETED: Final[str] = "onex.evt.omnibase-infra.eval-completed.v1"
-"""Evaluation pipeline completed event.
-
-Published by ServiceAutoEvalRunner after each eval task completes.
-Carries eval_id, model_id, pass/fail counts, and overall verdict.
-
-Producer: ServiceAutoEvalRunner (OMN-6796)
-Consumer: omnidash eval dashboard, observability
-Ticket: OMN-6798
-"""
-
 
 # ---------------------------------------------------------------------------
 # Delegation Pipeline Topics (OMN-7040)
@@ -550,10 +514,19 @@ TOPIC_DELEGATION_BASELINE_COMPARISON: Final[str] = (
 TOPIC_DELEGATE_SKILL_COMPLETED: Final[str] = (
     "onex.evt.omnimarket.delegate-skill-completed.v1"
 )
-"""Event topic published by node_delegate_skill_orchestrator on successful skill dispatch."""
+"""Event topic published by node_delegate_skill_orchestrator on successful skill dispatch.
+
+Generator source for ``EnumOmnimarketTopic.EVT_DELEGATE_SKILL_COMPLETED_V1``, which is
+consumed in ``runtime/service_kernel.py`` to wire the delegate-skill terminal result
+applier (OMN-11996). Keep this constant: deleting it drops the generated enum member.
+"""
 
 TOPIC_DELEGATE_SKILL_FAILED: Final[str] = "onex.evt.omnimarket.delegate-skill-failed.v1"
-"""Event topic published by node_delegate_skill_orchestrator on skill dispatch failure."""
+"""Event topic published by node_delegate_skill_orchestrator on skill dispatch failure.
+
+Generator source for ``EnumOmnimarketTopic.EVT_DELEGATE_SKILL_FAILED_V1``, which is
+consumed in ``runtime/service_kernel.py`` (OMN-11996). Keep this constant.
+"""
 
 __all__ = [
     "TOPIC_DELEGATE_SKILL_COMPLETED",
@@ -568,9 +541,6 @@ __all__ = [
     "TOPIC_DELEGATION_QUALITY_GATE_RESULT",
     "TOPIC_DELEGATION_REQUEST",
     "TOPIC_DELEGATION_ROUTING_DECISION",
-    "TOPIC_DELEGATE_SKILL_COMPLETED",
-    "TOPIC_DELEGATE_SKILL_FAILED",
-    "TOPIC_EVAL_COMPLETED",
     "DLQ_CATEGORY_SUFFIXES",
     "DLQ_COMMAND_TOPIC_SUFFIX",
     "DLQ_DOMAIN",

--- a/tests/unit/nodes/node_dlq_replay_effect/test_handler_dlq_replay.py
+++ b/tests/unit/nodes/node_dlq_replay_effect/test_handler_dlq_replay.py
@@ -15,7 +15,8 @@ the consumer / replay producer / quarantine producer / tracking service:
     5. dlq_replay_history records every terminal outcome.
     6. Eligibility is decided by the reused should_replay() (max-retry,
        non-retryable error type) — not a reimplementation.
-    7. The QUARANTINED enum member and onex.dlq.omnibase-infra.quarantine.v1 constant exist.
+    7. The QUARANTINED enum member exists and build_dlq_topic("quarantine")
+       resolves to onex.dlq.omnibase-infra.quarantine.v1.
 """
 
 from __future__ import annotations
@@ -28,7 +29,7 @@ import pytest
 from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
 from omnibase_infra.dlq.models.enum_replay_status import EnumReplayStatus
 from omnibase_infra.dlq.models.model_dlq_replay_record import ModelDlqReplayRecord
-from omnibase_infra.event_bus.topic_constants import TOPIC_DLQ_QUARANTINE
+from omnibase_infra.event_bus.topic_constants import build_dlq_topic
 from omnibase_infra.nodes.node_dlq_replay_effect.engine_dlq_replay import (
     DLQ_REPLAY_CONSUMER_GROUP,
     DLQQuarantineProducer,
@@ -201,7 +202,7 @@ def _handler(
 
 
 def test_quarantine_constants_exist() -> None:
-    assert TOPIC_DLQ_QUARANTINE == "onex.dlq.omnibase-infra.quarantine.v1"
+    assert build_dlq_topic("quarantine") == "onex.dlq.omnibase-infra.quarantine.v1"
     assert EnumReplayStatus.QUARANTINED.value == "quarantined"
     assert DLQ_REPLAY_CONSUMER_GROUP == "onex-dlq-replay"
 

--- a/tests/unit/services/session_registry/test_session_registry_projector.py
+++ b/tests/unit/services/session_registry/test_session_registry_projector.py
@@ -12,7 +12,6 @@ import pytest
 
 from omnibase_infra.event_bus.topic_constants import (
     TOPIC_SESSION_COORDINATION_SIGNAL,
-    TOPIC_SESSION_STATUS_CHANGED,
 )
 from omnibase_infra.services.session_registry.enum_session_phase import EnumSessionPhase
 from omnibase_infra.services.session_registry.enum_session_registry_status import (
@@ -187,7 +186,3 @@ class TestProjectorConstants:
     def test_coordination_topic_follows_onex_naming(self) -> None:
         assert TOPIC_SESSION_COORDINATION_SIGNAL.startswith("onex.evt.")
         assert ".v1" in TOPIC_SESSION_COORDINATION_SIGNAL
-
-    def test_status_changed_topic_follows_onex_naming(self) -> None:
-        assert TOPIC_SESSION_STATUS_CHANGED.startswith("onex.evt.")
-        assert ".v1" in TOPIC_SESSION_STATUS_CHANGED


### PR DESCRIPTION
Evidence-Source: OCC#2676
Evidence-Ticket: OMN-13190

## OMN-13190 — Remove zero-consumer TOPIC_* constants

Epic: OMN-13188 (platform-debt: contract-source topics + envelope dedup).

Removes the 3 `TOPIC_*` constants in `event_bus/topic_constants.py` that verification AND the build confirmed dead (zero production AND zero test references). The plan listed 6 candidates; **3 were refuted as NOT dead** and kept.

### Removed (3 confirmed dead)
| Constant | Why dead |
|----------|----------|
| `TOPIC_DLQ_QUARANTINE` | Constant-only; the quarantine **topic** stays live via `build_dlq_topic("quarantine")` (engine + contract use the literal, not the constant). Only consumer was a test. |
| `TOPIC_EVAL_COMPLETED` | Zero production + zero test references. |
| `TOPIC_SESSION_STATUS_CHANGED` | Only consumer was a test; not in omniclaude session source; not in any contract.yaml. |

### Kept (NOT dead — refuted)
- `TOPIC_SESSION_COORDINATION_SIGNAL` — live consumer in omnimarket `node_emit_daemon/contract.yaml:155`.
- `TOPIC_DELEGATE_SKILL_COMPLETED` / `TOPIC_DELEGATE_SKILL_FAILED` — **build-time discovery**: these are the `TopicEnumGenerator` (OMN-2964) source for `EnumOmnimarketTopic.EVT_DELEGATE_SKILL_*_V1`, which `runtime/service_kernel.py:2045-2048` consumes to wire the delegate-skill terminal result applier (OMN-11996). Deleting them dropped the generated enum members and broke `bootstrap()` (caught by `tests/unit/runtime/test_kernel.py`). Restored. The verification's grep missed the constant → generated-enum → service_kernel indirection.

All 16 DLQ builder/format helpers untouched. Generated topic enums regenerated from source so the **Topic Enum Drift Check** passes; only `EVT_EVAL_COMPLETED_V1` + `EVT_SESSION_STATUS_CHANGED_V1` drop (both zero-consumer). Test assertions referencing removed constants updated; no unrelated tests weakened.

## dod_evidence (OMN-13190)

OCC carrier: `contracts/OMN-13190.yaml`.

**1. Zero remaining references (production + test) across omnibase_infra / omnibase_core / omnimarket:**
```
$ grep -rn -e TOPIC_DLQ_QUARANTINE -e TOPIC_EVAL_COMPLETED -e TOPIC_SESSION_STATUS_CHANGED \
    -e EVT_EVAL_COMPLETED_V1 -e EVT_SESSION_STATUS_CHANGED_V1 --include='*.py' src/ tests/
(no output)  # exit 0
```
Cross-repo grep (omnibase_infra, omnibase_core, omnimarket, omniclaude, omnibase_spi): zero hits for all 3 removed constants.

**2. Both topic gates green:**
```
$ uv run python scripts/validation/check_topic_literals.py
OK: No new raw topic literals found in 2416 file(s) (9 pre-existing violations suppressed)

$ pre-commit run no-hardcoded-topics --all-files
No hardcoded ONEX topic strings..........................................Passed

$ uv run python scripts/generate_topic_enums.py --check
CHECK PASSED: 14 generated file(s) are up to date.
```

**3. Tests:**
- Topic + DLQ-replay + session-registry + delegation + topic-registry suites: **722 passed**.
- `tests/unit/runtime/test_kernel.py`: **56 passed** (proves the kept delegate-skill enum members remain wired in bootstrap).
- Full unit suite: **20436 passed, 15 skipped, 0 failures** (excluding one pre-existing baseline failure `test_cli.py::test_registration_only`, which fails identically on unmodified `origin/dev` and is environment-sensitive, not a regression from this PR).

**4. Local gates:** `ruff format` + `ruff check --fix` clean, `mypy --strict` clean on changed files, `pre-commit run` all hooks Passed (incl. Topic Naming Lint, Topic Enum Drift Check, AI-slop, SPDX).

