### PR TITLE
feat(OMN-12634): move DLQ feature gating from env vars to contract overlay

### DIFF
--- a/config/overlays/dlq-feature.yaml.example
+++ b/config/overlays/dlq-feature.yaml.example
@@ -1,0 +1,30 @@
+# DLQ feature overlay example (OMN-12634)
+#
+# Copy the services.dlq block below into your ~/.omnibase/overlay.yaml
+# to activate the DLQ plugin.  The overlay.yaml must conform to ModelOverlayFile
+# schema (overlay_version: "1.0.0").
+#
+# DLQ keys live under services.dlq so they are cleanly namespaced and do not
+# collide with transport-level keys (postgres.*, kafka.*, etc.).
+#
+# Keys:
+#   DLQ_ENABLED  — Set to "true" to activate PluginDlq at kernel boot.
+#                  Any of "true" / "1" / "yes" (case-insensitive) enables.
+#                  Absent or any other value disables the plugin.
+#   DLQ_DB_URL   — PostgreSQL DSN for the DLQ tracking table.
+#                  Required when DLQ_ENABLED is truthy; kernel raises ValueError
+#                  if enabled without a DSN (fail-fast, no silent default).
+#
+# Example ~/.omnibase/overlay.yaml snippet:
+#
+# overlay_version: "1.0.0"
+# environment: local
+# scope: env
+# transports:
+#   db:
+#     POSTGRES_HOST: localhost
+#     POSTGRES_PORT: "5436"
+# services:
+#   dlq:
+#     DLQ_ENABLED: "true"
+#     DLQ_DB_URL: "postgresql://postgres:secret@localhost:5436/onex_dlq"

--- a/src/omnibase_infra/dlq/plugin_dlq.py
+++ b/src/omnibase_infra/dlq/plugin_dlq.py
@@ -7,20 +7,30 @@ Wires ServiceDlqTracking (replay history) and ServiceRetryWorker
 (poll-and-retry loop) into the kernel lifecycle via the
 ProtocolDomainPlugin protocol.
 
-Activation:
-    The plugin activates when ``OMNIBASE_INFRA_DLQ_ENABLED`` is set to a
-    truthy value **and** ``OMNIBASE_INFRA_DB_URL`` is available for the
-    DLQ PostgreSQL table.
+Activation (OMN-12634):
+    The plugin activates when ``DLQ_ENABLED`` is set to a truthy value AND
+    ``DLQ_DB_URL`` is present in ``config.overlay_config``.  Both keys are
+    resolved from the contract overlay; environment variables are no longer
+    consulted for feature gating.
+
+    If ``overlay_config`` is ``None`` (kernel not yet overlay-capable) the
+    plugin skips silently.  If ``DLQ_ENABLED`` is truthy but ``DLQ_DB_URL``
+    is absent the plugin raises ``ValueError`` — fail-fast, no silent default.
 
 Lifecycle:
-    1. should_activate() — checks env vars
+    1. should_activate() — reads overlay_config, raises on misconfiguration
     2. initialize() — creates asyncpg pool, initializes ServiceDlqTracking
     3. wire_handlers() — no-op (DLQ has no handlers)
     4. wire_dispatchers() — no-op (DLQ has no dispatch routes)
     5. start_consumers() — starts ServiceRetryWorker as asyncio background task
     6. shutdown() — stops retry worker, shuts down DLQ tracking, closes pool
 
+Overlay keys:
+    DLQ_ENABLED  — "true" / "1" / "yes" (case-insensitive) to activate
+    DLQ_DB_URL   — PostgreSQL DSN for the DLQ tracking table (required when enabled)
+
 Related:
+    - OMN-12634: Move DLQ feature gating from env vars to contract overlay
     - OMN-6601: Wire DLQ + retry worker into kernel lifecycle
     - OMN-1032: PostgreSQL tracking integration
     - OMN-1454: RetryWorker for subscription notification delivery
@@ -30,7 +40,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -72,35 +81,47 @@ class PluginDlq:
         return "DLQ"
 
     def should_activate(self, config: ModelDomainPluginConfig) -> bool:
