### PR TITLE
feat(OMN-12633): retire ServiceDlqTracking runtime DDL — dlq_replay_history to migration-managed schema

### DIFF
--- a/contracts/OMN-12633.yaml
+++ b/contracts/OMN-12633.yaml
@@ -1,0 +1,63 @@
+# OMN-12633 contract file for omnibase_infra deploy-gate.
+# The canonical ticket contract and PASS receipts live in onex_change_control.
+schema_version: "1.0.0"
+ticket_id: "OMN-12633"
+title: "feat(OMN-12633): retire ServiceDlqTracking runtime DDL — dlq_replay_history to migration-managed schema"
+summary: >-
+  Removes ServiceDlqTracking._ensure_table_exists() and the CREATE TABLE IF NOT EXISTS
+  call from initialize(). The dlq_replay_history table is now provisioned by the
+  canonical forward migration runner (086_create_dlq_replay_history.sql), making it
+  visible to public.schema_migrations and owned by node_dlq_replay_effect per
+  CONTRACT/NODE/HANDLER (OMN-12525). Adds static-analysis ratchet test preventing
+  re-introduction of imperative DDL.
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: "tests"
+    description: "DLQ unit tests pass — no runtime DDL in ServiceDlqTracking"
+    command: >-
+      uv run pytest tests/unit/dlq/ -q
+  - kind: "ci"
+    description: "CI gates pass on omnibase_infra PR #2012"
+    command: "gh pr checks 2012 --repo OmniNode-ai/omnibase_infra"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-contract-artifact"
+    description: "Repo-local deploy evidence contract is present for OMN-12633"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "test -f contracts/OMN-12633.yaml"
+  - id: "dod-unit-tests"
+    description: "DLQ unit tests pass including no-runtime-DDL ratchet"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: >-
+          uv run pytest tests/unit/dlq/ -q
+  - id: "dod-no-imperative-ddl"
+    description: "ServiceDlqTracking._ensure_table_exists() removed; no CREATE TABLE in method bodies"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: >-
+          uv run pytest tests/unit/dlq/test_service_dlq_tracking_no_runtime_ddl.py -q
+  - id: "dod-migration-exists"
+    description: "Forward migration 086_create_dlq_replay_history.sql is present"
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "test -f docker/migrations/forward/086_create_dlq_replay_history.sql"
+  - id: "dod-deploy"
+    description: >-
+      Deploy validation: tech-debt cleanup removing runtime table creation from ServiceDlqTracking.
+      The table must be pre-created by the forward migration runner before DLQ plugin activates.
+      No new Kafka topics; no API surface changes. Migration 086 is idempotent (IF NOT EXISTS).
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "deploy-gate: migration 086 creates dlq_replay_history idempotently; no topic/API changes"

