### PR TITLE
fix(OMN-13203): quarantine per-handler resolution failures instead of crashing runtime-effects boot

### DIFF
--- a/contracts/OMN-13203.yaml
+++ b/contracts/OMN-13203.yaml
@@ -16,8 +16,8 @@ evidence_requirements:
     command: "uv run pytest tests/unit/runtime/auto_wiring/test_handler_wiring_unresolvable_quarantine.py tests/unit/runtime/auto_wiring/test_wiring.py tests/unit/runtime/test_handler_wiring_resolver_integration.py tests/integration/runtime/test_auto_wiring_resolver_end_to_end.py -q"
   - kind: ci
     description: >-
-      ruff format/check clean, mypy --strict clean on the three changed production modules, pre-commit passes on all changed files (no bypass).
-    command: "uv run mypy src/omnibase_infra/runtime/auto_wiring/handler_wiring.py src/omnibase_infra/runtime/auto_wiring/report.py src/omnibase_infra/runtime/auto_wiring/enum_quarantine_reason.py --strict"
+      ruff format/check clean, repo-wide mypy --strict gate (the Type Safety Validation CI job) passes on src/omnibase_infra/ including the changed production modules (handler_wiring.py, report.py, enum_quarantine_reason.py), pre-commit passes on all changed files (no bypass).
+    command: "uv run mypy src/omnibase_infra/ --strict"
 emergency_bypass:
   enabled: false
   justification: ""

--- a/contracts/OMN-13203.yaml
+++ b/contracts/OMN-13203.yaml
@@ -1,0 +1,39 @@
+# OMN-13203 contract file for omnibase_infra deploy-gate.
+# The canonical ticket contract and PASS receipts live in onex_change_control.
+# This file is the per-repo deploy-evidence carrier only.
+schema_version: "1.0.0"
+ticket_id: "OMN-13203"
+title: "fix(OMN-13203): quarantine per-handler resolution failures instead of crashing runtime-effects boot"
+summary: >-
+  P0 crash-loop repair for the DEV effects worker. OMN-12982 (commit ee79972c) flipped non-canonical nodes' runtime_profiles onto [effects], which exposed handlers the resolver cannot construct. A single handler_routing entry whose constructor the ServiceHandlerResolver cannot satisfy (e.g. omnimarket node_pr_review_bot HandlerJudgeVerifier requiring ctor params ['judge_base_url', 'judge_model_id']) raised a bare resolver TypeError (Step 2 ctor-arg-mismatch / Step 6 unsatisfiable-ctor) or a per-handler ValueError. In _prepare_handler_wiring the non-Protocol TypeError re-raised, propagated through the OMN-8735 except-TypeError guards in _prepare_contract_wiring and wire_from_manifest, then out through the kernel's except-Exception, exiting the process BEFORE the :8086 health server bound. Docker crash-looped runtime-effects (verified live on .201 DEV: RestartCount=446, signature "TypeError: Handler ...HandlerJudgeVerifier requires constructor parameters ['judge_base_url', 'judge_model_id']"). One bad handler took down every healthy handler in the manifest. This change quarantines the two per-handler resolution-failure classes (non-Protocol resolver TypeError; per-handler ValueError) to EnumQuarantineReason.UNRESOLVABLE_HANDLER so wire_from_manifest COMPLETES, the kernel reaches freeze() + the :8086 bind, and the bad handler is REPORTED (loud WARNING + counted in total_failed) rather than crashing boot or silently dropped. ONEX_WIRING_STRICT_MODE=1 re-raises every resolution failure, preserving the pre-fix fail-closed gate. Infra outages (broker/DB/secret/manifest) surface as ModelOnexError / InfraConnectionError / ConnectionError / OSError, never a bare resolver TypeError/ValueError, so they are NOT caught by the new arms and STILL crash boot.
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: tests
+    description: >-
+      New tests/unit/runtime/auto_wiring/test_handler_wiring_unresolvable_quarantine.py plus updated negative tests in test_wiring.py, test_handler_wiring_resolver_integration.py, and test_auto_wiring_resolver_end_to_end.py prove: unsatisfiable/ctor-mismatch handler is quarantined+failed (not crash), per-handler ValueError contained identically, mixed good+bad wires the good handler, fatal InfraConnectionError still crashes boot, strict mode re-raises every resolution failure. Changed-area suite: 71 passed.
+    command: "uv run pytest tests/unit/runtime/auto_wiring/test_handler_wiring_unresolvable_quarantine.py tests/unit/runtime/auto_wiring/test_wiring.py tests/unit/runtime/test_handler_wiring_resolver_integration.py tests/integration/runtime/test_auto_wiring_resolver_end_to_end.py -q"
+  - kind: ci
+    description: >-
+      ruff format/check clean, mypy --strict clean on the three changed production modules, pre-commit passes on all changed files (no bypass).
+    command: "uv run mypy src/omnibase_infra/runtime/auto_wiring/handler_wiring.py src/omnibase_infra/runtime/auto_wiring/report.py src/omnibase_infra/runtime/auto_wiring/enum_quarantine_reason.py --strict"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: dod-unresolvable-handler-quarantined-not-crash
+    description: >-
+      An unsatisfiable-constructor handler is quarantined as UNRESOLVABLE_HANDLER and counted in total_failed while wire_from_manifest COMPLETES (the boot-crash invariant is removed in default mode), proven by test_unsatisfiable_handler_quarantined_completes_and_counts_failed.
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "uv run pytest tests/unit/runtime/auto_wiring/test_handler_wiring_unresolvable_quarantine.py::test_unsatisfiable_handler_quarantined_completes_and_counts_failed -q"
+  - id: dod-fatal-infra-still-crashes-and-strict-reraises
+    description: >-
+      Infra outages still crash boot (InfraConnectionError is NOT quarantined) and strict mode re-raises every resolution failure, preserving the fail-closed gate.
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "uv run pytest tests/unit/runtime/auto_wiring/test_handler_wiring_unresolvable_quarantine.py::test_fatal_infra_error_still_crashes_boot tests/unit/runtime/auto_wiring/test_handler_wiring_unresolvable_quarantine.py::test_strict_mode_reraises_unresolvable_handler -q"