-        """Activate when DLQ is enabled and DB URL is available."""
-        enabled = (
-            os.environ.get(  # ONEX_FLAG_EXEMPT: activation gate
-                "OMNIBASE_INFRA_DLQ_ENABLED", ""
-            ).lower()
-            in _TRUTHY
-        )
-        self._dsn = os.environ.get(
-            "OMNIBASE_INFRA_DB_URL", ""
-        )  # ONEX_FLAG_EXEMPT: activation gate
+        """Activate when DLQ_ENABLED and DLQ_DB_URL are set in overlay_config.
 
+        Reads activation state exclusively from ``config.overlay_config`` — env
+        vars are never consulted (OMN-12634).
+
+        Returns False when:
+        - ``overlay_config`` is ``None`` (kernel not yet overlay-capable)
+        - ``DLQ_ENABLED`` key is absent or falsy
+
+        Raises ValueError when:
+        - ``DLQ_ENABLED`` is truthy but ``DLQ_DB_URL`` is missing — fail-fast,
+          no silent default.
+        """
+        overlay = getattr(config, "overlay_config", None)
+        if overlay is None:
+            logger.debug(
+                "PluginDlq: overlay_config not present, skipping (correlation_id=%s)",
+                config.correlation_id,
+            )
+            return False
+
+        enabled = overlay.get("DLQ_ENABLED", "").lower() in _TRUTHY
         if not enabled:
             logger.debug(
-                "PluginDlq: OMNIBASE_INFRA_DLQ_ENABLED not set, skipping "
+                "PluginDlq: DLQ_ENABLED not set in overlay, skipping "
                 "(correlation_id=%s)",
                 config.correlation_id,
             )
             return False
 
-        if not self._dsn:
-            logger.warning(
-                "PluginDlq: DLQ enabled but OMNIBASE_INFRA_DB_URL not set, skipping "
-                "(correlation_id=%s)",
-                config.correlation_id,
+        db_url = overlay.get("DLQ_DB_URL", "").strip()
+        if not db_url:
+            raise ValueError(
+                "PluginDlq: DLQ_ENABLED is true in overlay but DLQ_DB_URL is "
+                "missing or empty — set DLQ_DB_URL in the overlay config "
+                f"(correlation_id={config.correlation_id})"
             )
-            return False
 
+        self._dsn = db_url
         logger.info(
-            "PluginDlq: activating (correlation_id=%s)",
+            "PluginDlq: activating from overlay config (correlation_id=%s)",
             config.correlation_id,
         )
         return True

--- a/src/omnibase_infra/runtime/models/model_domain_plugin_config.py
+++ b/src/omnibase_infra/runtime/models/model_domain_plugin_config.py
@@ -114,5 +114,11 @@ class ModelDomainPluginConfig:
     # Optional: Per-event-type topic routing from contract published_events.
     output_topic_map: dict[str, str] | None = None
 
+    # Optional: Resolved overlay config key-value pairs for feature gating (OMN-12634).
+    # Plugins read their activation flags from this dict instead of environment variables.
+    # Keys are defined per-feature (e.g. DLQ_ENABLED, DLQ_DB_URL for the DLQ plugin).
+    # None when the kernel has not loaded an overlay (legacy env-var mode).
+    overlay_config: dict[str, str] | None = None
+
 
 __all__ = ["ModelDomainPluginConfig"]

--- a/src/omnibase_infra/runtime/service_kernel.py
+++ b/src/omnibase_infra/runtime/service_kernel.py
@@ -849,6 +849,58 @@ async def bootstrap() -> int:
             correlation_id,
         )
 
