### PR TITLE
docs(OMN-13204): fix Protocol Conformance Note — retarget deleted ModelOnexEnvelope (B5 residual)

### DIFF
--- a/src/omnibase_infra/nodes/node_llm_inference_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_llm_inference_effect/contract.yaml
@@ -7,6 +7,12 @@
 #   without overriding declared fields (2026-06-07)
 # OMN-13158: HandlerLlmCliSubprocess resolves OAuth/subscription CLI backends
 #   from request.model (codex-cli, claude-cli, gemini-cli, opencode-cli).
+# OMN-13204: HandlerLlmOpenaiCompatible Protocol Conformance Note corrected to
+#   the real protocol I/O types — ProtocolHandler.execute(ModelProtocolRequest)
+#   -> ModelProtocolResponse and ProtocolMessageHandler.handle(ModelEventEnvelope)
+#   -> ModelHandlerOutput — replacing the deleted ModelOnexEnvelope reference
+#   (B5 residual of OMN-13196; deploy-gate runtime-path docstring edit, behavior
+#   unchanged). (2026-06-17)
 # Copyright (c) 2026 OmniNode Team
 #
 # ONEX Node Contract

--- a/src/omnibase_infra/nodes/node_llm_inference_effect/handlers/handler_llm_openai_compatible.py
+++ b/src/omnibase_infra/nodes/node_llm_inference_effect/handlers/handler_llm_openai_compatible.py
@@ -149,16 +149,17 @@ class HandlerLlmOpenaiCompatible:
 
     Protocol Conformance Note:
         This handler intentionally does NOT implement ``ProtocolHandler``
-        or ``ProtocolMessageHandler``. Those protocols operate on
-        ``ModelOnexEnvelope`` and ``ModelEventEnvelope`` respectively,
-        which are envelope-based dispatch interfaces for the node runtime.
-        This handler operates at the infrastructure layer with a typed
-        request model (``ModelLlmInferenceRequest``) and returns a typed
-        response model (``ModelLlmInferenceResponse``), bypassing
-        envelope-based dispatch entirely. LLM inference calls are direct
-        infrastructure effects, not routed events. The ``handler_type``
-        and ``handler_category`` properties are still provided for
-        introspection and classification consistency.
+        or ``ProtocolMessageHandler``. ``ProtocolHandler.execute`` takes a
+        ``ModelProtocolRequest`` and returns a ``ModelProtocolResponse``;
+        ``ProtocolMessageHandler.handle`` takes a ``ModelEventEnvelope`` and
+        returns a ``ModelHandlerOutput`` (the envelope-based dispatch interface
+        for the node runtime). This handler instead operates at the
+        infrastructure layer with a typed request model
+        (``ModelLlmInferenceRequest``) and returns a typed response model
+        (``ModelLlmInferenceResponse``), bypassing both protocols entirely.
+        LLM inference calls are direct infrastructure effects, not routed
+        events. The ``handler_type`` and ``handler_category`` properties are
+        still provided for introspection and classification consistency.
 
     Auth Strategy:
         When a request includes ``api_key``, the handler creates a

--- a/tests/unit/nodes/node_llm_inference_effect/handlers/test_handler_llm_openai_compatible_class.py
+++ b/tests/unit/nodes/node_llm_inference_effect/handlers/test_handler_llm_openai_compatible_class.py
@@ -177,6 +177,42 @@ class TestHandlerLlmOpenaiCompatibleInit:
 
 
 # ---------------------------------------------------------------------------
