### PR TITLE
feat(OMN-13195): A4 — delete orphaned delegation TOPIC_* constants + fix false-green guard + narrow topic gate exemption

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,11 +35,16 @@ repos:
         args: [--baseline, config/validation/transport_mock_baseline.yaml]
   # Hardcoded topic guard — sourced from onex_change_control (OMN-5256/OMN-5259)
   # Pre-existing violations excluded pending migration to canonical constants (OMN-5259)
+  # OMN-13195 (phase A4): dropped the redundant `event_bus/topic_constants.py`
+  # exclude — the hook already approves that basename via its internal
+  # APPROVED_BASENAMES (check_hardcoded_topics.py), so the path-regex exclude was
+  # a no-op. The 3 remaining kept literals in that file stay covered by the hook's
+  # basename approval; full removal is the A5-full follow-up (OMN-13199).
   - repo: https://github.com/OmniNode-ai/onex_change_control
     rev: 8d7e85bc00e7f1b1306d1cb40949be1ab6e7e91a # pragma: allowlist secret
     hooks:
       - id: no-hardcoded-topics
-        exclude: ^(src/omnibase_infra/(enums/generated|cli|tui|models/registration/model_event_bus_topic_entry\.py|nodes/.*/handlers|nodes/.*/services|nodes/.*/contracts|runtime/contract_registration_event_router\.py|services/observability|services/service_timeout_emitter\.py|topics/service_topic_registry\.py|event_bus/topic_constants\.py|validation|contracts/)|scripts/|tests/|contracts/|src/dep_health_allowlist\.yaml)
+        exclude: ^(src/omnibase_infra/(enums/generated|cli|tui|models/registration/model_event_bus_topic_entry\.py|nodes/.*/handlers|nodes/.*/services|nodes/.*/contracts|runtime/contract_registration_event_router\.py|services/observability|services/service_timeout_emitter\.py|topics/service_topic_registry\.py|validation|contracts/)|scripts/|tests/|contracts/|src/dep_health_allowlist\.yaml)
       - id: no-bare-feature-flags
         # YAML formatting (standard across ecosystem)
       - id: no-untracked-todos

--- a/scripts/validation/check_topic_literals.py
+++ b/scripts/validation/check_topic_literals.py
@@ -14,9 +14,11 @@
 # Exclusions:
 #   - tests/, fixtures/, docs/            (not production code)
 #   - generated/                          (auto-generated enum files)
-#   - topics.py, topic_constants.py       (canonical topic definition files)
+#   - topics.py                           (canonical topic definition file)
 #   - platform_topic_suffixes.py          (canonical platform topic registry)
 #   - contract.yaml                       (contract definitions, not Python)
+#   NOTE: topic_constants.py is NO LONGER whole-file excluded (OMN-13195/A4); its
+#   3 remaining kept literals are suppressed per-line in the baseline instead.
 #
 # Pre-existing violations that were present before OMN-3343 are suppressed
 # via `scripts/validation/topic_literal_baseline.txt`. New violations added
@@ -48,11 +50,20 @@ from pathlib import Path
 # Only match strings that START with the ONEX prefix (no env prefix like dev./prod.)
 _TOPIC_PATTERN = re.compile(r"^onex\.(evt|cmd)\.[a-z][a-z0-9._-]*$")
 