+        # 1d. Load overlay config for feature gating (OMN-12634).
+        # Resolves the operator's overlay YAML into a flat key-value dict that is
+        # passed to domain plugins via ModelDomainPluginConfig.overlay_config.
+        # Plugins (e.g. PluginDlq) read their activation flags from this dict
+        # instead of env vars.  Gracefully absent: if the overlay file is not
+        # present the kernel continues without it and plugins that require an
+        # overlay will skip activation silently.
+        _boot_overlay_config: dict[str, str] | None = None
+        try:
+            from pathlib import Path as _Path
+
+            from omnibase_infra.runtime.overlay.boot_overlay import (
+                load_overlay_config as _load_overlay_config,
+            )
+            from omnibase_infra.runtime.overlay.errors import (
+                OverlayNotFoundError as _OverlayNotFoundError,
+            )
+
+            _overlay_path = _Path.home() / ".omnibase" / "overlay.yaml"
+            _overlay_result = _load_overlay_config(
+                overlay_path=_overlay_path,
+                contracts_dir=contracts_dir,
+                require_overlay=False,
+            )
+            if _overlay_result is not None:
+                _boot_overlay_config = dict(_overlay_result.resolved)
+                logger.info(
+                    "Overlay config loaded from %s (%d keys) (correlation_id=%s)",
+                    _overlay_path,
+                    len(_boot_overlay_config),
+                    correlation_id,
+                )
+            else:
+                logger.debug(
+                    "Overlay file absent — running without overlay config "
+                    "(correlation_id=%s)",
+                    correlation_id,
+                )
+        except _OverlayNotFoundError:
+            logger.debug(
+                "Overlay file not found — running without overlay config "
+                "(correlation_id=%s)",
+                correlation_id,
+            )
+        except Exception:  # noqa: BLE001 — graceful degradation; overlay is optional
+            logger.warning(
+                "Failed to load overlay config, continuing without it "
+                "(correlation_id=%s)",
+                correlation_id,
+                exc_info=True,
+            )
+
         # 2. Load runtime configuration (may raise ProtocolConfigurationError)
         # Pass correlation_id for consistent tracing across initialization sequence
         config_start_time = time.time()
@@ -1990,6 +2042,7 @@ async def bootstrap() -> int:
             node_identity=plugin_node_identity,
             kafka_bootstrap_servers=kafka_bootstrap_servers,
             runtime_profile=kernel_profile.name,
+            overlay_config=_boot_overlay_config,
         )
 
         # Activate plugins using two-pass lifecycle (OMN-2050, OMN-2089)

--- a/tests/unit/dlq/__init__.py
+++ b/tests/unit/dlq/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/unit/dlq/test_plugin_dlq_overlay_activation.py
+++ b/tests/unit/dlq/test_plugin_dlq_overlay_activation.py
@@ -116,10 +116,11 @@ class TestModelDomainPluginConfigOverlayField:
     def test_overlay_config_defaults_to_none(self) -> None:
         from uuid import uuid4
 
+        from omnibase_infra.event_bus import EventBusInmemory
         from omnibase_infra.runtime.models import ModelDomainPluginConfig
 
         mock_container = MagicMock()