--- a/docker/migrations/forward/nodes/node_projection_delegation/0014_generation_semantic_pass.sql
+++ b/docker/migrations/forward/nodes/node_projection_delegation/0014_generation_semantic_pass.sql
@@ -1,0 +1,35 @@
+-- OMN-13166: persist the behavioral (semantic) verdict on generation_events,
+-- separate from the contract/shape verdict (contract_passed).
+--
+-- The 2026-06-16 gate-zero stability SEA cell generated a snake_case ->
+-- PascalCase handler that split on whitespace instead of underscores
+-- ("hello_world" -> "Hello_world"), yet the run was projected as
+-- contract_passed=true. contract_passed only proves the artifact is SHAPED like
+-- an ONEX node (valid YAML fields, parseable handler, no hardcoded paths/topics).
+-- It says nothing about whether the handler performs the requested
+-- transformation.
+--
+-- These columns record the behavioral verdict produced by the generation
+-- consumer's semantic-validation layer, which executes the generated handle()
+-- against synthesized input/expected fixtures derived from the task:
+--   - semantic_checked: TRUE when a behavioral fixture was derivable for the
+--                       task (i.e. the check was applicable). FALSE means the
+--                       check was inconclusive (no known invariant) — which is
+--                       NOT a behavioral pass.
+--   - semantic_passed:  TRUE only when semantic_checked is TRUE AND the handler
+--                       produced the correct output for every fixture.
+--
+-- A row with contract_passed=TRUE and semantic_passed=FALSE is the gate-zero
+-- false-green made visible: shape-valid but behaviorally wrong.
+--
+-- Default FALSE backfills existing rows as "behavior not verified", which is the
+-- honest historical state — they predate the semantic layer.
+--
+-- Applied only (never reversed); deploy to live lanes is user-gated.
+
+ALTER TABLE generation_events
+    ADD COLUMN IF NOT EXISTS semantic_checked BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS semantic_passed BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE INDEX IF NOT EXISTS idx_generation_events_semantic_passed
+    ON generation_events (semantic_passed);

--- a/src/omnibase_infra/runtime/auto_wiring/enum_quarantine_reason.py
+++ b/src/omnibase_infra/runtime/auto_wiring/enum_quarantine_reason.py
@@ -29,10 +29,26 @@ class EnumQuarantineReason(str, Enum):
       ``typing.Protocol`` interface rather than a concrete handler class.
       Follow-up: change the contract to reference the concrete handler and keep
       Protocols in dependency/interface declarations.
+    - ``UNRESOLVABLE_HANDLER``: per-handler resolution/construction failed with
+      a deterministic, never-recoverable wiring bug — the resolver could not
+      satisfy the handler's constructor (unsatisfiable-ctor / ctor-arg-mismatch
+      ``TypeError`` from ``ServiceHandlerResolver`` Steps 2/6) or the handler
+      entry was malformed (``ValueError`` — not-handle-shaped / blank-required).
+      Before OMN-13203 this re-raised and crashed runtime-effects boot, taking
+      down every healthy handler in the manifest. It is now contained so the
+      runtime binds its health server and reports the one bad handler. This is
+      a per-handler wiring bug, NEVER recoverable runtime state and NEVER an
+      infra outage (broker/DB/secret failures surface as ModelOnexError /
+      InfraConnectionError / ConnectionError / OSError, not a bare resolver
+      ``TypeError``/``ValueError``, and still crash boot). Counts toward
+      ``total_failed`` so it is reported as a failure, not silently dropped.
+      Follow-up: fix the contract/handler constructor so the resolver can wire
+      it. ``ONEX_WIRING_STRICT_MODE=1`` re-raises instead of quarantining.
     """
 
     ASYNC_INCOMPATIBLE = "async_incompatible"
     PROTOCOL_HANDLER_DECLARATION = "protocol_handler_declaration"
+    UNRESOLVABLE_HANDLER = "unresolvable_handler"
 
 
 __all__ = ["EnumQuarantineReason"]

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -1909,6 +1909,17 @@ def _strict_dispatcher_coverage_enabled() -> bool:
     )
 
 
+def _wiring_strict_mode_enabled() -> bool:
+    """Return True when ONEX_WIRING_STRICT_MODE is active (OMN-9126).
+
+    In strict mode no failure is demoted: per-handler resolution failures
+    re-raise (preserving the pre-OMN-13203 boot-crash invariant) instead of
+    being quarantined. Mirrors the env check at ``wire_from_manifest`` so a
+    single source defines strict semantics.
+    """
+    return os.environ.get("ONEX_WIRING_STRICT_MODE", "").lower() in ("1", "true")
+
+
 def _is_orchestrator_contract(contract: ModelDiscoveredContract) -> bool:
     """Return True when a discovered contract is an orchestrator variant."""
     return "orchestrator" in contract.node_type.lower()
@@ -2962,7 +2973,40 @@ def _prepare_handler_wiring(
                     reason=EnumQuarantineReason.PROTOCOL_HANDLER_DECLARATION,
                     detail=_sanitize_exc(exc),
                 )
-            raise
+            # OMN-13203: a bare resolver TypeError that is NOT a Protocol target
+            # is exactly the unsatisfiable-ctor (ServiceHandlerResolver Step 6)
+            # or ctor-arg-mismatch (Step 2) per-handler wiring bug. These are
+            # the ONLY `raise TypeError` sites in the resolver (Steps 1a/2/6),
+            # are deterministic, never recoverable runtime state, and never an
+            # infra outage — broker/DB/secret failures surface as ModelOnexError
+            # / InfraConnectionError / ConnectionError / OSError, never a bare
+            # resolver TypeError. Before this change the bare re-raise here
+            # propagated through the OMN-8735 TypeError guards and crashed the
+            # whole runtime-effects boot (every healthy handler with it). Quarantine
+            # the single bad handler and continue so the runtime binds its health
+            # server and reports failed=N. Strict mode re-raises (preserves the
+            # boot-crash invariant) so the gate can still fail closed.
+            if _wiring_strict_mode_enabled():
+                raise
+            return _quarantine_prepared(
+                reason=EnumQuarantineReason.UNRESOLVABLE_HANDLER,
+                detail=_sanitize_exc(exc),
+            )
+        except ValueError as exc:
+            # OMN-13203: a per-handler ValueError from resolver/context construction
+            # (not-handle-shaped handler, blank-required field) is the same class
+            # of deterministic per-handler wiring bug as the unsatisfiable-ctor
+            # TypeError above — contain it identically. ValueError is NOT raised by
+            # broker/DB/secret transports (those raise ModelOnexError /
+            # InfraConnectionError / ConnectionError / OSError, caught by the
+            # `except Exception` arms upstream which still propagate), so this does
+            # not over-broaden the catch into infra outages. Strict mode re-raises.
+            if _wiring_strict_mode_enabled():
+                raise
+            return _quarantine_prepared(
+                reason=EnumQuarantineReason.UNRESOLVABLE_HANDLER,
+                detail=_sanitize_exc(exc),
+            )
         except RuntimeError as exc:
             # OMN-9457: deterministic containment for handlers whose
             # construction path calls asyncio.run() inside runtime-managed

--- a/src/omnibase_infra/runtime/auto_wiring/report.py
+++ b/src/omnibase_infra/runtime/auto_wiring/report.py
@@ -34,6 +34,16 @@ class EnumWiringOutcome(str, Enum):
     FAILED = "failed"
 
 
+# OMN-13203: quarantine reasons that represent a genuine per-handler WIRING
+# FAILURE (a deterministic, never-recoverable contract/handler bug) rather than
+# a deferred migration. These count toward ``total_failed`` so they are reported
+# as failures, never silently dropped. PROTOCOL_HANDLER_DECLARATION and
+# ASYNC_INCOMPATIBLE remain migration-quarantine-only (``total_quarantined``).
+_RESOLUTION_FAILURE_REASONS: frozenset[EnumQuarantineReason] = frozenset(
+    {EnumQuarantineReason.UNRESOLVABLE_HANDLER}
+)
+
+
 class ModelWiringOutcome(BaseModel):
     """Per-handler resolver outcome row within a contract-level wiring result.
 