-# Files that ARE canonical topic definitions — raw literals are legitimate here
+# Files that ARE canonical topic definitions — raw literals are legitimate here.
+#
+# OMN-13195 (phase A4) narrowed this list: ``topic_constants.py`` is no longer a
+# whole-file exemption. After the 13 orphaned ``TOPIC_DELEGATION_*`` constants
+# were deleted, only 3 unavoidable topic literals remain in that file
+# (TOPIC_SESSION_COORDINATION_SIGNAL + the two TOPIC_DELEGATE_SKILL_* codegen-AST
+# sources). Those 3 specific lines are suppressed per-line in
+# ``topic_literal_baseline.txt`` instead — a far narrower allowlist than the
+# whole file. Full un-allowlisting (removing even those 3 baseline lines) is the
+# A5-full follow-up once the codegen reads contracts instead of this AST source
+# (OMN-13202 → OMN-13199).
 _EXCLUDED_FILENAMES: frozenset[str] = frozenset(
     {
         "topics.py",
-        "topic_constants.py",
         "service_topic_registry.py",
         "platform_topic_suffixes.py",
         "contract.yaml",

--- a/scripts/validation/topic_literal_baseline.txt
+++ b/scripts/validation/topic_literal_baseline.txt
@@ -2,7 +2,13 @@
 # Pre-existing violations grandfathered in on 2026-03-02 (updated 2026-03-10 for SPDX line shifts).
 # Format: <repo-relative-path>:<lineno>
 # DO NOT add new entries here — fix violations instead.
-# Total entries: 123
+#
+# The ONLY exception is the documented "OMN-13195 kept topic_constants.py
+# literals" block at the bottom of this file: those 3 lines replace the former
+# whole-file exemption of topic_constants.py with a narrow per-line allowlist and
+# are removed entirely by the A5-full follow-up (OMN-13202 → OMN-13199). They are
+# intentional, not grandfathered debt.
+# Total entries: 123 grandfathered + 3 OMN-13195 kept-constant exemptions
 src/omnibase_infra/cli/git_hook_relay.py:72
 src/omnibase_infra/cli/git_hook_relay.py:74
 src/omnibase_infra/cli/infra_test/introspect.py:25
@@ -123,3 +129,17 @@ src/omnibase_infra/tui/consumers/consumer_status.py:42
 src/omnibase_infra/runtime/service_kernel.py:2015
 src/omnibase_infra/runtime/service_kernel.py:2016
 src/omnibase_infra/validation/demo_loop_gate.py:76
+#
+# --- OMN-13195: kept topic_constants.py literals (narrowed from whole-file) ---
+# These 3 literals are the only ones remaining in topic_constants.py after the 13
+# orphaned TOPIC_DELEGATION_* constants were deleted. They are unavoidable today:
+#   - TOPIC_SESSION_COORDINATION_SIGNAL: live consumer omnimarket
+#     node_emit_daemon/contract.yaml (publish_topics).
+#   - TOPIC_DELEGATE_SKILL_COMPLETED / TOPIC_DELEGATE_SKILL_FAILED: AST source for
+#     generate_topic_enums.py -> EnumOmnimarketTopic.EVT_DELEGATE_SKILL_*_V1,
+#     consumed at bootstrap by runtime/service_kernel.py (OMN-11996).
+# Removed by the A5-full follow-up (OMN-13202 migrates the codegen to read
+# contracts; OMN-13199 then fully un-allowlists topic_constants.py).
+src/omnibase_infra/event_bus/topic_constants.py:446
+src/omnibase_infra/event_bus/topic_constants.py:472
+src/omnibase_infra/event_bus/topic_constants.py:481

--- a/src/omnibase_infra/enums/generated/enum_omnibase_infra_topic.py
+++ b/src/omnibase_infra/enums/generated/enum_omnibase_infra_topic.py
@@ -18,16 +18,11 @@ class EnumOmnibaseInfraTopic(str, Enum):
     All values are raw topic strings as declared in contract.yaml.
     Members are sorted by (kind, event_name, version).
     """
-    CMD_BASELINE_COMPARISON_REQUEST_V1 = "onex.cmd.omnibase-infra.baseline-comparison-request.v1"  # onex.cmd.omnibase-infra.baseline-comparison-request.v1
     CMD_BASELINES_BATCH_COMPUTE_V1 = "onex.cmd.omnibase-infra.baselines-batch-compute.v1"  # onex.cmd.omnibase-infra.baselines-batch-compute.v1
     CMD_BUILD_LOOP_APPEND_V1 = "onex.cmd.omnibase-infra.build-loop-append.v1"  # onex.cmd.omnibase-infra.build-loop-append.v1
     CMD_CHAIN_LEARN_V1 = "onex.cmd.omnibase-infra.chain-learn.v1"  # onex.cmd.omnibase-infra.chain-learn.v1
     CMD_CONSUMER_RESTART_V1 = "onex.cmd.omnibase-infra.consumer-restart.v1"  # onex.cmd.omnibase-infra.consumer-restart.v1
     CMD_DELEGATION_INFERENCE_REQUEST_V1 = "onex.cmd.omnibase-infra.delegation-inference-request.v1"  # onex.cmd.omnibase-infra.delegation-inference-request.v1
-    CMD_DELEGATION_QUALITY_GATE_REQUEST_V1 = "onex.cmd.omnibase-infra.delegation-quality-gate-request.v1"  # onex.cmd.omnibase-infra.delegation-quality-gate-request.v1
-    CMD_DELEGATION_REQUEST_V1 = "onex.cmd.omnibase-infra.delegation-request.v1"  # onex.cmd.omnibase-infra.delegation-request.v1
-    CMD_DELEGATION_ROUTING_REQUEST_V1 = "onex.cmd.omnibase-infra.delegation-routing-request.v1"  # onex.cmd.omnibase-infra.delegation-routing-request.v1
-    CMD_INVOCATION_V1 = "onex.cmd.omnibase-infra.invocation.v1"  # onex.cmd.omnibase-infra.invocation.v1
     CMD_LLM_COMPLETION_REQUEST_V1 = "onex.cmd.omnibase-infra.llm-completion-request.v1"  # onex.cmd.omnibase-infra.llm-completion-request.v1
     CMD_LLM_EMBEDDING_REQUEST_V1 = "onex.cmd.omnibase-infra.llm-embedding-request.v1"  # onex.cmd.omnibase-infra.llm-embedding-request.v1
     CMD_LLM_INFERENCE_REQUEST_V1 = "onex.cmd.omnibase-infra.llm-inference-request.v1"  # onex.cmd.omnibase-infra.llm-inference-request.v1
@@ -51,8 +46,6 @@ class EnumOmnibaseInfraTopic(str, Enum):
     EVT_CHAIN_VERIFIED_V1 = "onex.evt.omnibase-infra.chain-verified.v1"  # onex.evt.omnibase-infra.chain-verified.v1
     EVT_CONSUMER_HEALTH_V1 = "onex.evt.omnibase-infra.consumer-health.v1"  # onex.evt.omnibase-infra.consumer-health.v1
     EVT_DB_ERROR_V1 = "onex.evt.omnibase-infra.db-error.v1"  # onex.evt.omnibase-infra.db-error.v1
-    EVT_DELEGATION_COMPLETED_V1 = "onex.evt.omnibase-infra.delegation-completed.v1"  # onex.evt.omnibase-infra.delegation-completed.v1
-    EVT_DELEGATION_FAILED_V1 = "onex.evt.omnibase-infra.delegation-failed.v1"  # onex.evt.omnibase-infra.delegation-failed.v1
     EVT_EVENT_FORWARDED_V1 = "onex.evt.omnibase-infra.event-forwarded.v1"  # onex.evt.omnibase-infra.event-forwarded.v1
     EVT_GATEWAY_HEARTBEAT_V1 = "onex.evt.omnibase-infra.gateway-heartbeat.v1"  # onex.evt.omnibase-infra.gateway-heartbeat.v1
     EVT_GMAIL_INTENT_RECEIVED_V1 = "onex.evt.omnibase-infra.gmail-intent-received.v1"  # onex.evt.omnibase-infra.gmail-intent-received.v1
@@ -63,8 +56,6 @@ class EnumOmnibaseInfraTopic(str, Enum):
     EVT_ONBOARDING_COMPLETED_V1 = "onex.evt.omnibase-infra.onboarding-completed.v1"  # onex.evt.omnibase-infra.onboarding-completed.v1
     EVT_ONBOARDING_STEP_VERIFIED_V1 = "onex.evt.omnibase-infra.onboarding-step-verified.v1"  # onex.evt.omnibase-infra.onboarding-step-verified.v1
     EVT_PATTERN_B_DISPATCH_COMPLETED_V1 = "onex.evt.omnibase-infra.pattern-b-dispatch-completed.v1"  # onex.evt.omnibase-infra.pattern-b-dispatch-completed.v1
-    EVT_QUALITY_GATE_RESULT_V1 = "onex.evt.omnibase-infra.quality-gate-result.v1"  # onex.evt.omnibase-infra.quality-gate-result.v1
-    EVT_ROUTING_DECISION_V1 = "onex.evt.omnibase-infra.routing-decision.v1"  # onex.evt.omnibase-infra.routing-decision.v1
     EVT_ROW_COUNT_DIAGNOSTIC_V1 = "onex.evt.omnibase-infra.row-count-diagnostic.v1"  # onex.evt.omnibase-infra.row-count-diagnostic.v1
     EVT_RUNNER_HEALTH_SNAPSHOT_V1 = "onex.evt.omnibase-infra.runner-health-snapshot.v1"  # onex.evt.omnibase-infra.runner-health-snapshot.v1
     EVT_RUNTIME_BOOTED_V1 = "onex.evt.omnibase-infra.runtime-booted.v1"  # onex.evt.omnibase-infra.runtime-booted.v1

--- a/src/omnibase_infra/enums/generated/enum_omniclaude_topic.py
+++ b/src/omnibase_infra/enums/generated/enum_omniclaude_topic.py
@@ -21,4 +21,3 @@ class EnumOmniclaudeTopic(str, Enum):
     EVT_CONTEXT_AUDIT_DLQ_V1 = "onex.evt.omniclaude.context-audit-dlq.v1"  # onex.evt.omniclaude.context-audit-dlq.v1
     EVT_SESSION_COORDINATION_SIGNAL_V1 = "onex.evt.omniclaude.session-coordination-signal.v1"  # onex.evt.omniclaude.session-coordination-signal.v1
     EVT_SESSION_ENDED_V1 = "onex.evt.omniclaude.session-ended.v1"  # onex.evt.omniclaude.session-ended.v1
-    EVT_TASK_DELEGATED_V1 = "onex.evt.omniclaude.task-delegated.v1"  # onex.evt.omniclaude.task-delegated.v1

--- a/src/omnibase_infra/event_bus/topic_constants.py
+++ b/src/omnibase_infra/event_bus/topic_constants.py
@@ -451,65 +451,22 @@ TOPIC_SESSION_COORDINATION_SIGNAL: Final[str] = (
 # ---------------------------------------------------------------------------
 # Delegation Pipeline Topics (OMN-7040)
 # ---------------------------------------------------------------------------
-
-TOPIC_DELEGATION_REQUEST: Final[str] = "onex.cmd.omnibase-infra.delegation-request.v1"
-"""Command topic for delegation requests from /delegate skill."""
-
-TOPIC_DELEGATION_ROUTING_DECISION: Final[str] = (
-    "onex.evt.omnibase-infra.routing-decision.v1"
-)
-"""Event topic for routing decisions from the delegation routing reducer."""
-
-TOPIC_DELEGATION_COMPLETED: Final[str] = (
-    "onex.evt.omnibase-infra.delegation-completed.v1"
-)
-"""Event topic for successful delegation completions."""
-
-TOPIC_DELEGATION_FAILED: Final[str] = "onex.evt.omnibase-infra.delegation-failed.v1"
-"""Event topic for failed delegation attempts."""
-
-TOPIC_DELEGATION_QUALITY_GATE_RESULT: Final[str] = (
-    "onex.evt.omnibase-infra.quality-gate-result.v1"
-)
-"""Event topic for quality gate evaluation results."""
-
-TOPIC_DELEGATION_ROUTING_REQUEST: Final[str] = (
-    "onex.cmd.omnibase-infra.delegation-routing-request.v1"
-)
-"""Command topic for routing reducer invocation from the delegation orchestrator."""
-
-TOPIC_DELEGATION_INVOCATION_COMMAND: Final[str] = (
-    "onex.cmd.omnibase-infra.invocation.v1"
-)
-"""Command topic for typed invocation commands from the delegation orchestrator."""
-
-TOPIC_DELEGATION_AGENT_TASK_LIFECYCLE: Final[str] = (
-    "onex.evt.omnibase-infra.agent-task-lifecycle.v1"
-)
-"""Event topic for remote agent task lifecycle updates."""
-
-TOPIC_DELEGATION_QUALITY_GATE_REQUEST: Final[str] = (
-    "onex.cmd.omnibase-infra.delegation-quality-gate-request.v1"
-)
-"""Command topic for quality gate reducer invocation from the delegation orchestrator."""
-
-TOPIC_DELEGATION_INFERENCE_REQUEST: Final[str] = (
-    "onex.cmd.omnibase-infra.delegation-inference-request.v1"
-)
-"""Command topic for LLM inference invocation from the delegation orchestrator."""
-
-TOPIC_DELEGATION_INFERENCE_RESPONSE: Final[str] = (
-    "onex.evt.omnibase-infra.inference-response.v1"
-)
-"""Event topic for LLM inference responses in the delegation pipeline."""
-
-TOPIC_DELEGATION_TASK_DELEGATED: Final[str] = "onex.evt.omniclaude.task-delegated.v1"
-"""Backward-compatible event topic for omnidash delegation projection."""
-
-TOPIC_DELEGATION_BASELINE_COMPARISON: Final[str] = (
-    "onex.cmd.omnibase-infra.baseline-comparison-request.v1"
-)
-"""Command topic for baseline comparison compute from the delegation orchestrator."""
+#
+# The 13 ``TOPIC_DELEGATION_*`` pipeline constants formerly defined here were
+# removed in OMN-13195 (plan: platform-debt contract-sourced-topics, phase A4).
+# Their production consumers were migrated to contract-sourced resolution in
+# OMN-13191 (infra applier → ``ServiceTopicRegistry``) and OMN-13193 (omnimarket
+# ``node_delegation_orchestrator`` → its own ``contract.yaml``). After those
+# merges every constant had ZERO production (``src/``) importers — verified by
+# per-constant grep across all repos under ``$OMNI_HOME`` on 2026-06-17 — so the
+# Python literals were deleted. The topic strings themselves still live in their
+# owning ``contract.yaml`` files; resolve them via ``ServiceTopicRegistry`` /
+# ``topic_keys`` (infra) or ``contract_publish_topics`` / ``contract_subscribe_topics``
+# (omnimarket), never by re-adding a literal here.
+#
+# Two ``TOPIC_DELEGATE_SKILL_*`` constants below are intentionally KEPT: they are
+# the AST source for ``generate_topic_enums.py`` and have no contract-resolution
+# replacement yet (follow-up tracked in OMN-13202 / unblocks A5-full OMN-13199).
 
 TOPIC_DELEGATE_SKILL_COMPLETED: Final[str] = (
     "onex.evt.omnimarket.delegate-skill-completed.v1"
@@ -531,16 +488,6 @@ consumed in ``runtime/service_kernel.py`` (OMN-11996). Keep this constant.
 __all__ = [
     "TOPIC_DELEGATE_SKILL_COMPLETED",
     "TOPIC_DELEGATE_SKILL_FAILED",
-    "TOPIC_DELEGATION_COMPLETED",
-    "TOPIC_DELEGATION_FAILED",
-    "TOPIC_DELEGATION_AGENT_TASK_LIFECYCLE",
-    "TOPIC_DELEGATION_INFERENCE_REQUEST",
-    "TOPIC_DELEGATION_INFERENCE_RESPONSE",
-    "TOPIC_DELEGATION_INVOCATION_COMMAND",
-    "TOPIC_DELEGATION_QUALITY_GATE_REQUEST",
-    "TOPIC_DELEGATION_QUALITY_GATE_RESULT",
-    "TOPIC_DELEGATION_REQUEST",
-    "TOPIC_DELEGATION_ROUTING_DECISION",
     "DLQ_CATEGORY_SUFFIXES",
     "DLQ_COMMAND_TOPIC_SUFFIX",
     "DLQ_DOMAIN",

--- a/tests/integration/runtime/test_delegation_intent_topic_routing_integration.py
+++ b/tests/integration/runtime/test_delegation_intent_topic_routing_integration.py
@@ -38,18 +38,31 @@ from omnibase_infra.enums import EnumDispatchStatus
 from omnibase_infra.enums.generated.enum_omnibase_infra_topic import (
     EnumOmnibaseInfraTopic,
 )
-from omnibase_infra.event_bus.topic_constants import (
-    TOPIC_DELEGATION_BASELINE_COMPARISON,
-    TOPIC_DELEGATION_INFERENCE_REQUEST,
-    TOPIC_DELEGATION_QUALITY_GATE_REQUEST,
-    TOPIC_DELEGATION_ROUTING_REQUEST,
-)
 from omnibase_infra.models.dispatch.model_dispatch_result import ModelDispatchResult
 from omnibase_infra.runtime.service_dispatch_result_applier import (
     DispatchResultApplier,
 )
+from omnibase_infra.topics import topic_keys
+from omnibase_infra.topics.service_topic_registry import ServiceTopicRegistry
 
 pytestmark = pytest.mark.integration
+
+# The applier resolves these delegation topics from ``ServiceTopicRegistry``
+# (contract-sourced, OMN-13191). The legacy ``TOPIC_DELEGATION_*`` constants were
+# deleted in OMN-13195 — assert against the same registry path the applier uses.
+_REGISTRY = ServiceTopicRegistry.from_defaults()
+TOPIC_DELEGATION_ROUTING_REQUEST = _REGISTRY.resolve(
+    topic_keys.DELEGATION_ROUTING_REQUEST
+)
+TOPIC_DELEGATION_INFERENCE_REQUEST = _REGISTRY.resolve(
+    topic_keys.DELEGATION_INFERENCE_REQUEST
+)
+TOPIC_DELEGATION_QUALITY_GATE_REQUEST = _REGISTRY.resolve(
+    topic_keys.DELEGATION_QUALITY_GATE_REQUEST
+)
+TOPIC_DELEGATION_BASELINE_COMPARISON = _REGISTRY.resolve(
+    topic_keys.DELEGATION_BASELINE_COMPARISON
+)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/event_bus/test_delegation_topics.py
+++ b/tests/unit/event_bus/test_delegation_topics.py
@@ -2,13 +2,22 @@
 # SPDX-License-Identifier: MIT
 
 # Copyright (c) 2026 OmniNode Team
-"""Unit tests for delegation pipeline topic constants.
+"""Unit tests for delegation pipeline topics.
 
 Verifies that all delegation topics follow ONEX naming conventions:
     onex.<kind>.<producer>.<event-name>.v<N>
 
+The delegation topic strings are no longer Python literals: the legacy
+``TOPIC_DELEGATION_*`` constants were deleted in OMN-13195 (phase A4) after their
+production consumers migrated to contract-sourced resolution (OMN-13191 /
+OMN-13193). These tests now assert against the contract-anchored strings resolved
+through ``ServiceTopicRegistry`` — the same path production code uses — so the
+naming/value/kind invariants remain enforced against the durable source.
+
 Related:
     - OMN-7040: Node-based delegation pipeline
+    - OMN-13191/OMN-13193: contract-sourced delegation topic resolution
+    - OMN-13195: deletion of the orphaned ``TOPIC_DELEGATION_*`` constants
 """
 
 from __future__ import annotations
@@ -17,13 +26,8 @@ import re
 
 import pytest
 
-from omnibase_infra.event_bus.topic_constants import (
-    TOPIC_DELEGATION_COMPLETED,
-    TOPIC_DELEGATION_FAILED,
-    TOPIC_DELEGATION_QUALITY_GATE_RESULT,
-    TOPIC_DELEGATION_REQUEST,
-    TOPIC_DELEGATION_ROUTING_DECISION,
-)
+from omnibase_infra.topics import topic_keys
+from omnibase_infra.topics.service_topic_registry import ServiceTopicRegistry
 
 pytestmark = [pytest.mark.unit]
 
@@ -32,12 +36,21 @@ _TOPIC_PATTERN = re.compile(
     r"^onex\.(cmd|evt|int)\.[a-z][a-z0-9-]*\.[a-z][a-z0-9-]*\.v\d+$"
 )
 
+_REGISTRY = ServiceTopicRegistry.from_defaults()
+
+
+def _resolve(key_name: str) -> str:
+    """Resolve a delegation topic key through the contract-sourced registry."""
+    return _REGISTRY.resolve(getattr(topic_keys, key_name))
+
+
+# The five infra-produced delegation topics whose naming/kind is asserted below.
 _ALL_DELEGATION_TOPICS = [
-    TOPIC_DELEGATION_REQUEST,
-    TOPIC_DELEGATION_ROUTING_DECISION,
-    TOPIC_DELEGATION_COMPLETED,
-    TOPIC_DELEGATION_FAILED,
-    TOPIC_DELEGATION_QUALITY_GATE_RESULT,
+    _resolve("DELEGATION_REQUEST"),
+    _resolve("DELEGATION_ROUTING_DECISION"),
+    _resolve("DELEGATION_COMPLETED"),
+    _resolve("DELEGATION_FAILED"),
+    _resolve("DELEGATION_QUALITY_GATE_RESULT"),
 ]
 
 
@@ -60,31 +73,35 @@ class TestDelegationTopicNaming:
 
 
 class TestDelegationTopicValues:
-    """Verify exact topic string values."""
+    """Verify exact topic string values (anchored to the contract-sourced registry)."""
 
     def test_delegation_request_topic(self) -> None:
         assert (
-            TOPIC_DELEGATION_REQUEST == "onex.cmd.omnibase-infra.delegation-request.v1"
+            _resolve("DELEGATION_REQUEST")
+            == "onex.cmd.omnibase-infra.delegation-request.v1"
         )
 
     def test_routing_decision_topic(self) -> None:
         assert (
-            TOPIC_DELEGATION_ROUTING_DECISION
+            _resolve("DELEGATION_ROUTING_DECISION")
             == "onex.evt.omnibase-infra.routing-decision.v1"
         )
 
     def test_delegation_completed_topic(self) -> None:
         assert (
-            TOPIC_DELEGATION_COMPLETED
+            _resolve("DELEGATION_COMPLETED")
             == "onex.evt.omnibase-infra.delegation-completed.v1"
         )
 
     def test_delegation_failed_topic(self) -> None:
-        assert TOPIC_DELEGATION_FAILED == "onex.evt.omnibase-infra.delegation-failed.v1"
+        assert (
+            _resolve("DELEGATION_FAILED")
+            == "onex.evt.omnibase-infra.delegation-failed.v1"
+        )
 
     def test_quality_gate_result_topic(self) -> None:
         assert (
-            TOPIC_DELEGATION_QUALITY_GATE_RESULT
+            _resolve("DELEGATION_QUALITY_GATE_RESULT")
             == "onex.evt.omnibase-infra.quality-gate-result.v1"
         )
 
@@ -93,14 +110,14 @@ class TestDelegationTopicKinds:
     """Verify command vs event topic kinds."""
 
     def test_request_is_command(self) -> None:
-        assert TOPIC_DELEGATION_REQUEST.startswith("onex.cmd.")
+        assert _resolve("DELEGATION_REQUEST").startswith("onex.cmd.")
 
     def test_events_are_evt(self) -> None:
         event_topics = [
-            TOPIC_DELEGATION_ROUTING_DECISION,
-            TOPIC_DELEGATION_COMPLETED,
-            TOPIC_DELEGATION_FAILED,
-            TOPIC_DELEGATION_QUALITY_GATE_RESULT,
+            _resolve("DELEGATION_ROUTING_DECISION"),
+            _resolve("DELEGATION_COMPLETED"),
+            _resolve("DELEGATION_FAILED"),
+            _resolve("DELEGATION_QUALITY_GATE_RESULT"),
         ]
         for topic in event_topics:
             assert topic.startswith("onex.evt."), (

--- a/tests/unit/runtime/test_dispatch_result_applier_topic_routing.py
+++ b/tests/unit/runtime/test_dispatch_result_applier_topic_routing.py
@@ -437,27 +437,50 @@ class TestDelegationTopicRegistryNoDrift:
     """OMN-13191: the applier resolves delegation topics from ServiceTopicRegistry
     (contract-sourced) instead of importing TOPIC_* string constants.
 
-    Proves the three-way equality the migration depends on:
-    registry-resolved string == legacy TOPIC_* constant == contract-declared string.
-    A mismatch on any leg means a topic drifted and the migration is unsafe.
+    Proves the two-way equality the migration depends on:
+    registry-resolved string == contract-declared string.
+    A mismatch on either leg means a topic drifted and the migration is unsafe.
+
+    OMN-13195 (phase A4): the legacy ``TOPIC_DELEGATION_*`` Python constants were
+    deleted once their last production consumers moved to contract-sourced
+    resolution. The expected strings below are the canonical contract-declared
+    values that those constants used to mirror; ``test_applier_resolved_topics_
+    match_owning_contract`` additionally anchors the applier subset to the real
+    ``contract.yaml`` on disk.
     """
 
-    # Logical key -> legacy constant name (the 4 topics the applier resolves
-    # plus the wider delegation family added to the registry for completeness).
-    _KEY_TO_CONSTANT: dict[str, str] = {
-        "DELEGATION_REQUEST": "TOPIC_DELEGATION_REQUEST",
-        "DELEGATION_ROUTING_DECISION": "TOPIC_DELEGATION_ROUTING_DECISION",
-        "DELEGATION_COMPLETED": "TOPIC_DELEGATION_COMPLETED",
-        "DELEGATION_FAILED": "TOPIC_DELEGATION_FAILED",
-        "DELEGATION_QUALITY_GATE_RESULT": "TOPIC_DELEGATION_QUALITY_GATE_RESULT",
-        "DELEGATION_ROUTING_REQUEST": "TOPIC_DELEGATION_ROUTING_REQUEST",
-        "DELEGATION_INVOCATION_COMMAND": "TOPIC_DELEGATION_INVOCATION_COMMAND",
-        "DELEGATION_AGENT_TASK_LIFECYCLE": "TOPIC_DELEGATION_AGENT_TASK_LIFECYCLE",
-        "DELEGATION_QUALITY_GATE_REQUEST": "TOPIC_DELEGATION_QUALITY_GATE_REQUEST",
-        "DELEGATION_INFERENCE_REQUEST": "TOPIC_DELEGATION_INFERENCE_REQUEST",
-        "DELEGATION_INFERENCE_RESPONSE": "TOPIC_DELEGATION_INFERENCE_RESPONSE",
-        "DELEGATION_TASK_DELEGATED": "TOPIC_DELEGATION_TASK_DELEGATED",
-        "DELEGATION_BASELINE_COMPARISON": "TOPIC_DELEGATION_BASELINE_COMPARISON",
+    # Logical key -> canonical contract-declared topic string (the 4 topics the
+    # applier resolves plus the wider delegation family added to the registry for
+    # completeness). Formerly mirrored by the deleted ``TOPIC_DELEGATION_*``
+    # constants; now asserted directly against the contract-sourced registry.
+    _KEY_TO_EXPECTED_TOPIC: dict[str, str] = {
+        "DELEGATION_REQUEST": "onex.cmd.omnibase-infra.delegation-request.v1",
+        "DELEGATION_ROUTING_DECISION": "onex.evt.omnibase-infra.routing-decision.v1",
+        "DELEGATION_COMPLETED": "onex.evt.omnibase-infra.delegation-completed.v1",
+        "DELEGATION_FAILED": "onex.evt.omnibase-infra.delegation-failed.v1",
+        "DELEGATION_QUALITY_GATE_RESULT": (
+            "onex.evt.omnibase-infra.quality-gate-result.v1"
+        ),
+        "DELEGATION_ROUTING_REQUEST": (
+            "onex.cmd.omnibase-infra.delegation-routing-request.v1"
+        ),
+        "DELEGATION_INVOCATION_COMMAND": "onex.cmd.omnibase-infra.invocation.v1",
+        "DELEGATION_AGENT_TASK_LIFECYCLE": (
+            "onex.evt.omnibase-infra.agent-task-lifecycle.v1"
+        ),
+        "DELEGATION_QUALITY_GATE_REQUEST": (
+            "onex.cmd.omnibase-infra.delegation-quality-gate-request.v1"
+        ),
+        "DELEGATION_INFERENCE_REQUEST": (
+            "onex.cmd.omnibase-infra.delegation-inference-request.v1"
+        ),
+        "DELEGATION_INFERENCE_RESPONSE": (
+            "onex.evt.omnibase-infra.inference-response.v1"
+        ),
+        "DELEGATION_TASK_DELEGATED": "onex.evt.omniclaude.task-delegated.v1",
+        "DELEGATION_BASELINE_COMPARISON": (
+            "onex.cmd.omnibase-infra.baseline-comparison-request.v1"
+        ),
     }
 
     # The 4 topics the infra applier actually resolves, mapped to the owning
@@ -469,20 +492,18 @@ class TestDelegationTopicRegistryNoDrift:
         "DELEGATION_ROUTING_REQUEST",
     )
 
-    def test_registry_resolution_equals_legacy_constant(self) -> None:
-        """Every delegation key resolves to the same string as its TOPIC_* constant."""
-        from omnibase_infra.event_bus import topic_constants
+    def test_registry_resolution_equals_expected_contract_topic(self) -> None:
+        """Every delegation key resolves to its canonical contract-declared string."""
         from omnibase_infra.topics import topic_keys
         from omnibase_infra.topics.service_topic_registry import ServiceTopicRegistry
 
         registry = ServiceTopicRegistry.from_defaults()
-        for key_name, const_name in self._KEY_TO_CONSTANT.items():
+        for key_name, expected in self._KEY_TO_EXPECTED_TOPIC.items():
             key = getattr(topic_keys, key_name)
             resolved = registry.resolve(key)
-            constant = getattr(topic_constants, const_name)
-            assert resolved == constant, (
+            assert resolved == expected, (
                 f"drift: registry.resolve({key_name})={resolved!r} != "
-                f"{const_name}={constant!r}"
+                f"expected contract string {expected!r}"
             )
 
     def test_applier_resolved_topics_match_owning_contract(self) -> None:

--- a/tests/unit/topics/test_topic_registry_integration.py
+++ b/tests/unit/topics/test_topic_registry_integration.py
@@ -15,6 +15,7 @@ Related:
 
 from __future__ import annotations
 
+import re
 import subprocess
 from pathlib import Path
 
@@ -24,6 +25,34 @@ from omnibase_infra.topics import topic_keys
 from omnibase_infra.topics.service_topic_registry import ServiceTopicRegistry
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Matches ``from omnibase_infra.event_bus.topic_constants import ... TOPIC_...``
+# in BOTH single-line and multiline parenthesized form. The original single-line
+# grep regex (``...import.*TOPIC_`` matched per line) missed the parenthesized
+# form below because the ``TOPIC_*`` name lands on a different line than the
+# ``import (`` token (false-green):
+#
+#     from omnibase_infra.event_bus.topic_constants import (
+#         TOPIC_DELEGATION_REQUEST,
+#     )
+#
+# Two non-overlapping alternatives keep the match scoped to the single import
+# statement so it cannot bleed into an unrelated later ``TOPIC_`` reference:
+#   1. multiline: ``import (`` ... up to the closing ``)`` containing ``TOPIC_``
+#   2. single-line: ``import`` ... up to end-of-line containing ``TOPIC_``
+_TOPIC_CONSTANT_IMPORT_RE = re.compile(
+    r"from\s+omnibase_infra\.event_bus\.topic_constants\s+import\s+"
+    r"(?:\([^)]*\bTOPIC_[^)]*\)|[^\n(]*\bTOPIC_[^\n]*)",
+    re.DOTALL,
+)
+
+
+def _find_topic_constant_imports(text: str) -> bool:
+    """Return True if *text* imports any ``TOPIC_*`` name from topic_constants.
+
+    Catches both single-line and multiline parenthesized import forms.
+    """
+    return _TOPIC_CONSTANT_IMPORT_RE.search(text) is not None
 
 
 @pytest.mark.unit
@@ -41,21 +70,53 @@ class TestTopicRegistryIntegration:
             )
 
     def test_no_topic_constant_imports_remain_in_src(self) -> None:
-        """No src/ file imports TOPIC_* from topic_constants."""
-        result = subprocess.run(
-            [
-                "grep",
-                "-rn",
-                r"from omnibase_infra.event_bus.topic_constants import.*TOPIC_",
-                "src/",
-            ],
-            capture_output=True,
-            text=True,
-            cwd=str(REPO_ROOT),
-            check=False,
+        """No src/ file imports TOPIC_* from topic_constants.
+
+        Reads each ``src/**/*.py`` whole-file (not line-by-line) and applies a
+        multiline-aware matcher so parenthesized imports are caught. The previous
+        single-line grep was false-green against the parenthesized form.
+        """
+        src_root = REPO_ROOT / "src"
+        offenders: list[str] = []
+        for py_file in sorted(src_root.rglob("*.py")):
+            text = py_file.read_text(encoding="utf-8")
+            if _find_topic_constant_imports(text):
+                offenders.append(str(py_file.relative_to(REPO_ROOT)))
+        assert offenders == [], (
+            "Remaining TOPIC_* imports from topic_constants in src/:\n"
+            + "\n".join(offenders)
         )
-        assert result.stdout == "", (
-            f"Remaining TOPIC_* imports in src/:\n{result.stdout}"
+
+    def test_guard_matcher_fires_on_planted_multiline_violation(self) -> None:
+        """Regression: the matcher must catch the multiline parenthesized form.
+
+        This is the exact shape the original single-line grep missed. If the
+        matcher silently false-greens again, this assertion fails.
+        """
+        planted_multiline = (
+            "from omnibase_infra.event_bus.topic_constants import (\n"
+            "    TOPIC_DELEGATION_REQUEST,\n"
+            ")\n"
+        )
+        planted_singleline = "from omnibase_infra.event_bus.topic_constants import TOPIC_DELEGATION_FAILED\n"
+        # Both real violation shapes must be detected.
+        assert _find_topic_constant_imports(planted_multiline), (
+            "matcher failed to detect a multiline parenthesized TOPIC_* import "
+            "(false-green regression)"
+        )
+        assert _find_topic_constant_imports(planted_singleline), (
+            "matcher failed to detect a single-line TOPIC_* import"
+        )
+        # A topic_constants import that pulls ONLY non-TOPIC_ helpers (e.g. the
+        # DLQ builders) must NOT be flagged — those are legitimate and stay.
+        legitimate_dlq = (
+            "from omnibase_infra.event_bus.topic_constants import (\n"
+            "    build_dlq_topic,\n"
+            "    parse_dlq_topic,\n"
+            ")\n"
+        )
+        assert not _find_topic_constant_imports(legitimate_dlq), (
+            "matcher false-positived on a legitimate DLQ-helper-only import"
         )
 
     def test_no_wiring_health_monitored_imports_remain_in_src(self) -> None:


### PR DESCRIPTION
## OMN-13195 — A4: delete orphaned delegation TOPIC_* constants, fix false-green guard, narrow topic gate exemption

Phase A4 of the platform-debt contract-sourced-topics plan (epic **OMN-13188**).
Predecessors merged to dev: **OMN-13191** (#2005, infra applier) and **OMN-13193** (#1241, omnimarket orchestrator).

### What changed
- **Deleted 13 orphaned `TOPIC_DELEGATION_*` constants** from `event_bus/topic_constants.py`. After A2/A3 a per-constant grep across all repos under `$OMNI_HOME` (2026-06-17) found **ZERO production (`src/`) importers**.
- **KEPT (verified live):** `TOPIC_SESSION_COORDINATION_SIGNAL` (live consumer omnimarket `node_emit_daemon/contract.yaml` publish_topics) and `TOPIC_DELEGATE_SKILL_COMPLETED` / `TOPIC_DELEGATE_SKILL_FAILED` (AST source for `generate_topic_enums.py` → `EnumOmnimarketTopic.EVT_DELEGATE_SKILL_*_V1`, consumed at bootstrap by `service_kernel.py`, OMN-11996). All 16 DLQ builder/format helpers kept.
- **Regenerated the topic enums.** The codegen sources `topic_constants.py` as a supplementary AST source, so deleting the constants drops **10 now-unused** generated enum members (the rest survive because they are also contract-declared). All 10 verified unused across src + tests in every repo. Keeps the **Topic Enum Drift Check** gate (pre-commit + CI) green. DELEGATE_SKILL members unchanged.
- **Migrated the 3 infra test files** that imported the deleted constants to resolve via `ServiceTopicRegistry` / `topic_keys` — the same contract-sourced path the applier uses — preserving every naming/value/kind/drift assertion against the durable contract source.
- **Fixed the false-green guard** `test_no_topic_constant_imports_remain_in_src`: its single-line grep missed multiline parenthesized imports. Replaced with a whole-file multiline-aware matcher + added `test_guard_matcher_fires_on_planted_multiline_violation` proving it fires on the planted form (and does not false-positive on a DLQ-helper-only import).
- **Narrowed the topic gate exemptions:** removed `topic_constants.py` from `check_topic_literals.py` `_EXCLUDED_FILENAMES` (whole-file) and suppressed only the 3 kept literals per-line in `topic_literal_baseline.txt`; dropped the redundant `topic_constants.py` entry from the `no-hardcoded-topics` pre-commit exclude (the hook already approves that basename via its internal `APPROVED_BASENAMES`). Full un-allowlisting tracked in follow-up **OMN-13202** → A5-full **OMN-13199**.

### dod_evidence
- **Zero production importers** (per-constant grep, all repos, src/): every one of the 13 deleted `TOPIC_DELEGATION_*` had only test-file references; those infra test refs are migrated in this PR.
- **`check_topic_literals.py`**: `OK: No new raw topic literals found in 2417 file(s) (12 pre-existing violations suppressed)` — `topic_constants.py` now scanned (no longer whole-file excluded); only the 3 documented kept lines baselined.
- **Topic Enum Drift Check**: `CHECK PASSED: 14 generated file(s) are up to date.`
- **Tests**: 717 relevant unit/integration tests green (`tests/unit/topics tests/unit/event_bus tests/unit/runtime/test_dispatch_result_applier_topic_routing.py tests/integration/runtime/test_delegation_intent_topic_routing_integration.py`); kernel bootstrap/delegate-skill slice (35) green; new guard test fires on a planted multiline violation.
- **ruff** format+check clean; **mypy --strict** clean on the touched src module; **pre-commit** all architecture/topic/drift hooks Passed on changed files.

Evidence-Source: OCC#2685
Evidence-Ticket: OMN-13195

🤖 Generated with [Claude Code](https://claude.ai/code)