-        mock_bus = MagicMock()
+        mock_bus = MagicMock(spec=EventBusInmemory)
         config = ModelDomainPluginConfig(
             container=mock_container,
             event_bus=mock_bus,
@@ -133,10 +134,11 @@ class TestModelDomainPluginConfigOverlayField:
     def test_overlay_config_can_be_set(self) -> None:
         from uuid import uuid4
 
+        from omnibase_infra.event_bus import EventBusInmemory
         from omnibase_infra.runtime.models import ModelDomainPluginConfig
 
         mock_container = MagicMock()
-        mock_bus = MagicMock()
+        mock_bus = MagicMock(spec=EventBusInmemory)
         overlay = {"DLQ_ENABLED": "true", "DLQ_DB_URL": "postgresql://localhost/dlq"}
         config = ModelDomainPluginConfig(
             container=mock_container,

--- a/tests/unit/dlq/test_plugin_dlq_overlay_activation.py
+++ b/tests/unit/dlq/test_plugin_dlq_overlay_activation.py
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for PluginDlq overlay-based activation (OMN-12634).
+
+Verifies that PluginDlq.should_activate() resolves DLQ_ENABLED and DLQ_DB_URL
+from config.overlay_config instead of environment variables.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+
+@dataclass
+class _MinimalPluginConfig:
+    """Minimal stand-in for ModelDomainPluginConfig — only fields PluginDlq reads."""
+
+    correlation_id: Any
+    overlay_config: dict[str, str] | None = None
+
+
+def _make_config(overlay: dict[str, str] | None = None) -> _MinimalPluginConfig:
+    return _MinimalPluginConfig(correlation_id=uuid4(), overlay_config=overlay)
+
+
+class TestPluginDlqOverlayActivation:
+    """PluginDlq.should_activate() must read from overlay_config, not env vars."""
+
+    def test_activates_when_overlay_enabled_and_db_url_set(self) -> None:
+        from omnibase_infra.dlq.plugin_dlq import PluginDlq
+
+        plugin = PluginDlq()
+        config = _make_config(
+            {"DLQ_ENABLED": "true", "DLQ_DB_URL": "postgresql://localhost/dlq"}
+        )
+        assert plugin.should_activate(config) is True  # type: ignore[arg-type]
+
+    def test_does_not_activate_when_dlq_disabled_in_overlay(self) -> None:
+        from omnibase_infra.dlq.plugin_dlq import PluginDlq
+
+        plugin = PluginDlq()
+        config = _make_config(
+            {"DLQ_ENABLED": "false", "DLQ_DB_URL": "postgresql://localhost/dlq"}
+        )
+        assert plugin.should_activate(config) is False  # type: ignore[arg-type]
+
+    def test_does_not_activate_when_dlq_key_absent_from_overlay(self) -> None:
+        from omnibase_infra.dlq.plugin_dlq import PluginDlq
+
+        plugin = PluginDlq()
+        # overlay present but DLQ_ENABLED key missing → treat as disabled
+        config = _make_config({"DLQ_DB_URL": "postgresql://localhost/dlq"})
+        assert plugin.should_activate(config) is False  # type: ignore[arg-type]
+
+    def test_raises_when_enabled_but_db_url_missing_from_overlay(self) -> None:
+        from omnibase_infra.dlq.plugin_dlq import PluginDlq
+
+        plugin = PluginDlq()
+        config = _make_config({"DLQ_ENABLED": "true"})
+        # fail-fast: overlay says enabled but DLQ_DB_URL not provided
+        with pytest.raises(ValueError, match="DLQ_DB_URL"):
+            plugin.should_activate(config)  # type: ignore[arg-type]
+
+    def test_does_not_activate_when_overlay_config_is_none(self) -> None:
+        from omnibase_infra.dlq.plugin_dlq import PluginDlq
+
+        plugin = PluginDlq()
+        config = _make_config(overlay=None)
+        assert plugin.should_activate(config) is False  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("truthy", ["true", "1", "yes", "True", "YES"])
+    def test_activates_for_all_truthy_values(self, truthy: str) -> None:
+        from omnibase_infra.dlq.plugin_dlq import PluginDlq
+
+        plugin = PluginDlq()
+        config = _make_config(
+            {"DLQ_ENABLED": truthy, "DLQ_DB_URL": "postgresql://localhost/dlq"}
+        )
+        assert plugin.should_activate(config) is True  # type: ignore[arg-type]
+
+    def test_dsn_stored_after_activation(self) -> None:
+        from omnibase_infra.dlq.plugin_dlq import PluginDlq
+
+        dsn = "postgresql://user:pass@host/dlq"
+        plugin = PluginDlq()
+        config = _make_config({"DLQ_ENABLED": "true", "DLQ_DB_URL": dsn})
+        plugin.should_activate(config)  # type: ignore[arg-type]
+        assert plugin._dsn == dsn
+
+    def test_env_vars_are_not_read_when_overlay_provided(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Env vars must NOT be consulted when overlay_config is present."""
+        from omnibase_infra.dlq.plugin_dlq import PluginDlq
+
+        # Set env vars to the opposite of overlay so any env-var read would fail
+        monkeypatch.setenv("OMNIBASE_INFRA_DLQ_ENABLED", "true")
+        monkeypatch.setenv("OMNIBASE_INFRA_DB_URL", "postgresql://env/wrong")
+
+        plugin = PluginDlq()
+        # overlay says disabled → must return False regardless of env
+        config = _make_config(
+            {"DLQ_ENABLED": "false", "DLQ_DB_URL": "postgresql://env/wrong"}
+        )
+        assert plugin.should_activate(config) is False  # type: ignore[arg-type]
+
+
+class TestModelDomainPluginConfigOverlayField:
+    """ModelDomainPluginConfig must carry overlay_config without breaking existing usage."""
+
+    def test_overlay_config_defaults_to_none(self) -> None:
+        from uuid import uuid4
+
+        from omnibase_infra.runtime.models import ModelDomainPluginConfig
+
+        mock_container = MagicMock()
+        mock_bus = MagicMock()
+        config = ModelDomainPluginConfig(
+            container=mock_container,
+            event_bus=mock_bus,
+            correlation_id=uuid4(),
+            input_topic="in",
+            output_topic="out",
+            consumer_group="g",
+        )
+        assert config.overlay_config is None
+
+    def test_overlay_config_can_be_set(self) -> None:
+        from uuid import uuid4
+
+        from omnibase_infra.runtime.models import ModelDomainPluginConfig
+
+        mock_container = MagicMock()
+        mock_bus = MagicMock()
+        overlay = {"DLQ_ENABLED": "true", "DLQ_DB_URL": "postgresql://localhost/dlq"}
+        config = ModelDomainPluginConfig(
+            container=mock_container,
+            event_bus=mock_bus,
+            correlation_id=uuid4(),
+            input_topic="in",
+            output_topic="out",
+            consumer_group="g",
+            overlay_config=overlay,
+        )
+        assert config.overlay_config == overlay

--- a/tests/unit/scripts/ci/test_detect_test_paths.py
+++ b/tests/unit/scripts/ci/test_detect_test_paths.py
@@ -54,16 +54,18 @@ def test_leaf_module_change_expands_to_its_reverse_deps() -> None:
 
 def test_services_module_expands_to_reverse_deps() -> None:
     # services is imported by adapters, dlq, handlers, runtime.
-    # `dlq` is dropped because tests/unit/dlq/ does not exist on disk — passing
-    # a missing path to pytest aborts collection with exit code 5. Only existing
-    # test directories are selected.
+    # All four reverse-dep test dirs exist on disk (tests/unit/dlq/ was added by
+    # the DLQ overlay work, OMN-12634), so every reverse dep is selected. Only
+    # existing test directories are emitted — a missing path would abort pytest
+    # collection with exit code 5.
     changed_files = ["src/omnibase_infra/services/foo.py"]
     paths = resolve_test_paths(changed_files, adjacency_path=ADJ)
     expected = sorted(
-        f"tests/unit/{m}/" for m in ("services", "adapters", "handlers", "runtime")
+        f"tests/unit/{m}/"
+        for m in ("services", "adapters", "dlq", "handlers", "runtime")
     )
     assert paths == expected
-    assert "tests/unit/dlq/" not in paths
+    assert "tests/unit/dlq/" in paths
 
 
 def test_missing_test_directories_are_filtered_out() -> None:


### PR DESCRIPTION
## Summary

- Removes \`OMNIBASE_INFRA_DLQ_ENABLED\` / \`OMNIBASE_INFRA_DB_URL\` env-var gating from \`PluginDlq\`
- \`PluginDlq.should_activate()\` now reads \`DLQ_ENABLED\` and \`DLQ_DB_URL\` from \`config.overlay_config\` (the resolved overlay key-value dict passed by the kernel)
- Fail-fast \`ValueError\` when \`DLQ_ENABLED=true\` in overlay but \`DLQ_DB_URL\` absent — no silent default
- Kernel step 1d: loads \`~/.omnibase/overlay.yaml\` at boot, passes \`all_env_pairs()\` as \`overlay_config\` on \`ModelDomainPluginConfig\`; graceful skip when overlay absent
- \`ModelDomainPluginConfig\` gains \`overlay_config: dict[str, str] | None = None\` field
- 14 unit tests covering: activation, disabled, absent key, fail-fast, env isolation, all truthy variants, DSN stored

Evidence-Source: OCC#2695
Evidence-Ticket: OMN-12634