@@ -209,11 +219,35 @@ class ModelAutoWiringReport(BaseModel):
 
     @property
     def total_failed(self) -> int:
-        return sum(1 for r in self.results if r.outcome == EnumWiringOutcome.FAILED)
+        """Count of wiring failures.
+
+        Includes both contract-level FAILED rows and per-handler
+        resolution-failure quarantines (OMN-13203 — unsatisfiable-ctor /
+        ctor-arg-mismatch / not-handle-shaped handlers). The latter previously
+        crashed runtime boot; they are now contained but MUST still surface as
+        failures so the gate and ``ONEX_WIRING_STRICT_MODE`` assertion react to
+        them. Migration-quarantines (Protocol/async) are NOT counted here —
+        they are reported via ``total_quarantined``.
+        """
+        failed_rows = sum(
+            1 for r in self.results if r.outcome == EnumWiringOutcome.FAILED
+        )
+        resolution_failures = sum(
+            1
+            for q in self.quarantined_handlers
+            if q.reason in _RESOLUTION_FAILURE_REASONS
+        )
+        return failed_rows + resolution_failures
 
     @property
     def total_quarantined(self) -> int:
-        """Count of handlers quarantined during wiring (OMN-9457)."""
+        """Count of handlers quarantined during wiring (OMN-9457).
+
+        Counts every quarantined handler, including OMN-13203
+        resolution-failure quarantines, so the ``quarantined=N`` summary field
+        stays a faithful count of contained handlers. The resolution-failure
+        subset is *additionally* surfaced in ``total_failed``.
+        """
         return len(self.quarantined_handlers)
 
     def __bool__(self) -> bool:

--- a/tests/integration/runtime/test_auto_wiring_resolver_end_to_end.py
+++ b/tests/integration/runtime/test_auto_wiring_resolver_end_to_end.py
@@ -527,15 +527,22 @@ class TestFullAutoWiringExercisesResolver:
         assert report_a.total_failed == report_b.total_failed
 
     @pytest.mark.asyncio
-    async def test_unresolvable_handler_raises_typeerror_no_report(self) -> None:
-        """Plan Task 8 negative case: OMN-8735 fail-fast preserved.
+    async def test_unresolvable_handler_quarantined_default_raised_strict(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """OMN-13203: unresolvable handler is quarantined (default) / raised (strict).
 
