### PR TITLE
fix(OMN-13201): lane-namespace intelligence-migration container_name (DEV migration gap)

### DIFF
--- a/contracts/OMN-13201.yaml
+++ b/contracts/OMN-13201.yaml
@@ -1,0 +1,35 @@
+# OMN-13201 contract file for omnibase_infra deploy-gate.
+# The canonical ticket contract and PASS receipts live in onex_change_control.
+# This file is the per-repo deploy-evidence carrier only.
+schema_version: "1.0.0"
+ticket_id: "OMN-13201"
+title: "fix(OMN-13201): lane-namespace intelligence-migration container_name (DEV migration gap)"
+summary: >-
+  P0 DEV effects-lane crash-loop repair, part (c): the base (DEV-lane) intelligence-migration one-shot used the fixed, non-lane-prefixed container_name omnibase-intelligence-migration, unlike every sibling migration service (omnibase-infra-forward-migration, omnibase-infra-migration-gate) and every other lane (stability-test/judge/prod all carry their lane prefix). On a shared Docker host the fixed name collides across lanes, so the DEV one-shot never ran -- 015_create_db_metadata.sql was never applied to the DEV omniintelligence database and the runtime entrypoint logged "relation public.db_metadata does not exist" on every effects boot. Verified live on .201 DEV: omniintelligence DB has 9 tables, no schema_migrations table, no db_metadata relation. Fix renames the base container_name to omnibase-infra-intelligence-migration in both the canonical catalog manifest and the hand-maintained DEV compose, matching its forward-migration / migration-gate siblings.
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: tests
+    description: >-
+      New regression test_intelligence_migration_uses_lane_namespaced_container_name asserts the generated runtime compose gives intelligence-migration the omnibase-infra- lane prefix matching forward-migration and migration-gate. Catalog generator + completeness + resolver + lane suites pass (54 passed).
+    command: "uv run pytest tests/unit/infra/test_catalog_generator.py tests/unit/infra/test_catalog_completeness.py tests/unit/infra/test_catalog_resolver.py tests/unit/infra/test_stability_test_runtime_lane.py tests/unit/infra/test_judge_compose_profile.py -q"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: dod-intelligence-migration-lane-prefix
+    description: >-
+      The generated runtime compose assigns intelligence-migration the lane-prefixed container_name omnibase-infra-intelligence-migration, matching its sibling migration one-shots, proven by test_intelligence_migration_uses_lane_namespaced_container_name.
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "uv run pytest tests/unit/infra/test_catalog_generator.py::test_intelligence_migration_uses_lane_namespaced_container_name -q"
+  - id: dod-catalog-compose-parity
+    description: >-
+      Both the canonical catalog manifest and the hand-maintained DEV compose carry the same lane-prefixed container_name (no drift).
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "grep -q 'container_name: omnibase-infra-intelligence-migration' docker/catalog/services/intelligence-migration.yaml && grep -q 'container_name: omnibase-infra-intelligence-migration' docker/docker-compose.infra.yml"

--- a/docker/catalog/services/intelligence-migration.yaml
+++ b/docker/catalog/services/intelligence-migration.yaml
@@ -2,7 +2,7 @@ name: intelligence-migration
 description: One-shot migration runner for omniintelligence database
 image: postgres:16-alpine
 layer: infrastructure
-container_name: omnibase-intelligence-migration
+container_name: omnibase-infra-intelligence-migration
 required_env:
   - POSTGRES_PASSWORD
 hardcoded_env:

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -1119,7 +1119,7 @@ services:
   # service_completed_successfully so it will not start if migration fails.
   intelligence-migration:
     image: postgres:16-alpine
-    container_name: omnibase-intelligence-migration
+    container_name: omnibase-infra-intelligence-migration
     profiles: ["runtime", "full"]
     depends_on:
       postgres:

--- a/tests/unit/infra/test_catalog_generator.py
+++ b/tests/unit/infra/test_catalog_generator.py
@@ -73,6 +73,38 @@ def test_generated_compose_preserves_redpanda_ulimits() -> None:
 
 
 @pytest.mark.unit