+# Tests: Protocol Conformance Note docstring accuracy (OMN-13204)
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolConformanceNote:
+    """The class docstring's Protocol Conformance Note must name real types.
+
+    OMN-13204 (B5 residual of OMN-13196): ``ModelOnexEnvelope`` was deleted
+    from omnibase_core in B4. The Protocol Conformance Note previously claimed
+    ``ProtocolHandler`` operates on ``ModelOnexEnvelope`` -- which was wrong on
+    two counts: the type no longer exists, and ``ProtocolHandler.execute``
+    actually takes ``ModelProtocolRequest`` and returns ``ModelProtocolResponse``
+    (omnibase_spi protocols/handlers/protocol_handler.py:113-117).
+    ``ProtocolMessageHandler.handle`` takes ``ModelEventEnvelope`` and returns
+    ``ModelHandlerOutput`` (omnibase_core protocols/runtime/protocol_message_handler.py).
+    """
+
+    def test_note_does_not_reference_deleted_envelope(self) -> None:
+        """No reference to the deleted ModelOnexEnvelope symbol remains."""
+        doc = HandlerLlmOpenaiCompatible.__doc__ or ""
+        assert "ModelOnexEnvelope" not in doc
+
+    def test_note_names_protocol_handler_request_response_types(self) -> None:
+        """ProtocolHandler is documented with its real request/response I/O types."""
+        doc = HandlerLlmOpenaiCompatible.__doc__ or ""
+        assert "ModelProtocolRequest" in doc
+        assert "ModelProtocolResponse" in doc
+
+    def test_note_names_message_handler_envelope_output_types(self) -> None:
+        """ProtocolMessageHandler is documented with its real envelope/output types."""
+        doc = HandlerLlmOpenaiCompatible.__doc__ or ""
+        assert "ModelEventEnvelope" in doc
+        assert "ModelHandlerOutput" in doc
+
+
+# ---------------------------------------------------------------------------
 # Tests: Class-level constants
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## OMN-13204 — B5 residual: clean ModelOnexEnvelope doc-only ref in omnibase_infra

Follow-up from **OMN-13196** (B4, delete `ModelOnexEnvelope`). B4 deleted the class from `omnibase_core` and retargeted the one live cross-repo importer. This PR clears the last in-scope doc-only residual in `omnibase_infra`.

### Change
`src/omnibase_infra/nodes/node_llm_inference_effect/handlers/handler_llm_openai_compatible.py` — the `Protocol Conformance Note` in the `HandlerLlmOpenaiCompatible` class docstring **falsely** claimed `ProtocolHandler` operates on `ModelOnexEnvelope`. That is wrong on two counts:
1. `ModelOnexEnvelope` was deleted from `omnibase_core` in B4.
2. `ProtocolHandler.execute` actually takes `ModelProtocolRequest` and returns `ModelProtocolResponse` (omnibase_spi `protocols/handlers/protocol_handler.py:113-117`), while `ProtocolMessageHandler.handle` takes `ModelEventEnvelope` and returns `ModelHandlerOutput` (omnibase_core `protocols/runtime/protocol_message_handler.py`).

The note now names the real I/O types for each protocol. A `TestProtocolConformanceNote` regression guard asserts the docstring names the real types and never the deleted symbol.

### Scope verification (against origin/dev, post-B4)
`grep -rniE 'ModelOnexEnvelope|model_onex_envelope'` on `origin/dev`:
- **omnibase_spi**: ZERO — `protocols/README.md` already uses `ModelEventEnvelope` (retargeted in an earlier wave).
- **omniintelligence**: ZERO — `runtime/model_event_bus_config.py` already says "wraps them into ModelEventEnvelope".
- **omnibase_infra**: the single residual fixed here was the only one left (`mixin_kafka_broadcast.py`, `CLAUDE.md`, `PROTOCOL_SEQUENCE_DIAGRAMS.md` were already clean on dev).

After this PR, `omnibase_infra` has ZERO `ModelOnexEnvelope` references outside the regression test (which must name the symbol to assert its absence).

### OCC recipe
Evidence-Source: OCC#2699
Evidence-Ticket: OMN-13204

### dod_evidence
- check_name: `docstring-regression-test`
  check_command: `uv run pytest tests/unit/nodes/node_llm_inference_effect/handlers/test_handler_llm_openai_compatible_class.py -q`
  check_value: `81 passed` (TestProtocolConformanceNote: 3 new tests RED before fix, GREEN after)
- check_name: `mypy-strict`
  check_command: `uv run mypy src/omnibase_infra/nodes/node_llm_inference_effect/handlers/handler_llm_openai_compatible.py --strict`
  check_value: `Success: no issues found in 1 source file`
- check_name: `pre-commit-all`
  check_command: `pre-commit run --files <changed files>`
  check_value: all hooks Passed/Skipped, none Failed
- check_name: `deploy-path-no-op-verification`
  check_command: `git diff origin/dev..HEAD -- src/ | grep -E '^[+-]' | grep -vE '^[+-]{3}|^[+-]\s*(#|\*|\"\"\")'`
  check_value: deploy-gate runtime-path: change is docstring-only (no executable line changed). No runtime restart / `docker exec` / `rpk topic produce` is required because the handler's behavior, signatures, and dispatch wiring are unchanged — only the class docstring text. The handler is not redeployed by this PR; the dev-lane LLM inference effect handler continues to operate against the verbatim contract `endpoint_url` exactly as before (OMN-12815 behavior preserved, covered by `TestBuildUrl`).