-        A single unresolvable handler in the manifest propagates ``TypeError``
-        unchanged from the resolver's Step 6; no ``ModelAutoWiringReport``
-        is produced. Proves the cutover in Task 5 did not weaken the
-        fail-fast invariant that protects the runtime from booting with
-        partially-wired handlers.
+        Default mode: the resolver's Step-6 unsatisfiable-ctor ``TypeError`` is
+        contained so ``wire_from_manifest`` COMPLETES and the runtime can bind
+        its health server; the bad handler is reported failed + quarantined as
+        ``UNRESOLVABLE_HANDLER`` and named in the detail. Strict mode preserves
+        the OMN-8735 fail-fast invariant — the TypeError propagates unchanged so
+        the boot log identifies exactly which wiring gap would crash startup.
         """
+        from omnibase_infra.runtime.auto_wiring.enum_quarantine_reason import (
+            EnumQuarantineReason,
+        )
+
         unresolvable_contract = _make_single_handler_contract(
             name="node_unresolvable",
             handler_cls=HandlerUnresolvable,
@@ -545,8 +552,28 @@ class TestFullAutoWiringExercisesResolver:
             contracts=(unresolvable_contract,),
             errors=(),
         )
-        engine = MessageDispatchEngine()
 
+        # Default (non-strict) mode: quarantine + complete.
+        monkeypatch.delenv("ONEX_WIRING_STRICT_MODE", raising=False)
+        with patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+            side_effect=_import_handler_stub,
+        ):
+            report = await wire_from_manifest(
+                manifest=manifest,
+                dispatch_engine=MessageDispatchEngine(),
+                event_bus=None,
+                environment="test",
+                container=None,
+            )
+        assert report.total_failed >= 1
+        assert report.total_quarantined == 1
+        q = report.quarantined_handlers[0]
+        assert q.reason is EnumQuarantineReason.UNRESOLVABLE_HANDLER
+        assert "some_undeclared_service" in q.detail
+
+        # Strict mode: the TypeError still propagates unchanged.
+        monkeypatch.setenv("ONEX_WIRING_STRICT_MODE", "1")
         with patch(
             "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
             side_effect=_import_handler_stub,
@@ -554,12 +581,11 @@ class TestFullAutoWiringExercisesResolver:
             with pytest.raises(TypeError) as exc_info:
                 await wire_from_manifest(
                     manifest=manifest,
-                    dispatch_engine=engine,
+                    dispatch_engine=MessageDispatchEngine(),
                     event_bus=None,
                     environment="test",
                     container=None,
                 )
-
         assert "some_undeclared_service" in str(exc_info.value), (
             "TypeError must name the missing constructor parameter so the "
             "runtime boot log identifies exactly which wiring gap crashed startup."

--- a/tests/unit/runtime/auto_wiring/test_handler_wiring_unresolvable_quarantine.py
+++ b/tests/unit/runtime/auto_wiring/test_handler_wiring_unresolvable_quarantine.py
@@ -1,0 +1,441 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for per-handler resolution-failure quarantine in wire_from_manifest (OMN-13203).
+
+Before OMN-13203 the per-handler resolution-failure path crashed runtime boot:
+``ServiceHandlerResolver`` raises a bare ``TypeError`` when a handler's
+constructor cannot be satisfied (Step 6 unsatisfiable-ctor / Step 2
+ctor-arg-mismatch). The bare ``raise`` at the resolver call site propagated
+through the OMN-8735 ``except TypeError: raise`` guards, exited the kernel via
+its ``except Exception: raise``, and the process died BEFORE binding the
+``:8086`` health server — Docker then crash-looped the runtime-effects
+container. A single bad handler took down every healthy handler in the manifest.
+
+This containment quarantines exactly those deterministic, never-recoverable
+per-handler wiring bugs:
+
+- unsatisfiable-ctor / ctor-arg-mismatch ``TypeError`` (resolver Steps 2/6),
+- not-handle-shaped / blank-required ``ValueError`` for a single handler entry,
+
+so ``wire_from_manifest`` COMPLETES, the runtime binds its health server, and
+the bad handler is REPORTED (``failed >= 1`` + WARNING log) — never silently
+skipped. Truly-fatal infra errors (broker/DB unreachable, manifest unreadable)
+surface as ``ModelOnexError`` / ``InfraConnectionError`` / ``ConnectionError`` /
+``OSError`` — NOT a bare resolver ``TypeError``/``ValueError`` — and STILL crash
+boot. ``ONEX_WIRING_STRICT_MODE=1`` re-raises, preserving the pre-OMN-13203
+boot-crash invariant.
+
+Tests:
+  1. An unsatisfiable-ctor handler is quarantined, wire_from_manifest COMPLETES,
+     ``total_failed >= 1``, reason recorded as UNRESOLVABLE_HANDLER + logged.
+  2. A not-handle-shaped ValueError is quarantined identically.
+  3. Mixed: a good handler wires, the unresolvable one is failed/quarantined.
+  4. A truly-fatal infra error (broker/DB unreachable surfaced as a real
+     InfraConnectionError, NOT a bare resolver TypeError) STILL propagates —
+     the guard did not swallow it.
+  5. ONEX_WIRING_STRICT_MODE=1 re-raises the resolver TypeError (boot fails).
+  6. total_failed counts the resolution-quarantine; total_quarantined still
+     counts it as a contained handler.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from omnibase_infra.enums import EnumInfraTransportType
+from omnibase_infra.errors import InfraConnectionError, ModelInfraErrorContext
+from omnibase_infra.protocols import ProtocolEventBusLike
+from omnibase_infra.runtime.auto_wiring.enum_quarantine_reason import (
+    EnumQuarantineReason,
+)
+from omnibase_infra.runtime.auto_wiring.handler_wiring import wire_from_manifest
+from omnibase_infra.runtime.auto_wiring.models import (
+    ModelAutoWiringManifest,
+    ModelContractVersion,
+    ModelDiscoveredContract,
+    ModelEventBusWiring,
+    ModelHandlerRef,
+    ModelHandlerRouting,
+    ModelHandlerRoutingEntry,
+)
+from omnibase_infra.runtime.auto_wiring.report import EnumWiringOutcome
+
+
+def _make_contract(
+    *,
+    node_name: str,
+    handler_entries: tuple[tuple[str, str], ...],
+    topic: str = "onex.evt.test.event.v1",
+) -> ModelDiscoveredContract:
+    entries = tuple(
+        ModelHandlerRoutingEntry(
+            handler=ModelHandlerRef(name=name, module=module),
+            event_model=ModelHandlerRef(
+                name=f"ModelTestEvent{idx}", module="fake.models"
+            ),
+            operation=None,
+        )
+        for idx, (module, name) in enumerate(handler_entries)
+    )
+    return ModelDiscoveredContract(
+        name=node_name,
+        node_type="ORCHESTRATOR_GENERIC",
+        package_name="test_pkg",
+        entry_point_name=node_name,
+        contract_version=ModelContractVersion(major=1, minor=0, patch=0),
+        contract_path=Path("/fake/contract.yaml"),
+        handler_routing=ModelHandlerRouting(
+            routing_strategy="payload_type_match",
+            handlers=entries,
+        ),
+        event_bus=ModelEventBusWiring(
+            subscribe_topics=(topic,),
+            publish_topics=(),
+        ),
+    )
+
+
+def _make_dispatch_engine() -> MagicMock:
+    engine = MagicMock()
+    engine._routes = {}
+    engine._container = None
+    engine.register_dispatcher = MagicMock()
+    engine.register_route = MagicMock()
+    engine.freeze = MagicMock()
+    return engine
+
+
+def _make_event_bus() -> MagicMock:
+    bus = MagicMock(spec=ProtocolEventBusLike)
+    bus.subscribe = AsyncMock()
+    return bus
+
+
+# ---------------------------------------------------------------------------
+# Handler classes that exercise the resolver failure surface
+# ---------------------------------------------------------------------------
+
+
+class _HandlerNormalZeroArg:
+    """Normal async-safe handler — wires via zero-arg resolver step."""
+
+    async def handle(self, envelope: object) -> None:
+        return None
+
+
+class _HandlerUnsatisfiableCtor:
+    """Handler the resolver cannot construct — required ctor params no precedence
+    path (node registry / container / known-injectable) can satisfy.
+
+    The resolver's Step 6 raises a bare ``TypeError`` for this case (the exact
+    path that crashed boot before OMN-13203).
+    """
+
+    def __init__(self, some_unresolvable_dependency: object) -> None:
+        self._dep = some_unresolvable_dependency
+
+    async def handle(self, envelope: object) -> None:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# 1. Unsatisfiable-ctor TypeError is quarantined; wire COMPLETES; failed >= 1.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_unsatisfiable_handler_quarantined_completes_and_counts_failed(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The OMN-13203 regression: an unsatisfiable handler no longer crashes boot.
+
+    wire_from_manifest COMPLETES (no exception), the handler is contained, and
+    it is REPORTED — failed >= 1 and the reason is logged loudly with the
+    contract + handler + reason.
+    """
+    contract = _make_contract(
+        node_name="node_unsatisfiable",
+        handler_entries=(("fake.module", "_HandlerUnsatisfiableCtor"),),
+    )
+    manifest = ModelAutoWiringManifest(contracts=(contract,), errors=())
+
+    with (
+        caplog.at_level(logging.WARNING),
+        patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+            return_value=_HandlerUnsatisfiableCtor,
+        ),
+    ):
+        # No exception: wire_from_manifest COMPLETES so the kernel proceeds to
+        # freeze() and the :8086 health-server bind.
+        report = await wire_from_manifest(
+            manifest=manifest,
+            dispatch_engine=_make_dispatch_engine(),
+            event_bus=_make_event_bus(),
+            container=None,
+        )
+
+    # REPORTED, not silently skipped: failed >= 1.
+    assert report.total_failed >= 1
+    assert report.total_failed == 1
+    # Still counted as a contained handler.
+    assert report.total_quarantined == 1
+    assert len(report.quarantined_handlers) == 1
+
+    q = report.quarantined_handlers[0]
+    assert q.handler_name == "_HandlerUnsatisfiableCtor"
+    assert q.handler_module == "fake.module"
+    assert q.contract_name == "node_unsatisfiable"
+    assert q.package_name == "test_pkg"
+    assert q.reason is EnumQuarantineReason.UNRESOLVABLE_HANDLER
+    assert q.detail  # sanitized resolver TypeError text recorded
+
+    # The contract is SKIPPED (its only handler was contained) but the handler
+    # is still surfaced as failed at the report level.
+    result = report.results[0]
+    assert result.outcome is EnumWiringOutcome.SKIPPED
+    assert len(result.quarantined_handlers) == 1
+
+    # Logged loudly: contract + handler + reason all appear in the WARNING log.
+    logged = "\n".join(rec.getMessage() for rec in caplog.records)
+    assert "_HandlerUnsatisfiableCtor" in logged
+    assert "node_unsatisfiable" in logged
+    assert EnumQuarantineReason.UNRESOLVABLE_HANDLER.value in logged
+
+
+# ---------------------------------------------------------------------------
+# 2. A per-handler ValueError (not-handle-shaped / blank-required) is contained.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_value_error_handler_quarantined_completes_and_counts_failed() -> None:
+    """A per-handler ValueError from resolution is contained like the TypeError."""
+    contract = _make_contract(
+        node_name="node_value_error",
+        handler_entries=(("fake.module", "_HandlerNotShaped"),),
+    )
+    manifest = ModelAutoWiringManifest(contracts=(contract,), errors=())
+
+    class _Resolver:
+        def resolve(self, ctx: object) -> object:
+            # Simulate a not-handle-shaped / blank-required per-handler bug.
+            raise ValueError("handler entry is not handle-shaped: missing handle()")
+
+    with (
+        patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+            return_value=_HandlerNormalZeroArg,
+        ),
+        patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring.ServiceHandlerResolver",
+            return_value=_Resolver(),
+        ),
+    ):
+        report = await wire_from_manifest(
+            manifest=manifest,
+            dispatch_engine=_make_dispatch_engine(),
+            event_bus=_make_event_bus(),
+            container=None,
+        )
+
+    assert report.total_failed == 1
+    assert report.total_quarantined == 1
+    q = report.quarantined_handlers[0]
+    assert q.reason is EnumQuarantineReason.UNRESOLVABLE_HANDLER
+    assert "handle-shaped" in q.detail
+
+
+# ---------------------------------------------------------------------------
+# 3. Mixed: good handler wires, unresolvable handler is failed/quarantined.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_mixed_good_and_unresolvable_handler() -> None:
+    """One good handler wires; the unresolvable one is contained + counted failed."""
+    contract = _make_contract(
+        node_name="node_mixed_unresolvable",
+        handler_entries=(
+            ("fake.module", "_HandlerNormalZeroArg"),
+            ("fake.module", "_HandlerUnsatisfiableCtor"),
+        ),
+    )
+    manifest = ModelAutoWiringManifest(contracts=(contract,), errors=())
+
+    def _import_side_effect(module: str, name: str) -> type:
+        if name == "_HandlerNormalZeroArg":
+            return _HandlerNormalZeroArg
+        if name == "_HandlerUnsatisfiableCtor":
+            return _HandlerUnsatisfiableCtor
+        raise AssertionError(f"Unexpected import: {module}.{name}")
+
+    with patch(
+        "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+        side_effect=_import_side_effect,
+    ):
+        report = await wire_from_manifest(
+            manifest=manifest,
+            dispatch_engine=_make_dispatch_engine(),
+            event_bus=_make_event_bus(),
+            container=None,
+        )
+
+    # Contract WIRED because at least one handler resolved; the bad handler is
+    # still surfaced as failed + quarantined at the report level.
+    assert report.total_wired == 1
+    assert report.total_failed == 1
+    assert report.total_quarantined == 1
+    assert report.quarantined_handlers[0].handler_name == "_HandlerUnsatisfiableCtor"
+    assert (
+        report.quarantined_handlers[0].reason
+        is EnumQuarantineReason.UNRESOLVABLE_HANDLER
+    )
+    result = report.results[0]
+    assert result.outcome is EnumWiringOutcome.WIRED
+    assert len(result.dispatchers_registered) == 1
+
+
+# ---------------------------------------------------------------------------
+# 4. Truly-fatal infra error STILL propagates (the guard did not swallow it).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fatal_infra_error_still_crashes_boot() -> None:
+    """A real infra outage (broker/DB unreachable) must NOT be quarantined.
+
+    Infra failures surface as ModelOnexError / InfraConnectionError /
+    ConnectionError / OSError — never a bare resolver TypeError/ValueError. The
+    new resolution-quarantine arms catch only TypeError/ValueError, so an
+    InfraConnectionError raised from resolution propagates: the contract fails
+    (and the kernel would crash boot). The guard must NOT have widened to
+    ``except Exception``.
+    """
+    contract = _make_contract(
+        node_name="node_infra_down",
+        handler_entries=(("fake.module", "_HandlerNormalZeroArg"),),
+    )
+    manifest = ModelAutoWiringManifest(contracts=(contract,), errors=())
+
+    class _ResolverInfraDown:
+        def resolve(self, ctx: object) -> object:
+            context = ModelInfraErrorContext.with_correlation(
+                transport_type=EnumInfraTransportType.DATABASE,
+                operation="resolve_handler",
+            )
+            raise InfraConnectionError(
+                "broker/DB unreachable during handler resolution",
+                context=context,
+            )
+
+    with (
+        patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+            return_value=_HandlerNormalZeroArg,
+        ),
+        patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring.ServiceHandlerResolver",
+            return_value=_ResolverInfraDown(),
+        ),
+    ):
+        report = await wire_from_manifest(
+            manifest=manifest,
+            dispatch_engine=_make_dispatch_engine(),
+            event_bus=_make_event_bus(),
+            container=None,
+        )
+
+    # InfraConnectionError is collected as a contract-level FAILED row (NOT
+    # quarantined), so it is NOT demoted to a silent skip. In strict mode this
+    # raises; in non-strict mode total_failed > 0 still fails the kernel
+    # postcondition / gate. Crucially it was NOT swallowed into a quarantine.
+    assert report.total_quarantined == 0
+    assert report.total_failed == 1
+    assert report.results[0].outcome is EnumWiringOutcome.FAILED
+    assert "InfraConnectionError" in report.results[0].reason
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fatal_infra_error_raises_in_strict_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """In strict mode an infra-down contract failure raises (boot fails)."""
+    monkeypatch.setenv("ONEX_WIRING_STRICT_MODE", "1")
+    contract = _make_contract(
+        node_name="node_infra_down_strict",
+        handler_entries=(("fake.module", "_HandlerNormalZeroArg"),),
+    )
+    manifest = ModelAutoWiringManifest(contracts=(contract,), errors=())
+
+    class _ResolverInfraDown:
+        def resolve(self, ctx: object) -> object:
+            context = ModelInfraErrorContext.with_correlation(
+                transport_type=EnumInfraTransportType.DATABASE,
+                operation="resolve_handler",
+            )
+            raise InfraConnectionError("broker unreachable", context=context)
+
+    with (
+        patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+            return_value=_HandlerNormalZeroArg,
+        ),
+        patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring.ServiceHandlerResolver",
+            return_value=_ResolverInfraDown(),
+        ),
+        pytest.raises(Exception),
+    ):
+        await wire_from_manifest(
+            manifest=manifest,
+            dispatch_engine=_make_dispatch_engine(),
+            event_bus=_make_event_bus(),
+            container=None,
+        )
+
+
+# ---------------------------------------------------------------------------
+# 5. ONEX_WIRING_STRICT_MODE=1 re-raises the resolver TypeError (boot fails).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_strict_mode_reraises_unresolvable_handler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Strict mode preserves the pre-OMN-13203 boot-crash invariant.
+
+    The unsatisfiable-ctor TypeError must NOT be quarantined under strict mode;
+    it propagates so the gate can still fail closed.
+    """
+    monkeypatch.setenv("ONEX_WIRING_STRICT_MODE", "1")
+    contract = _make_contract(
+        node_name="node_unsatisfiable_strict",
+        handler_entries=(("fake.module", "_HandlerUnsatisfiableCtor"),),
+    )
+    manifest = ModelAutoWiringManifest(contracts=(contract,), errors=())
+
+    with (
+        patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+            return_value=_HandlerUnsatisfiableCtor,
+        ),
+        pytest.raises(TypeError),
+    ):
+        await wire_from_manifest(
+            manifest=manifest,
+            dispatch_engine=_make_dispatch_engine(),
+            event_bus=_make_event_bus(),
+            container=None,
+        )

--- a/tests/unit/runtime/auto_wiring/test_handler_wiring_unresolvable_quarantine.py
+++ b/tests/unit/runtime/auto_wiring/test_handler_wiring_unresolvable_quarantine.py
@@ -46,6 +46,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from omnibase_core.models.errors.model_onex_error import ModelOnexError
 from omnibase_infra.enums import EnumInfraTransportType
 from omnibase_infra.errors import InfraConnectionError, ModelInfraErrorContext
 from omnibase_infra.protocols import ProtocolEventBusLike
@@ -394,7 +395,7 @@ async def test_fatal_infra_error_raises_in_strict_mode(
             "omnibase_infra.runtime.auto_wiring.handler_wiring.ServiceHandlerResolver",
             return_value=_ResolverInfraDown(),
         ),
-        pytest.raises(Exception),
+        pytest.raises(ModelOnexError) as exc_info,
     ):
         await wire_from_manifest(
             manifest=manifest,
@@ -402,6 +403,11 @@ async def test_fatal_infra_error_raises_in_strict_mode(
             event_bus=_make_event_bus(),
             container=None,
         )
+    # The fatal infra failure surfaces as the auto-wiring aggregate ModelOnexError
+    # carrying the underlying InfraConnectionError message — proves the broker
+    # outage propagated (boot fails) rather than being quarantined.
+    assert "InfraConnectionError" in str(exc_info.value)
+    assert "broker unreachable" in str(exc_info.value)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/runtime/auto_wiring/test_wiring.py
+++ b/tests/unit/runtime/auto_wiring/test_wiring.py
@@ -736,9 +736,22 @@ class TestWireFromManifest:
         assert report.total_wired == 0
 
     @pytest.mark.asyncio
-    async def test_unsatisfiable_di_raises_on_startup(self) -> None:
-        """OMN-8735 negative test: handler with unsatisfiable DI deps must raise."""
-        from omnibase_core.models.errors import ModelOnexError
+    async def test_unsatisfiable_di_quarantined_in_default_mode(self) -> None:
+        """OMN-13203: handler with unsatisfiable DI deps is quarantined, not boot-fatal.
+
+        Before OMN-13203 the resolver's unsatisfiable-ctor TypeError re-raised
+        and crashed runtime-effects boot (taking every healthy handler with it).
+        It is now contained so wire_from_manifest COMPLETES and the bad handler
+        is REPORTED: failed >= 1 + quarantined + a loud WARNING. The OMN-8735
+        fail-fast invariant is preserved under ONEX_WIRING_STRICT_MODE=1 (see
+        test_unsatisfiable_di_raises_on_startup_in_strict_mode below).
+        """
+        import os
+        from unittest.mock import patch as _patch
+
+        from omnibase_infra.runtime.auto_wiring.enum_quarantine_reason import (
+            EnumQuarantineReason,
+        )
         from omnibase_infra.runtime.message_dispatch_engine import (
             MessageDispatchEngine,
         )
@@ -758,11 +771,57 @@ class TestWireFromManifest:
             async def handle(self, envelope: object) -> None:
                 pass
 
-        with patch(
-            "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
-            return_value=HandlerWithDeps,
+        with (
+            _patch.dict(os.environ, {}, clear=False),
+            patch(
+                "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+                return_value=HandlerWithDeps,
+            ),
         ):
-            with pytest.raises((ModelOnexError, TypeError)):
+            os.environ.pop("ONEX_WIRING_STRICT_MODE", None)
+            # COMPLETES — no exception (the boot-crash regression is fixed).
+            report = await wire_from_manifest(manifest, engine)
+
+        assert report.total_failed >= 1
+        assert report.total_quarantined == 1
+        assert (
+            report.quarantined_handlers[0].reason
+            is EnumQuarantineReason.UNRESOLVABLE_HANDLER
+        )
+
+    @pytest.mark.asyncio
+    async def test_unsatisfiable_di_raises_on_startup_in_strict_mode(self) -> None:
+        """OMN-8735 invariant preserved: strict mode re-raises unsatisfiable DI."""
+        import os
+        from unittest.mock import patch as _patch
+
+        from omnibase_infra.runtime.message_dispatch_engine import (
+            MessageDispatchEngine,
+        )
+
+        handler_routing = _make_handler_routing(
+            handler_name="HandlerWithDeps",
+            handler_module="fake.module",
+        )
+        contract = _make_contract(handler_routing=handler_routing)
+        manifest = ModelAutoWiringManifest(contracts=(contract,))
+        engine = MessageDispatchEngine()
+
+        class HandlerWithDeps:
+            def __init__(self, required_service: object) -> None:
+                self.required_service = required_service
+
+            async def handle(self, envelope: object) -> None:
+                pass
+
+        with (
+            _patch.dict(os.environ, {"ONEX_WIRING_STRICT_MODE": "1"}),
+            patch(
+                "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+                return_value=HandlerWithDeps,
+            ),
+        ):
+            with pytest.raises(TypeError):
                 await wire_from_manifest(manifest, engine)
 
     @pytest.mark.asyncio

--- a/tests/unit/runtime/test_handler_wiring_resolver_integration.py
+++ b/tests/unit/runtime/test_handler_wiring_resolver_integration.py
@@ -237,8 +237,57 @@ class TestPrepareHandlerWiringDelegatesToResolver:
         assert prepared.route_ids == []
 
     @pytest.mark.unit
-    def test_raises_typeerror_when_unresolvable(self) -> None:
-        """Plan Task 5 acceptance: OMN-8735 fail-fast invariant preserved."""
+    def test_unresolvable_handler_quarantined_in_default_mode(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """OMN-13203: an unresolvable handler is quarantined (not boot-fatal).
+
+        Default mode contains the resolver's unsatisfiable-ctor TypeError so
+        runtime boot completes; the bad handler is reported as
+        UNRESOLVABLE_HANDLER.
+        """
+        from omnibase_infra.runtime.auto_wiring.enum_quarantine_reason import (
+            EnumQuarantineReason,
+        )
+
+        monkeypatch.delenv("ONEX_WIRING_STRICT_MODE", raising=False)
+        contract = _make_contract()
+        entry = contract.handler_routing.handlers[0]  # type: ignore[union-attr]
+
+        class HandlerWithDeps:
+            def __init__(self, required_service: object) -> None:
+                self.required_service = required_service
+
+            async def handle(self, envelope: object) -> None:
+                return None
+
+        ownership = ServiceLocalHandlerOwnershipQuery(
+            local_node_names=frozenset({contract.name})
+        )
+        resolver = ServiceHandlerResolver()
+        with patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+            return_value=HandlerWithDeps,
+        ):
+            prepared = _prepare_handler_wiring(
+                contract=contract,
+                entry=entry,
+                dispatch_engine=None,
+                resolver=resolver,
+                ownership_query=ownership,
+                event_bus=None,
+                container=None,
+            )
+        assert prepared.is_quarantined is True
+        assert prepared.quarantine_reason is EnumQuarantineReason.UNRESOLVABLE_HANDLER
+        assert "required_service" in prepared.quarantine_detail
+
+    @pytest.mark.unit
+    def test_raises_typeerror_when_unresolvable_in_strict_mode(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """OMN-8735 fail-fast invariant preserved under strict mode."""
+        monkeypatch.setenv("ONEX_WIRING_STRICT_MODE", "1")
         contract = _make_contract()
         entry = contract.handler_routing.handlers[0]  # type: ignore[union-attr]
 
@@ -578,15 +627,24 @@ class TestWireFromManifestResolverOutcomes:
         assert result.routes_registered == ()
 
     @pytest.mark.asyncio
-    async def test_typeerror_propagates_unchanged(self) -> None:
-        """Plan Task 5 acceptance: unresolvable-path invariant test (OMN-8735)."""
+    async def test_unresolvable_quarantined_default_raises_strict(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """OMN-13203: unresolvable handler is quarantined in default mode, raised in strict.
+
+        Default mode: wire_from_manifest COMPLETES (no exception) and the
+        handler is reported failed + quarantined. Strict mode preserves the
+        OMN-8735 fail-fast invariant — the resolver TypeError propagates.
+        """
+        from omnibase_infra.runtime.auto_wiring.enum_quarantine_reason import (
+            EnumQuarantineReason,
+        )
         from omnibase_infra.runtime.message_dispatch_engine import (
             MessageDispatchEngine,
         )
 
         contract = _make_contract(handler_name="HandlerNeedsDep")
         manifest = _make_manifest(contract)
-        engine = MessageDispatchEngine()
 
         class HandlerNeedsDep:
             def __init__(self, required_service: object) -> None:
@@ -595,12 +653,28 @@ class TestWireFromManifestResolverOutcomes:
             async def handle(self, envelope: object) -> None:
                 return None
 
+        # Default (non-strict) mode: quarantine + complete.
+        monkeypatch.delenv("ONEX_WIRING_STRICT_MODE", raising=False)
+        with patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+            return_value=HandlerNeedsDep,
+        ):
+            report = await wire_from_manifest(manifest, MessageDispatchEngine())
+        assert report.total_failed >= 1
+        assert report.total_quarantined == 1
+        assert (
+            report.quarantined_handlers[0].reason
+            is EnumQuarantineReason.UNRESOLVABLE_HANDLER
+        )
+
+        # Strict mode: the resolver TypeError still propagates unchanged.
+        monkeypatch.setenv("ONEX_WIRING_STRICT_MODE", "1")
         with patch(
             "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
             return_value=HandlerNeedsDep,
         ):
             with pytest.raises(TypeError) as exc_info:
-                await wire_from_manifest(manifest, engine)
+                await wire_from_manifest(manifest, MessageDispatchEngine())
         assert "required_service" in str(exc_info.value)
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## OMN-13203 — P0: Quarantine per-handler resolution failures (report failed=N, don't crash effects boot)

Ticket: OMN-13203 (P0 crash-loop repair for the gating blocker). Re-opens PR #2011 which was closed unmerged; this branch rebases the single guard commit onto current `dev` + adds the per-repo OCC contract carrier.

Related: OMN-12982 (commit `ee79972c`, the runtime_profiles flip that exposed the debt), OMN-13201 (canonical migration of `node_pr_review_bot` off the bespoke runner — the durable fix the band-aid does not do).

### Live crash signature (verified on .201 DEV effects, 2026-06-17)
`omninode-runtime-effects` (compose project `omnibase-infra`, DEV lane): **RestartCount=446**, repeating fatal:
```
[ERROR] omnibase_infra.runtime.service_kernel: ONEX runtime failed with unexpected error:
TypeError: Handler omnimarket.nodes.node_pr_review_bot.handlers.handler_judge_verifier.HandlerJudgeVerifier
requires constructor parameters ['judge_base_url', 'judge_model_id'] but no ownership_query, node registry
explicit deps, container, or known injectable params could satisfy them.
```
One unresolvable handler crashed the whole effects worker before the `:8086` health server bound.

### Boot-fatal mechanism (the bug)
A `handler_routing` entry whose constructor `ServiceHandlerResolver.resolve()` cannot satisfy raised a bare `TypeError` (Step 2 ctor-arg-mismatch / Step 6 unsatisfiable-ctor) or a per-handler `ValueError`. In `_prepare_handler_wiring` the non-Protocol `TypeError` re-raised, propagated through the OMN-8735 `except TypeError: raise` guards in `_prepare_contract_wiring` / `wire_from_manifest`, then out through the kernel's `except Exception: raise` — exiting the process before the `:8086` bind. Docker then crash-looped `runtime-effects`.

### Fix — quarantine instead of crash
`_prepare_handler_wiring` now contains the two per-handler resolution-failure classes (a non-Protocol resolver `TypeError`; a per-handler `ValueError`) via `_quarantine_prepared(reason=UNRESOLVABLE_HANDLER, ...)`. `wire_from_manifest` COMPLETES, the kernel reaches `freeze()` + the `:8086` bind, and the bad handler is REPORTED (loud WARNING + counted) rather than silently dropped. New enum value `EnumQuarantineReason.UNRESOLVABLE_HANDLER`. `ModelAutoWiringReport.total_failed` counts resolution-failure quarantines so `failed=N` surfaces and the gate reacts; migration quarantines (Protocol/async) remain `total_quarantined`-only.

### Failure-class boundary (no masking of infra outages)
The new arms catch only `TypeError`/`ValueError`. Broker/DB/secret/manifest failures surface as `ModelOnexError` / `InfraConnectionError` / `ConnectionError` / `OSError` — never a bare resolver `TypeError`/`ValueError` — so they are NOT caught and STILL crash boot. `ONEX_WIRING_STRICT_MODE=1` re-raises every resolution failure, preserving the pre-fix fail-closed gate.

### dod_evidence
- New `tests/unit/runtime/auto_wiring/test_handler_wiring_unresolvable_quarantine.py` (unsatisfiable handler quarantined+failed not crash; per-handler ValueError contained; mixed good+bad; fatal InfraConnectionError still crashes; strict-mode re-raises). Updated negative tests in `test_wiring.py`, `test_handler_wiring_resolver_integration.py`, `test_auto_wiring_resolver_end_to_end.py` (quarantine-in-default / raise-in-strict, OMN-8735 invariant preserved under strict mode).
- Changed-area suite: **71 passed** (`uv run pytest tests/unit/runtime/auto_wiring/test_handler_wiring_unresolvable_quarantine.py tests/unit/runtime/auto_wiring/test_wiring.py tests/unit/runtime/test_handler_wiring_resolver_integration.py tests/integration/runtime/test_auto_wiring_resolver_end_to_end.py -q`).
- `uv run ruff format/check src/omnibase_infra/runtime/auto_wiring/` — clean.
- `uv run mypy src/omnibase_infra/runtime/auto_wiring/handler_wiring.py report.py enum_quarantine_reason.py --strict` — Success: no issues found in 3 source files.
- `pre-commit run --files <changed>` — pass (no bypass).

### OCC
Evidence-Source: 258653374845360acc545f116f5f376396073f42
Evidence-Ticket: OMN-13203


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Handler wiring failures are now quarantined individually, allowing runtime boot to continue even when specific handlers have unsatisfiable dependencies
  * Added configurable strict mode to enforce crash-on-failure behavior when needed

* **Improvements**
  * Enhanced wiring reports to clearly distinguish between resolved failures and quarantined handlers, providing better visibility into per-handler resolution issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