+def test_intelligence_migration_uses_lane_namespaced_container_name() -> None:
+    """OMN-13201: intelligence-migration must carry the lane prefix.
+
+    Regression for the DEV effects crash-loop's migration gap: the base
+    (DEV-lane) intelligence-migration one-shot used the fixed, non-lane-prefixed
+    container_name ``omnibase-intelligence-migration`` while every other lane and
+    every sibling migration service uses the ``omnibase-infra-`` prefix
+    (``omnibase-infra-forward-migration``, ``omnibase-infra-migration-gate``).
+    The mismatched name meant the DEV one-shot never ran, so
+    ``015_create_db_metadata.sql`` was never applied to the DEV omniintelligence
+    database and the runtime entrypoint logged "relation public.db_metadata does
+    not exist" on every effects boot. The name must match its siblings.
+    """
+    resolver = CatalogResolver(catalog_dir=CATALOG_DIR)
+    resolved = resolver.resolve(bundles=["runtime"])
+    compose = generate_compose(resolved)
+    services = compose["services"]
+    assert (
+        services["intelligence-migration"]["container_name"]
+        == "omnibase-infra-intelligence-migration"
+    )
+    # Sibling migration one-shots define the shared lane-prefix convention.
+    assert (
+        services["forward-migration"]["container_name"]
+        == "omnibase-infra-forward-migration"
+    )
+    assert (
+        services["migration-gate"]["container_name"] == "omnibase-infra-migration-gate"
+    )
+
+
+@pytest.mark.unit
 def test_generated_compose_preserves_one_shot_semantics() -> None:
     resolver = CatalogResolver(catalog_dir=CATALOG_DIR)
     resolved = resolver.resolve(bundles=["runtime"])


### PR DESCRIPTION
## OMN-13201 — lane-namespace intelligence-migration container_name (DEV migration gap, P0 part c)

Ticket: OMN-13201. Part (c) of the P0 DEV effects-lane crash-loop repair: eliminate the "relation public.db_metadata does not exist" migration gap that interleaves with (and masks) the effects boot crash.

### Root cause (verified live on .201 DEV, 2026-06-17)
The base (DEV-lane) `intelligence-migration` one-shot used the fixed, non-lane-prefixed `container_name: omnibase-intelligence-migration` — unlike every sibling migration service (`omnibase-infra-forward-migration`, `omnibase-infra-migration-gate`) and every other lane (`omnibase-infra-stability-test-intelligence-migration`, `omnibase-infra-judge-intelligence-migration`, `omnibase-infra-prod-intelligence-migration`). On a shared Docker host the fixed name collides across lanes, so the DEV one-shot never ran. Result on the DEV `omniintelligence` database: only 9 (old) tables, **no `schema_migrations` table, no `db_metadata` relation** — `docker/migrations/intelligence/015_create_db_metadata.sql` was never applied. The runtime entrypoint then logs `ERROR: relation "public.db_metadata" does not exist` (`omniintelligence stamp attempt N/5 failed`) on every effects boot.

### Fix
Rename the base `intelligence-migration` container to `omnibase-infra-intelligence-migration` (matching its siblings) in both:
- `docker/catalog/services/intelligence-migration.yaml` — the canonical catalog manifest (the authoritative source the generator renders from)
- `docker/docker-compose.infra.yml` — the hand-maintained DEV compose, kept in sync

So each lane runs its own collision-free intelligence-migration one-shot and applies `015_create_db_metadata.sql`.

### dod_evidence
- New `tests/unit/infra/test_catalog_generator.py::test_intelligence_migration_uses_lane_namespaced_container_name` asserts the generated runtime compose gives `intelligence-migration` the `omnibase-infra-` lane prefix matching `forward-migration` / `migration-gate`.
- `uv run pytest tests/unit/infra/test_catalog_generator.py tests/unit/infra/test_catalog_completeness.py tests/unit/infra/test_catalog_resolver.py tests/unit/infra/test_stability_test_runtime_lane.py tests/unit/infra/test_judge_compose_profile.py -q` — **54 passed**.
- `uv run ruff format/check` — clean. `pre-commit run --files <changed>` — passes; the only failing hook is `check-required-env-vars GITHUB_TOKEN`, which fails IDENTICALLY on the clean base (`git stash` → same failure), references a pre-existing `${GITHUB_TOKEN:?}` runtime-secret line my diff does not touch, and reflects local `~/.omnibase/.env` state only — no bypass used.

### Note
The mypy-strict `object is not indexable` lines in the new test mirror the file's established `compose["services"][...]` access pattern (15 identical pre-existing instances incl. lines 23-24); this test file is not strict-mypy-gated in CI.

### OCC
Evidence-Source: OCC#2716
Evidence-Ticket: OMN-13201