--- a/docker/migrations/forward/086_create_dlq_replay_history.sql
+++ b/docker/migrations/forward/086_create_dlq_replay_history.sql
@@ -1,0 +1,29 @@
+-- OMN-12633: Create the DLQ replay history table.
+-- DDL owner: node_dlq_replay_effect (CONTRACT/NODE/HANDLER pattern — OMN-12525).
+--
+-- Previously this table was created at runtime by ServiceDlqTracking via an
+-- imperative CREATE TABLE IF NOT EXISTS inside _ensure_table_exists().  That
+-- method has been removed (OMN-12633).  The table is now provisioned here,
+-- through the canonical forward migration runner, and is therefore visible to
+-- public.schema_migrations.
+
+CREATE TABLE IF NOT EXISTS dlq_replay_history (
+    id UUID PRIMARY KEY,
+    original_message_id UUID NOT NULL,
+    replay_correlation_id UUID NOT NULL,
+    original_topic VARCHAR(255) NOT NULL,
+    target_topic VARCHAR(255) NOT NULL,
+    replay_status VARCHAR(50) NOT NULL,
+    replay_timestamp TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    success BOOLEAN NOT NULL,
+    error_message TEXT,
+    dlq_offset BIGINT NOT NULL,
+    dlq_partition INTEGER NOT NULL,
+    retry_count INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_dlq_replay_history_message_id
+    ON dlq_replay_history (original_message_id);
+
+CREATE INDEX IF NOT EXISTS idx_dlq_replay_history_timestamp
+    ON dlq_replay_history (replay_timestamp);

--- a/docker/migrations/schema_fingerprint.sha256
+++ b/docker/migrations/schema_fingerprint.sha256
@@ -1,6 +1,6 @@
 # Schema migration fingerprint for omnibase_infra (auto-generated)
 # Regenerate: python scripts/check_schema_fingerprint.py stamp
 # Verify:     python scripts/check_schema_fingerprint.py verify
-sha256:8fb160a6ef81d8b2d88e2681c3312ddcc04dbdb6fe8199c1751bcdd97bb78fc7
-generated_at: 2026-06-14T06:12:29Z
-migration_file_count: 70
+sha256:422b8fc155e52f02d796fdb64b35206901cd2abe41291942b1adf653afd6ef1c
+generated_at: 2026-06-17T17:07:59Z
+migration_file_count: 71

--- a/src/omnibase_infra/dlq/service_dlq_tracking.py
+++ b/src/omnibase_infra/dlq/service_dlq_tracking.py
@@ -1,12 +1,12 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 # ruff: noqa: S608
-# S608 disabled: All SQL f-strings use storage_table which is validated via:
+# S608 disabled: INSERT/SELECT f-strings use storage_table which is validated via:
 # 1. Pydantic regex pattern (PATTERN_TABLE_NAME) in ModelDlqTrackingConfig
 # 2. Runtime validation in _validate_storage_table() (defense-in-depth)
 # Both use the shared PATTERN_TABLE_NAME constant from constants_dlq.py.
-# This defense-in-depth approach ensures only valid PostgreSQL identifiers are used,
-# preventing SQL injection even if config validation is somehow bypassed.
+# CREATE TABLE IF NOT EXISTS was removed from this class (OMN-12633) — table
+# provisioning now belongs to the canonical forward migration runner.
 """DLQ Replay Tracking Service.
 
 A PostgreSQL-based service for tracking DLQ replay
@@ -15,33 +15,26 @@ operations, enabling persistent history of replay attempts.
 The service uses asyncpg for async database operations and provides
 methods for recording replay attempts and querying replay history.
 
-Table Schema:
-    CREATE TABLE IF NOT EXISTS dlq_replay_history (
-        id UUID PRIMARY KEY,
-        original_message_id UUID NOT NULL,
-        replay_correlation_id UUID NOT NULL,
-        original_topic VARCHAR(255) NOT NULL,
-        target_topic VARCHAR(255) NOT NULL,
-        replay_status VARCHAR(50) NOT NULL,
-        replay_timestamp TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-        success BOOLEAN NOT NULL,
-        error_message TEXT,
-        dlq_offset BIGINT NOT NULL,
-        dlq_partition INTEGER NOT NULL,
-        retry_count INTEGER NOT NULL DEFAULT 0
-    );
-    CREATE INDEX IF NOT EXISTS idx_dlq_replay_message_id ON dlq_replay_history(original_message_id);
-    CREATE INDEX IF NOT EXISTS idx_dlq_replay_timestamp ON dlq_replay_history(replay_timestamp);
+Schema Ownership (OMN-12633):
+    The ``dlq_replay_history`` table is provisioned by the canonical forward
+    migration runner, not by this class.  The DDL lives in:
+
+    * ``src/omnibase_infra/schemas/schema_dlq_replay_history.sql``
+    * ``docker/migrations/forward/086_create_dlq_replay_history.sql``
+
+    This class no longer calls CREATE TABLE IF NOT EXISTS at runtime; the
+    table must already exist when ``initialize()`` is called.
 
 Security Note:
-    - DSN contains credentials - never log the raw value
+    - DSN contains credentials — never log the raw value
     - Use parameterized queries to prevent SQL injection
     - Connection pool handles credential management
     - Table names are validated at both config and runtime level (defense-in-depth)
 
 Related:
-    - scripts/dlq_replay.py - CLI tool that uses this service
-    - OMN-1032 - PostgreSQL tracking integration ticket
+    - scripts/dlq_replay.py — CLI tool that uses this service
+    - OMN-1032  — PostgreSQL tracking integration ticket
+    - OMN-12633 — retire ServiceDlqTracking runtime DDL
 """
 
 from __future__ import annotations
@@ -217,14 +210,15 @@ class ServiceDlqTracking(MixinAsyncCircuitBreaker):
             )
 
     async def initialize(self) -> None:
-        """Initialize the connection pool and ensure table exists.
+        """Initialize the connection pool.
 
-        Creates the asyncpg connection pool and verifies (or creates)
-        the dlq_replay_history table with proper schema.
+        Creates the asyncpg connection pool.  The ``dlq_replay_history``
+        table must already exist — it is owned by ``node_dlq_replay_effect``
+        and provisioned by the canonical forward migration runner (OMN-12633).
 
         Raises:
             InfraConnectionError: If database connection fails.
-            RuntimeHostError: If pool creation or table setup fails.
+            RuntimeHostError: If pool creation fails.
         """
         if self._initialized:
             return
@@ -244,9 +238,6 @@ class ServiceDlqTracking(MixinAsyncCircuitBreaker):
                 max_size=self._config.pool_max_size,
                 command_timeout=self._config.command_timeout,
             )
-
-            # Ensure table exists with proper schema
-            await self._ensure_table_exists()
 
             self._initialized = True
             logger.info(
@@ -283,61 +274,6 @@ class ServiceDlqTracking(MixinAsyncCircuitBreaker):
                 logger.debug("Cleaning up connection pool after initialization failure")
                 await self._pool.close()
                 self._pool = None
-
-    async def _ensure_table_exists(self) -> None:
-        """Create the DLQ replay history table if it doesn't exist.
-
-        Creates the table with:
-            - UUID primary key
-            - Indexes on original_message_id and replay_timestamp
-            - All required columns for replay tracking
-        """
-        if self._pool is None:
-            raise RuntimeHostError(
-                "Pool not initialized - call initialize() first",
-                context=ModelInfraErrorContext.with_correlation(
-                    transport_type=EnumInfraTransportType.DATABASE,
-                    operation="_ensure_table_exists",
-                    target_name="dlq_tracking_service",
-                ),
-            )
-
-        # Note: Table name is validated in config (alphanumeric + underscore only)
-        # so safe to use in SQL. We still use parameterized queries for data values.
-        create_table_sql = f"""
-            CREATE TABLE IF NOT EXISTS {self._config.storage_table} (
-                id UUID PRIMARY KEY,
-                original_message_id UUID NOT NULL,
-                replay_correlation_id UUID NOT NULL,
-                original_topic VARCHAR(255) NOT NULL,
-                target_topic VARCHAR(255) NOT NULL,
-                replay_status VARCHAR(50) NOT NULL,
-                replay_timestamp TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-                success BOOLEAN NOT NULL,
-                error_message TEXT,
-                dlq_offset BIGINT NOT NULL,
-                dlq_partition INTEGER NOT NULL,
-                retry_count INTEGER NOT NULL DEFAULT 0
-            )
-        """
-
-        create_message_id_index_sql = f"""
-            CREATE INDEX IF NOT EXISTS idx_{self._config.storage_table}_message_id
-            ON {self._config.storage_table}(original_message_id)
-        """
-
-        create_timestamp_index_sql = f"""
-            CREATE INDEX IF NOT EXISTS idx_{self._config.storage_table}_timestamp
-            ON {self._config.storage_table}(replay_timestamp)
-        """
-
-        async with self._pool.acquire() as conn:
-            # Wrap DDL in transaction for atomicity - if index creation fails,
-            # the table creation will be rolled back to avoid partial schema state
-            async with conn.transaction():
-                await conn.execute(create_table_sql)
-                await conn.execute(create_message_id_index_sql)
-                await conn.execute(create_timestamp_index_sql)
 
     async def shutdown(self) -> None:
         """Close the connection pool and release resources."""

--- a/src/omnibase_infra/schemas/schema_dlq_replay_history.sql
+++ b/src/omnibase_infra/schemas/schema_dlq_replay_history.sql
@@ -1,0 +1,81 @@
+-- ONEX DLQ Replay History Schema
+-- Ticket: OMN-12633 (retire ServiceDlqTracking runtime DDL)
+-- Node: node_dlq_replay_effect
+-- Version: 1.0.0
+--
+-- Design Notes:
+--   - dlq_replay_history is the audit ledger for every DLQ replay attempt.
+--   - Owned by node_dlq_replay_effect (CONTRACT/NODE/HANDLER pattern — OMN-12525).
+--   - This file replaces the runtime CREATE TABLE IF NOT EXISTS that was
+--     previously executed by ServiceDlqTracking._ensure_table_exists() on
+--     plugin initialisation.  The imperative DDL has been removed from
+--     ServiceDlqTracking; the forward migration runner is the canonical path.
+--   - Schema is idempotent (IF NOT EXISTS) — safe to re-run.
+--
+-- Related Tickets:
+--   - OMN-12633: retire ServiceDlqTracking runtime CREATE TABLE
+--   - OMN-12619: contract-native DLQ replay node + quarantine
+--   - OMN-1032:  PostgreSQL tracking integration
+
+-- =============================================================================
+-- MAIN TABLE
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS dlq_replay_history (
+    -- Identity
+    id UUID PRIMARY KEY,
+
+    -- Source message identity
+    original_message_id UUID NOT NULL,
+    replay_correlation_id UUID NOT NULL,
+
+    -- Routing
+    original_topic VARCHAR(255) NOT NULL,
+    target_topic VARCHAR(255) NOT NULL,
+
+    -- Outcome
+    replay_status VARCHAR(50) NOT NULL,
+    replay_timestamp TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    success BOOLEAN NOT NULL,
+    error_message TEXT,
+
+    -- Source position (for audit / dedup)
+    dlq_offset BIGINT NOT NULL,
+    dlq_partition INTEGER NOT NULL,
+    retry_count INTEGER NOT NULL DEFAULT 0
+);
+
+-- =============================================================================
+-- INDEXES
+-- =============================================================================
+
+-- Message-level dedup and lookup (primary replay query path)
+CREATE INDEX IF NOT EXISTS idx_dlq_replay_history_message_id
+    ON dlq_replay_history (original_message_id);
+
+-- Time-range scans for operator audit queries
+CREATE INDEX IF NOT EXISTS idx_dlq_replay_history_timestamp
+    ON dlq_replay_history (replay_timestamp);
+
+-- =============================================================================
+-- COMMENTS
+-- =============================================================================
+
+COMMENT ON TABLE dlq_replay_history IS
+    'Audit ledger for DLQ replay attempts (OMN-12633). '
+    'One row per replay attempt; owned by node_dlq_replay_effect.';
+
+COMMENT ON COLUMN dlq_replay_history.original_message_id IS
+    'Kafka message key / correlation id from the original DLQ message.';
+
+COMMENT ON COLUMN dlq_replay_history.replay_correlation_id IS
+    'Correlation id of the replay run that processed this message.';
+
+COMMENT ON COLUMN dlq_replay_history.replay_status IS
+    'Terminal replay status (EnumReplayStatus): COMPLETED | FAILED | QUARANTINED | SKIPPED.';
+
+COMMENT ON COLUMN dlq_replay_history.dlq_offset IS
+    'Kafka offset in the DLQ topic at which the original message was consumed.';
+
+COMMENT ON COLUMN dlq_replay_history.retry_count IS
+    'Number of prior replay attempts for this message before this record.';

--- a/tests/integration/dlq/conftest.py
+++ b/tests/integration/dlq/conftest.py
@@ -27,7 +27,7 @@ Related Ticket: OMN-1032 - Complete DLQ Replay PostgreSQL Tracking Integration
 from __future__ import annotations
 
 import logging
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Awaitable, Callable
 from uuid import UUID, uuid4
 
 import pytest
@@ -94,6 +94,98 @@ def _build_postgres_dsn() -> str:
     return _postgres_config.build_dsn()
 
 
+def _build_test_table_ddl(table_name: str) -> tuple[str, str, str]:
+    """Build the DLQ replay-history DDL for a per-test table.
+
+    ServiceDlqTracking no longer creates its table at runtime (OMN-12633) — the
+    canonical ``dlq_replay_history`` table is provisioned by the forward
+    migration runner (``docker/migrations/forward/086_create_dlq_replay_history.sql``).
+    Integration tests use a unique per-test table for isolation, so the fixture
+    must provision that table itself.  The DDL mirrors the canonical schema in
+    ``src/omnibase_infra/schemas/schema_dlq_replay_history.sql``.
+
+    Args:
+        table_name: Validated test table identifier (alphanumeric + underscore).
+
+    Returns:
+        Tuple of (create-table SQL, message-id-index SQL, timestamp-index SQL).
+    """
+    create_table_sql = f"""
+        CREATE TABLE IF NOT EXISTS {table_name} (
+            id UUID PRIMARY KEY,
+            original_message_id UUID NOT NULL,
+            replay_correlation_id UUID NOT NULL,
+            original_topic VARCHAR(255) NOT NULL,
+            target_topic VARCHAR(255) NOT NULL,
+            replay_status VARCHAR(50) NOT NULL,
+            replay_timestamp TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+            success BOOLEAN NOT NULL,
+            error_message TEXT,
+            dlq_offset BIGINT NOT NULL,
+            dlq_partition INTEGER NOT NULL,
+            retry_count INTEGER NOT NULL DEFAULT 0
+        )
+    """
+    create_message_id_index_sql = f"""
+        CREATE INDEX IF NOT EXISTS idx_{table_name}_message_id
+        ON {table_name}(original_message_id)
+    """
+    create_timestamp_index_sql = f"""
+        CREATE INDEX IF NOT EXISTS idx_{table_name}_timestamp
+        ON {table_name}(replay_timestamp)
+    """
+    return create_table_sql, create_message_id_index_sql, create_timestamp_index_sql
+
+
+async def _provision_test_table(dsn: str, table_name: str) -> None:
+    """Provision a per-test DLQ replay-history table over a short-lived connection.
+
+    ServiceDlqTracking no longer creates its table at runtime (OMN-12633), so any
+    test that constructs a service directly must provision the table first.
+
+    Args:
+        dsn: PostgreSQL DSN to connect with.
+        table_name: Validated test table identifier.
+    """
+    import asyncpg
+
+    create_table_sql, message_id_index_sql, timestamp_index_sql = _build_test_table_ddl(
+        table_name
+    )
+    conn = await asyncpg.connect(dsn=dsn)
+    try:
+        async with conn.transaction():
+            await conn.execute(create_table_sql)
+            await conn.execute(message_id_index_sql)
+            await conn.execute(timestamp_index_sql)
+    finally:
+        await conn.close()
+
+
+async def _drop_test_table(dsn: str, table_name: str) -> None:
+    """Drop a per-test DLQ replay-history table, logging on failure.
+
+    Args:
+        dsn: PostgreSQL DSN to connect with.
+        table_name: Validated test table identifier.
+    """
+    import asyncpg
+
+    try:
+        conn = await asyncpg.connect(dsn=dsn)
+        try:
+            await conn.execute(f"DROP TABLE IF EXISTS {table_name}")
+        finally:
+            await conn.close()
+    except Exception as e:  # noqa: BLE001 — boundary: logs warning and degrades
+        logger.warning(
+            "Cleanup failed for DLQ tracking table %s: %s",
+            table_name,
+            e,
+            exc_info=True,
+        )
+
+
 # =============================================================================
 # DLQ Tracking Fixtures
 # =============================================================================
@@ -157,26 +249,19 @@ async def dlq_tracking_service(
         ...     await dlq_tracking_service.record_replay_attempt(record)
         ...     # Table is automatically cleaned up after test
     """
