### PR TITLE
docs(OMN-13198): correct fabricated ProtocolHandler row + remove ModelOnexEnvelope from docs/docstrings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -397,7 +397,7 @@ nodes/<node_name>/
 
 | Protocol | Purpose | Input/Output |
 |----------|---------|--------------|
-| `ProtocolHandler` | Envelope-based (runtime) | `ModelOnexEnvelope` → `ModelOnexEnvelope` |
+| `ProtocolHandler` | Request/response I/O (HTTP, DB, Kafka) | `ModelProtocolRequest` → `ModelProtocolResponse` |
 | `ProtocolMessageHandler` | Category-based (dispatch) | `ModelEventEnvelope` → `ModelHandlerOutput` |
 
 ### Handler Routing Strategies

--- a/docs/conventions/TERMINOLOGY_GUIDE.md
+++ b/docs/conventions/TERMINOLOGY_GUIDE.md
@@ -32,7 +32,7 @@ For capitalization rules in prose vs. code contexts, see the quick-reference tab
 | Value wrapper | `ModelContainer[T]` | "value wrapper" | — | "DI container" (wrong type) |
 | Side-effect request | `ModelIntent` | "intent" | `ModelPayload*` (payload) | "action", "command", "thunk" |
 | State snapshot | `ModelProjection` / projection | "projection" | `Model*Projection` | "snapshot" (use only for point-in-time reads) |
-| Message envelope | `ModelOnexEnvelope` | "envelope" | — | "message", "event" alone |
+| Message envelope | `ModelEventEnvelope[T]` | "envelope" | — | "message", "event" alone |
 | Event payload | varies | "event" or "payload" | `Model*Event` | "message" (too generic) |
 | FSM transition fn | `delta(state, event) -> (state, intents[])` | "delta function" | — | "reducer function" alone |
 
@@ -121,7 +121,7 @@ For capitalization rules in prose vs. code contexts, see the quick-reference tab
 **Architectural meaning**: A handler is a unit of business logic invoked by a node to process a single event or request. Handlers encapsulate the "what" — they compute results, call services, and return output. They do not emit events directly.
 
 **Two protocols**:
-- `ProtocolHandler` — envelope-based; used by the runtime layer. Input and output are both `ModelOnexEnvelope`.
+- `ProtocolHandler` — request/response I/O; used for HTTP, DB, and Kafka handlers. Input is `ModelProtocolRequest`, output is `ModelProtocolResponse`.
 - `ProtocolMessageHandler` — category-based; used by the dispatch engine. Input is `ModelEventEnvelope`, output is `ModelHandlerOutput`.
 
 **Handler No-Publish Rule**: Handlers must not hold a reference to the event bus or call any publish method. Only orchestrators publish events. This constraint is enforced by the architecture validator.
@@ -170,8 +170,7 @@ Projections are distinct from the FSM state held in the reducer: the FSM state d
 
 **Architectural meaning**: An envelope is the transport wrapper for all events on the ONEX event bus. It carries metadata (correlation ID, causation ID, timestamps, node identity) alongside the event payload.
 
-- `ModelOnexEnvelope` — the primary runtime envelope used by `ProtocolHandler`.
-- `ModelEventEnvelope` — used by the dispatch engine and `ProtocolMessageHandler`.
+- `ModelEventEnvelope[T]` — the canonical runtime envelope used by the dispatch engine and `ProtocolMessageHandler`.
 
 Envelopes are always frozen (`frozen=True`). They cross node boundaries and must be immutable.
 

--- a/src/omnibase_infra/event_bus/mixin_kafka_broadcast.py
+++ b/src/omnibase_infra/event_bus/mixin_kafka_broadcast.py
@@ -158,7 +158,7 @@ class MixinKafkaBroadcast:
         Serializes the envelope to JSON bytes and publishes.
 
         Args:
-            envelope: Envelope object to publish (ModelOnexEnvelope)
+            envelope: Envelope object to publish (ModelEventEnvelope)
             topic: Target topic name
             key: Optional partition key for per-entity ordering. When provided,
                 the underlying transport uses this key for partition assignment


### PR DESCRIPTION
## OMN-13198 — B5 doc/docstring cleanup (omnibase_infra)

Phase B5 of the envelope-dedup / platform-debt workstream. Removes every
`ModelOnexEnvelope` reference from omnibase_infra docs + docstrings and corrects
a fabricated handler-protocol doc row. The legacy `ModelOnexEnvelope` class is
deleted by B4 (OMN-13196 / omnibase_core PR #1250); this PR is docstring/markdown
only and changes no runtime path.

### Fabricated row corrected (primary fix, OMN-13198)
`CLAUDE.md` → Handler Protocols table claimed:

| `ProtocolHandler` | Envelope-based (runtime) | `ModelOnexEnvelope` → `ModelOnexEnvelope` |

Verified against `omnibase_spi/src/omnibase_spi/protocols/handlers/protocol_handler.py`:
`ProtocolHandler.execute(request: ModelProtocolRequest, operation_config: ModelOperationConfig) -> ModelProtocolResponse`.
It is request/response I/O (HTTP/DB/Kafka), NOT envelope-based. Row corrected to
`ModelProtocolRequest → ModelProtocolResponse`. Matching prose in
`docs/conventions/TERMINOLOGY_GUIDE.md` (Handler + Envelope sections) corrected too.

### ModelOnexEnvelope → ModelEventEnvelope (doc/docstring)
- `docs/conventions/TERMINOLOGY_GUIDE.md` — envelope term row + Handler/Envelope sections
- `src/omnibase_infra/event_bus/mixin_kafka_broadcast.py` — `publish_envelope` Args docstring
- `src/omnibase_infra/nodes/node_llm_inference_effect/handlers/handler_llm_openai_compatible.py`
  — Protocol Conformance Note (also fixes the false "ProtocolHandler operates on ModelOnexEnvelope" claim)

### Acceptance
`grep -rn ModelOnexEnvelope` over `*.md`/`*.py` (excluding `.venv`) on this branch → 0.

### Gates (dod_evidence)
- ruff format --check + ruff check on changed src: clean
- mypy --strict on changed src modules: Success
- `pytest tests/ -k handler_llm_openai_compatible`: 174 passed, 2 skipped
- pre-commit (commit hooks): pass

dod_evidence: OCC receipt `drift/dod_receipts/OMN-13198/pr-omnibase_infra/command.yaml`
(status PASS, verifier=receipt-gate-local != runner) in onex_change_control; contract `contracts/OMN-13198.yaml`.

Closes the omnibase_infra portion of OMN-13198 (with OMN-13204).



Evidence-Source: OCC#2697
Evidence-Ticket: OMN-13198