+    # Provision the per-test table before initialising the service.
+    # ServiceDlqTracking no longer creates its table at runtime (OMN-12633);
+    # the canonical table is owned by the forward migration runner.  Tests use
+    # an isolated per-test table, so the fixture provisions it from the same
+    # DDL shape as the canonical schema.
+    await _provision_test_table(
+        dlq_tracking_config.dsn, dlq_tracking_config.storage_table
+    )
+
     service = ServiceDlqTracking(dlq_tracking_config)
     await service.initialize()
 
     yield service
-
-    # Cleanup: drop test table and shutdown
-    # Use try/finally to ensure cleanup even if test fails
-    try:
-        if service._pool is not None:
-            async with service._pool.acquire() as conn:
-                await conn.execute(
-                    f"DROP TABLE IF EXISTS {dlq_tracking_config.storage_table}"
-                )
-    except Exception as e:  # noqa: BLE001 — boundary: logs warning and degrades
-        logger.warning(
-            "Cleanup failed for DLQ tracking table %s: %s",
-            dlq_tracking_config.storage_table,
-            e,
-            exc_info=True,
-        )
 
     # Always attempt shutdown
     try:
@@ -187,6 +272,39 @@ async def dlq_tracking_service(
             e,
             exc_info=True,
         )
+
+    # Cleanup: drop test table after the pool is closed
+    await _drop_test_table(dlq_tracking_config.dsn, dlq_tracking_config.storage_table)
+
+
+@pytest_asyncio.fixture
+async def provision_dlq_table() -> AsyncGenerator[
+    Callable[[ModelDlqTrackingConfig], Awaitable[None]], None
+]:
+    """Provide a callable that provisions a per-test DLQ table for a config.
+
+    For tests that construct ``ServiceDlqTracking`` directly (rather than using
+    the ``dlq_tracking_service`` fixture) but still need the backing table to
+    exist — ServiceDlqTracking no longer creates it at runtime (OMN-12633).
+
+    The fixture tracks every provisioned table and drops it on teardown.
+
+    Example:
+        >>> async def test_x(dlq_tracking_config, provision_dlq_table):
+        ...     await provision_dlq_table(dlq_tracking_config)
+        ...     service = ServiceDlqTracking(dlq_tracking_config)
+        ...     await service.initialize()
+    """
+    provisioned: list[ModelDlqTrackingConfig] = []
+
+    async def _provision(config: ModelDlqTrackingConfig) -> None:
+        await _provision_test_table(config.dsn, config.storage_table)
+        provisioned.append(config)
+
+    yield _provision
+
+    for config in provisioned:
+        await _drop_test_table(config.dsn, config.storage_table)
 
 
 @pytest.fixture

--- a/tests/integration/dlq/test_dlq_tracking_integration.py
+++ b/tests/integration/dlq/test_dlq_tracking_integration.py
@@ -47,6 +47,7 @@ Related Ticket: OMN-1032 - Complete DLQ Replay PostgreSQL Tracking Integration
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, timedelta
 from uuid import UUID, uuid4
 
@@ -83,19 +84,21 @@ class TestServiceDlqTrackingInitialization:
     """Tests for ServiceDlqTracking initialization and lifecycle."""
 
     @pytest.mark.asyncio
-    async def test_initialize_creates_table(
+    async def test_initialize_opens_pool_against_provisioned_table(
         self,
         dlq_tracking_service: ServiceDlqTracking,
         dlq_tracking_config: ModelDlqTrackingConfig,
     ) -> None:
-        """Test that initialize creates the tracking table.
+        """Test that initialize opens a pool against the pre-provisioned table.
 
-        Verifies that:
+        The ``dlq_replay_history`` table is provisioned by the canonical forward
+        migration runner (OMN-12633), not by ``initialize()``.  This test
+        verifies that:
         1. Connection pool is created successfully
-        2. Table is created with correct name
+        2. The pre-provisioned table is reachable with the configured name
         3. Table exists in information_schema
         """
-        # Table should exist after initialization
+        # Pool should be open after initialization; table was provisioned by the fixture
         assert dlq_tracking_service._pool is not None
         assert dlq_tracking_service.is_initialized is True
 
@@ -109,14 +112,15 @@ class TestServiceDlqTrackingInitialization:
             )
 
     @pytest.mark.asyncio
-    async def test_initialize_creates_indexes(
+    async def test_provisioned_table_has_required_indexes(
         self,
         dlq_tracking_service: ServiceDlqTracking,
         dlq_tracking_config: ModelDlqTrackingConfig,
     ) -> None:
-        """Test that initialize creates required indexes.
+        """Test that the provisioned table carries the required indexes.
 
-        Verifies that:
+        The indexes are part of the canonical schema provisioned by the forward
+        migration runner (OMN-12633), not created by ``initialize()``.  Verifies:
         1. Index on original_message_id exists
         2. Index on replay_timestamp exists
         """
@@ -557,12 +561,16 @@ class TestServiceDlqTrackingHealth:
     async def test_health_check_after_shutdown(
         self,
         dlq_tracking_config: ModelDlqTrackingConfig,
+        provision_dlq_table: Callable[[ModelDlqTrackingConfig], Awaitable[None]],
     ) -> None:
         """Test health check returns False after shutdown.
 
         After shutdown, the service should report unhealthy since
         the connection pool is closed.
         """
+        # Provision the table — health_check verifies table existence and the
+        # service no longer creates it at runtime (OMN-12633).
+        await provision_dlq_table(dlq_tracking_config)
         service = ServiceDlqTracking(dlq_tracking_config)
         await service.initialize()
 

--- a/tests/unit/dlq/test_plugin_dlq_overlay_activation.py
+++ b/tests/unit/dlq/test_plugin_dlq_overlay_activation.py
@@ -116,11 +116,11 @@ class TestModelDomainPluginConfigOverlayField:
     def test_overlay_config_defaults_to_none(self) -> None:
         from uuid import uuid4
 
-        from omnibase_infra.event_bus import EventBusInmemory
+        from omnibase_infra.event_bus.event_bus_inmemory import EventBusInmemory
         from omnibase_infra.runtime.models import ModelDomainPluginConfig
 
         mock_container = MagicMock()
-        mock_bus = MagicMock(spec=EventBusInmemory)
+        mock_bus = MagicMock(spec_set=EventBusInmemory)
         config = ModelDomainPluginConfig(
             container=mock_container,
             event_bus=mock_bus,
@@ -134,11 +134,11 @@ class TestModelDomainPluginConfigOverlayField:
     def test_overlay_config_can_be_set(self) -> None:
         from uuid import uuid4
 
-        from omnibase_infra.event_bus import EventBusInmemory
+        from omnibase_infra.event_bus.event_bus_inmemory import EventBusInmemory
         from omnibase_infra.runtime.models import ModelDomainPluginConfig
 
         mock_container = MagicMock()
-        mock_bus = MagicMock(spec=EventBusInmemory)
+        mock_bus = MagicMock(spec_set=EventBusInmemory)
         overlay = {"DLQ_ENABLED": "true", "DLQ_DB_URL": "postgresql://localhost/dlq"}
         config = ModelDomainPluginConfig(
             container=mock_container,

--- a/tests/unit/dlq/test_service_dlq_tracking_no_runtime_ddl.py
+++ b/tests/unit/dlq/test_service_dlq_tracking_no_runtime_ddl.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests confirming ServiceDlqTracking contains no runtime DDL (OMN-12633).
+
+Architecture invariant: the dlq_replay_history table is owned by
+node_dlq_replay_effect and provisioned by the canonical forward migration
+runner.  ServiceDlqTracking must NOT contain CREATE TABLE IF NOT EXISTS or
+any _ensure_table_exists method — those are imperative Service* patterns
+that violate CONTRACT/NODE/HANDLER (OMN-12525).
+
+These tests are purely static (no DB required) and act as a ratchet: they
+fail if the imperative DDL is re-introduced.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+from pathlib import Path
+
+
+def _migration_sql_path() -> Path:
+    here = Path(__file__).parent
+    repo_root = here
+    for _ in range(10):
+        if (repo_root / "docker" / "migrations").exists():
+            break
+        repo_root = repo_root.parent
+    return (
+        repo_root
+        / "docker"
+        / "migrations"
+        / "forward"
+        / "086_create_dlq_replay_history.sql"
+    )
+
+
+def _schema_sql_path() -> Path:
+    here = Path(__file__).parent
+    repo_root = here
+    for _ in range(10):
+        if (repo_root / "src").exists():
+            break
+        repo_root = repo_root.parent
+    return (
+        repo_root
+        / "src"
+        / "omnibase_infra"
+        / "schemas"
+        / "schema_dlq_replay_history.sql"
+    )
+
+
+class TestServiceDlqTrackingNoRuntimeDdl:
+    """ServiceDlqTracking must not own or execute table DDL (OMN-12633)."""
+
+    def test_no_create_table_in_function_bodies(self) -> None:
+        """CREATE TABLE must not appear in string literals inside function bodies.
+
+        Module-level and class-level docstrings may reference the schema for
+        documentation purposes.  Only string literals inside method bodies
+        (FunctionDef nodes) are the imperative DDL surface we guard against.
+        """
+        from omnibase_infra.dlq import service_dlq_tracking
+
+        source_file = Path(inspect.getfile(service_dlq_tracking))
+        tree = ast.parse(source_file.read_text())
+
+        offending: list[tuple[int, str]] = []
+        for func_node in ast.walk(tree):
+            if not isinstance(func_node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            for node in ast.walk(func_node):
+                if isinstance(node, ast.Constant) and isinstance(node.value, str):
+                    if "CREATE TABLE" in node.value.upper():
+                        offending.append(
+                            (node.lineno, textwrap.shorten(node.value, 80))
+                        )
+
+        assert not offending, (
+            "ServiceDlqTracking contains CREATE TABLE inside a method body "
+            f"(OMN-12633): {offending}. "
+            "Imperative DDL must be removed; table provisioning belongs in "
+            "the canonical forward migration runner."
+        )
+
+    def test_no_ensure_table_exists_method(self) -> None:
+        """_ensure_table_exists() must not exist on ServiceDlqTracking (OMN-12633)."""
+        from omnibase_infra.dlq.service_dlq_tracking import ServiceDlqTracking
+
+        assert not hasattr(ServiceDlqTracking, "_ensure_table_exists"), (
+            "ServiceDlqTracking._ensure_table_exists() still exists — "
+            "the runtime table-creation method must be removed (OMN-12633)."
+        )
+
+    def test_initialize_does_not_call_ensure_table(self) -> None:
+        """ServiceDlqTracking.initialize() must not call _ensure_table_exists()."""
+        from omnibase_infra.dlq.service_dlq_tracking import ServiceDlqTracking
+
+        source = inspect.getsource(ServiceDlqTracking.initialize)
+        assert "_ensure_table_exists" not in source, (
+            "ServiceDlqTracking.initialize() still calls _ensure_table_exists() — "
+            "that call must be removed (OMN-12633)."
+        )
+
+    def test_forward_migration_file_exists(self) -> None:
+        """The canonical forward migration for dlq_replay_history must exist."""
+        migration_path = _migration_sql_path()
+        assert migration_path.exists(), (
+            f"Forward migration not found at {migration_path} — "
+            "create docker/migrations/forward/086_create_dlq_replay_history.sql (OMN-12633)."
+        )
+
+    def test_forward_migration_contains_create_table(self) -> None:
+        """The forward migration must define the dlq_replay_history table."""
+        migration_path = _migration_sql_path()
+        if not migration_path.exists():
+            return  # covered by test_forward_migration_file_exists
+        sql = migration_path.read_text()
+        assert "CREATE TABLE IF NOT EXISTS dlq_replay_history" in sql, (
+            f"Migration {migration_path} does not define dlq_replay_history table."
+        )
+
+    def test_schema_sql_file_exists(self) -> None:
+        """The node-owned schema SQL must exist in src/omnibase_infra/schemas/."""
+        schema_path = _schema_sql_path()
+        assert schema_path.exists(), (
+            f"Schema SQL not found at {schema_path} — "
+            "create src/omnibase_infra/schemas/schema_dlq_replay_history.sql (OMN-12633)."
+        )


### PR DESCRIPTION
## Summary

OMN-12633: Retire `ServiceDlqTracking._ensure_table_exists()` — the imperative `CREATE TABLE IF NOT EXISTS` in a `Service*` class that violates CONTRACT/NODE/HANDLER architecture (OMN-12525).

### Changes

- **Remove** `ServiceDlqTracking._ensure_table_exists()` method (imperative DDL)
- **Remove** `await self._ensure_table_exists()` call from `initialize()`
- **Add** `docker/migrations/forward/086_create_dlq_replay_history.sql` — canonical forward migration runner now owns the DDL; table becomes visible in `public.schema_migrations`
- **Add** `src/omnibase_infra/schemas/schema_dlq_replay_history.sql` — node-owned schema documentation owned by `node_dlq_replay_effect`
- **Add** `tests/unit/dlq/test_service_dlq_tracking_no_runtime_ddl.py` — static-analysis ratchet (no DB required) preventing re-introduction of imperative DDL

### Architecture alignment

Table is now provisioned by the canonical migration runner (not at plugin init time), making it visible to `public.schema_migrations` and owned by `node_dlq_replay_effect` per CONTRACT/NODE/HANDLER (OMN-12525).

### Depends on

Based on `jonah/omn-12634-dlq-contract-overlay` (PR #2010) — rebases cleanly onto dev once #2010 merges. The 12634 branch only touches `plugin_dlq.py`; 12633 only touches `service_dlq_tracking.py` and adds migration/schema/test files. No conflicts.

Evidence-Source: OCC#2693
Evidence-Ticket: OMN-12633