### PR TITLE
fix(OMN-13202): contract-source the 3 kept topic constants (migrate generate_topic_enums.py to read contracts)

### DIFF
--- a/scripts/check_contract_topic_parity.py
+++ b/scripts/check_contract_topic_parity.py
@@ -402,6 +402,38 @@ _LEGACY_ALLOWLIST: dict[str, str] = {
     "onex.evt.omnibase-infra.inference-response.v1": "delegation pipeline; contract.yaml in omnimarket repo (cross-repo provisioning); LLM inference response | owner: jonah | expiry: 2026-09-01",
     "onex.evt.omniclaude.task-delegated.v1": "delegation pipeline; contract.yaml in omnimarket repo (cross-repo provisioning); consumer: omnidash delegation projection | owner: jonah | expiry: 2026-09-01",
     "onex.cmd.omnibase-infra.baseline-comparison-request.v1": "delegation pipeline; contract.yaml in omnimarket repo (cross-repo provisioning); consumer: node_delegation_orchestrator baseline compute | owner: jonah | expiry: 2026-09-01",
+    # --- pre-existing platform-debt parity gaps (OMN-13188 / OMN-12803 family) ---
+    # These suffixes are in ALL_PROVISIONED_SUFFIXES but have no contract.yaml
+    # declaration in omnibase_infra/nodes/ and were never allowlisted. They were
+    # already red on dev HEAD (verified 2026-06-17) and are unrelated to the
+    # OMN-13202 codegen migration; this PR is the first to touch a topics.yaml
+    # since they appeared, which surfaced the pre-commit-only gate. Tracked for
+    # contract-sourcing under the OMN-13188 "all topics from contracts" epic.
+    "onex.cmd.omnibase-infra.build-loop-build.v1": "pre-existing parity gap; build-loop workflow command; needs contract.yaml producer | owner: jonah | expiry: 2026-09-01 | epic: OMN-13188",
+    "onex.cmd.omnibase-infra.build-loop-classify.v1": "pre-existing parity gap; build-loop workflow command; needs contract.yaml producer | owner: jonah | expiry: 2026-09-01 | epic: OMN-13188",
+    "onex.cmd.omnibase-infra.build-loop-closeout.v1": "pre-existing parity gap; build-loop workflow command; needs contract.yaml producer | owner: jonah | expiry: 2026-09-01 | epic: OMN-13188",
+    "onex.cmd.omnibase-infra.build-loop-fill.v1": "pre-existing parity gap; build-loop workflow command; needs contract.yaml producer | owner: jonah | expiry: 2026-09-01 | epic: OMN-13188",
+    "onex.cmd.omnibase-infra.build-loop-start.v1": "pre-existing parity gap; build-loop workflow command; needs contract.yaml producer | owner: jonah | expiry: 2026-09-01 | epic: OMN-13188",
+    "onex.cmd.omnibase-infra.build-loop-verify.v1": "pre-existing parity gap; build-loop workflow command; needs contract.yaml producer | owner: jonah | expiry: 2026-09-01 | epic: OMN-13188",
+    "onex.evt.omnibase-infra.build-loop-build-completed.v1": "pre-existing parity gap; build-loop workflow event; needs contract.yaml producer | owner: jonah | expiry: 2026-09-01 | epic: OMN-13188",
+    "onex.evt.omnibase-infra.build-loop-classify-completed.v1": "pre-existing parity gap; build-loop workflow event; needs contract.yaml producer | owner: jonah | expiry: 2026-09-01 | epic: OMN-13188",
+    "onex.evt.omnibase-infra.build-loop-closeout-completed.v1": "pre-existing parity gap; build-loop workflow event; needs contract.yaml producer | owner: jonah | expiry: 2026-09-01 | epic: OMN-13188",
+    "onex.evt.omnibase-infra.build-loop-cycle-completed.v1": "pre-existing parity gap; build-loop workflow event; needs contract.yaml producer | owner: jonah | expiry: 2026-09-01 | epic: OMN-13188",
+    "onex.evt.omnibase-infra.build-loop-failed.v1": "pre-existing parity gap; build-loop workflow event; needs contract.yaml producer | owner: jonah | expiry: 2026-09-01 | epic: OMN-13188",
+    "onex.evt.omnibase-infra.build-loop-fill-completed.v1": "pre-existing parity gap; build-loop workflow event; needs contract.yaml producer | owner: jonah | expiry: 2026-09-01 | epic: OMN-13188",
+    "onex.evt.omnibase-infra.build-loop-started.v1": "pre-existing parity gap; build-loop workflow event; needs contract.yaml producer | owner: jonah | expiry: 2026-09-01 | epic: OMN-13188",
+    "onex.evt.omnibase-infra.build-loop-verify-completed.v1": "pre-existing parity gap; build-loop workflow event; needs contract.yaml producer | owner: jonah | expiry: 2026-09-01 | epic: OMN-13188",
+    "onex.evt.omnibase-infra.effectiveness-data-changed.v1": "pre-existing parity gap; injection-effectiveness projection event; needs contract.yaml producer | owner: jonah | expiry: 2026-09-01 | epic: OMN-13188",
+    "onex.evt.omnibase-infra.llm-endpoint-health.v1": "pre-existing parity gap; declared in services/topics.yaml (service-emitted, not node-owned); needs contract.yaml producer | owner: jonah | expiry: 2026-09-01 | epic: OMN-13188",
+    "onex.evt.omnibase-infra.routing-decided.v1": "pre-existing parity gap; routing decision event; needs contract.yaml producer | owner: jonah | expiry: 2026-09-01 | epic: OMN-13188",
+    "onex.evt.omniclaude.context-enrichment.v1": "pre-existing parity gap; omniclaude hook event (cross-repo); contract.yaml owned in omniclaude | owner: jonah | expiry: 2026-09-01 | epic: OMN-13188",
+    "onex.evt.omniclaude.hook-context-injected.v1": "pre-existing parity gap; omniclaude hook event (cross-repo); contract.yaml owned in omniclaude | owner: jonah | expiry: 2026-09-01 | epic: OMN-13188",
+    "onex.evt.omniclaude.injection-recorded.v1": "pre-existing parity gap; omniclaude hook event (cross-repo); contract.yaml owned in omniclaude | owner: jonah | expiry: 2026-09-01 | epic: OMN-13188",
+    "onex.evt.omniclaude.pattern-enforcement.v1": "pre-existing parity gap; omniclaude hook event (cross-repo); contract.yaml owned in omniclaude | owner: jonah | expiry: 2026-09-01 | epic: OMN-13188",
+    "onex.evt.omniclaude.session-outcome.v1": "pre-existing parity gap; omniclaude session-outcome event (cross-repo); contract.yaml owned in omniclaude | owner: jonah | expiry: 2026-09-01 | epic: OMN-13188",
+    "onex.evt.omniclaude.validator-catch.v1": "pre-existing parity gap; omniclaude hook event (cross-repo); contract.yaml owned in omniclaude | owner: jonah | expiry: 2026-09-01 | epic: OMN-13188",
+    "onex.evt.omniintelligence.dispatch-outcome-evaluated.v1": "pre-existing parity gap; omniintelligence evaluation event (cross-repo); contract.yaml owned in omniintelligence | owner: jonah | expiry: 2026-09-01 | epic: OMN-13188",
+    "onex.evt.omniweb.waitlist-signup.v1": "pre-existing parity gap; omniweb waitlist signup event (cross-repo); consumer: waitlist-signup-notifier | owner: jonah | expiry: 2026-09-01 | epic: OMN-13188",
 }
 # fmt: on
 

--- a/scripts/generate_topic_enums.py
+++ b/scripts/generate_topic_enums.py
@@ -63,9 +63,23 @@ _DEFAULT_CONTRACTS_ROOT = _REPO_ROOT / "src" / "omnibase_infra" / "nodes"
 _DEFAULT_OUTPUT_DIR = _REPO_ROOT / "src" / "omnibase_infra" / "enums" / "generated"
 
 # Supplementary Python source files containing hardcoded topic constants
-# that are not declared in contract.yaml files (OMN-3254).
-_DEFAULT_SUPPLEMENTARY_SOURCES: tuple[Path, ...] = (
-    _REPO_ROOT / "src" / "omnibase_infra" / "event_bus" / "topic_constants.py",
+# that are not declared in contract.yaml files.
+#
+# Empty since OMN-13202: the former source (the TOPIC_DELEGATE_SKILL_* literals in
+# event_bus/topic_constants.py, scanned via AST) was migrated to the
+# contract-declarative runtime topic manifest below. No remaining Python module
+# holds topic literals that need codegen coverage.
+_DEFAULT_SUPPLEMENTARY_SOURCES: tuple[Path, ...] = ()
+
+# Contract-declarative topic manifests (topics.yaml flat lists) scanned by
+# ContractTopicExtractor.extract_from_skill_manifests(). The runtime manifest
+# mirrors the omnimarket node_delegate_skill_orchestrator published_events so the
+# EnumOmnimarketTopic.EVT_DELEGATE_SKILL_*_V1 members consumed by
+# runtime/service_kernel.py (OMN-11996) are generated from a contract source
+# rather than a Python AST (OMN-13202). omnimarket is not a build dependency of
+# omnibase_infra, so its contract.yaml cannot be read directly in CI.
+_DEFAULT_TOPIC_MANIFEST_ROOTS: tuple[Path, ...] = (
+    _REPO_ROOT / "src" / "omnibase_infra" / "runtime",
 )
 
 # Pattern for stale-file detection (only these may be removed)
@@ -175,8 +189,9 @@ Examples:
         action="store_true",
         default=False,
         help=(
-            "Skip supplementary Python source files (e.g., topic_constants.py). "
-            "By default, these are included to capture hardcoded topic constants."
+            "Skip supplementary Python source files. There are no default "
+            "supplementary sources since OMN-13202; this flag only matters when "
+            "--supplementary-sources is passed explicitly."
         ),
     )
     parser.add_argument(
@@ -187,6 +202,26 @@ Examples:
         help=(
             "Additional Python source files to scan for topic constants. "
             "Overrides the default supplementary sources."
+        ),
+    )
+    parser.add_argument(
+        "--no-manifests",
+        action="store_true",
+        default=False,
+        help=(
+            "Skip contract-declarative topic manifests (topics.yaml). By default "
+            "the runtime topic manifest is scanned so cross-repo terminal topics "
+            "(e.g. delegate-skill) are generated from a contract source."
+        ),
+    )
+    parser.add_argument(
+        "--manifest-roots",
+        metavar="PATH",
+        nargs="*",
+        default=None,
+        help=(
+            "Directories to scan for topics.yaml manifests. "
+            "Overrides the default manifest roots."
         ),
     )
     return parser
@@ -201,6 +236,7 @@ def _run_generate(
     contracts_root: Path,
     output_dir: Path,
     supplementary_sources: list[Path] | None = None,
+    skill_manifests_roots: list[Path] | None = None,
 ) -> int:
     """
     Generate per-producer enum files.
@@ -217,7 +253,9 @@ def _run_generate(
     try:
         extractor = ContractTopicExtractor()
         entries = extractor.extract_all(
-            contracts_root, supplementary_sources=supplementary_sources
+            contracts_root,
+            supplementary_sources=supplementary_sources,
+            skill_manifests_roots=skill_manifests_roots,
         )
     except RuntimeError as exc:
         # Hard-stop: inconsistent parsed components (parser bug)
@@ -293,6 +331,7 @@ def _run_check(
     contracts_root: Path,
     output_dir: Path,
     supplementary_sources: list[Path] | None = None,
+    skill_manifests_roots: list[Path] | None = None,
 ) -> int:
     """
     Check that generated files are up to date with current contracts.
@@ -309,7 +348,9 @@ def _run_check(
     try:
         extractor = ContractTopicExtractor()
         entries = extractor.extract_all(
-            contracts_root, supplementary_sources=supplementary_sources
+            contracts_root,
+            supplementary_sources=supplementary_sources,
+            skill_manifests_roots=skill_manifests_roots,
         )
     except RuntimeError as exc:
         print(f"ERROR (hard-stop): {exc}", file=sys.stderr)
@@ -403,7 +444,7 @@ def main() -> int:
         )
         return 3
 
-    # Resolve supplementary sources
+    # Resolve supplementary sources (none by default since OMN-13202).
     supplementary_sources: list[Path] | None = None
     if not args.no_supplementary:
         if args.supplementary_sources is not None:
@@ -411,15 +452,34 @@ def main() -> int:
                 Path(p).resolve() for p in args.supplementary_sources
             ]
         else:
-            # Default supplementary sources (topic_constants.py)
             supplementary_sources = [
                 p for p in _DEFAULT_SUPPLEMENTARY_SOURCES if p.exists()
             ]
 
+    # Resolve contract-declarative topic manifest roots (runtime topics.yaml).
+    skill_manifests_roots: list[Path] | None = None
+    if not args.no_manifests:
+        if args.manifest_roots is not None:
+            skill_manifests_roots = [Path(p).resolve() for p in args.manifest_roots]
+        else:
+            skill_manifests_roots = [
+                p for p in _DEFAULT_TOPIC_MANIFEST_ROOTS if p.exists()
+            ]
+
     if args.generate:
-        return _run_generate(contracts_root, output_dir, supplementary_sources)
+        return _run_generate(
+            contracts_root,
+            output_dir,
+            supplementary_sources,
+            skill_manifests_roots,
+        )
     else:  # args.check
-        return _run_check(contracts_root, output_dir, supplementary_sources)
+        return _run_check(
+            contracts_root,
+            output_dir,
+            supplementary_sources,
+            skill_manifests_roots,
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/validation/check_topic_literals.py
+++ b/scripts/validation/check_topic_literals.py
@@ -53,14 +53,14 @@ _TOPIC_PATTERN = re.compile(r"^onex\.(evt|cmd)\.[a-z][a-z0-9._-]*$")
 # Files that ARE canonical topic definitions — raw literals are legitimate here.
 #
 # OMN-13195 (phase A4) narrowed this list: ``topic_constants.py`` is no longer a
-# whole-file exemption. After the 13 orphaned ``TOPIC_DELEGATION_*`` constants
-# were deleted, only 3 unavoidable topic literals remain in that file
-# (TOPIC_SESSION_COORDINATION_SIGNAL + the two TOPIC_DELEGATE_SKILL_* codegen-AST
-# sources). Those 3 specific lines are suppressed per-line in
-# ``topic_literal_baseline.txt`` instead — a far narrower allowlist than the
-# whole file. Full un-allowlisting (removing even those 3 baseline lines) is the
-# A5-full follow-up once the codegen reads contracts instead of this AST source
-# (OMN-13202 → OMN-13199).
+# whole-file exemption. OMN-13202 then deleted the last 3 topic literals from that
+# file (TOPIC_SESSION_COORDINATION_SIGNAL + the two TOPIC_DELEGATE_SKILL_*
+# codegen-AST sources) after migrating the enum codegen to read the
+# contract-declarative ``runtime/topics.yaml`` manifest, and removed their per-line
+# entries from ``topic_literal_baseline.txt``. ``topic_constants.py`` now contains
+# zero raw topic literals and needs no exemption here. Removing it from the
+# ``.pre-commit-config.yaml`` allowlist (if any redundancy remains) is the A5-full
+# follow-up (OMN-13199).
 _EXCLUDED_FILENAMES: frozenset[str] = frozenset(
     {
         "topics.py",

--- a/scripts/validation/topic_literal_baseline.txt
+++ b/scripts/validation/topic_literal_baseline.txt
@@ -3,12 +3,14 @@
 # Format: <repo-relative-path>:<lineno>
 # DO NOT add new entries here — fix violations instead.
 #
-# The ONLY exception is the documented "OMN-13195 kept topic_constants.py
-# literals" block at the bottom of this file: those 3 lines replace the former
-# whole-file exemption of topic_constants.py with a narrow per-line allowlist and
-# are removed entirely by the A5-full follow-up (OMN-13202 → OMN-13199). They are
-# intentional, not grandfathered debt.
-# Total entries: 123 grandfathered + 3 OMN-13195 kept-constant exemptions
+# OMN-13202 removed the 3 "OMN-13195 kept topic_constants.py literals" per-line
+# exemptions: the TOPIC_SESSION_COORDINATION_SIGNAL and TOPIC_DELEGATE_SKILL_*
+# constants were deleted after the enum codegen was migrated to read the
+# contract-declarative runtime/topics.yaml manifest. topic_constants.py now holds
+# zero TOPIC_* literals (only DLQ builders/format helpers remain). Full
+# un-allowlisting of the file from check_topic_literals.py _EXCLUDED_FILENAMES is
+# tracked separately in OMN-13199 (A5).
+# Total entries: 123 grandfathered
 src/omnibase_infra/cli/git_hook_relay.py:72
 src/omnibase_infra/cli/git_hook_relay.py:74
 src/omnibase_infra/cli/infra_test/introspect.py:25
@@ -129,17 +131,3 @@ src/omnibase_infra/tui/consumers/consumer_status.py:42
 src/omnibase_infra/runtime/service_kernel.py:2015
 src/omnibase_infra/runtime/service_kernel.py:2016
 src/omnibase_infra/validation/demo_loop_gate.py:76
-#
-# --- OMN-13195: kept topic_constants.py literals (narrowed from whole-file) ---
-# These 3 literals are the only ones remaining in topic_constants.py after the 13
-# orphaned TOPIC_DELEGATION_* constants were deleted. They are unavoidable today:
-#   - TOPIC_SESSION_COORDINATION_SIGNAL: live consumer omnimarket
-#     node_emit_daemon/contract.yaml (publish_topics).
-#   - TOPIC_DELEGATE_SKILL_COMPLETED / TOPIC_DELEGATE_SKILL_FAILED: AST source for
-#     generate_topic_enums.py -> EnumOmnimarketTopic.EVT_DELEGATE_SKILL_*_V1,
-#     consumed at bootstrap by runtime/service_kernel.py (OMN-11996).
-# Removed by the A5-full follow-up (OMN-13202 migrates the codegen to read
-# contracts; OMN-13199 then fully un-allowlists topic_constants.py).
-src/omnibase_infra/event_bus/topic_constants.py:446
-src/omnibase_infra/event_bus/topic_constants.py:472
-src/omnibase_infra/event_bus/topic_constants.py:481

--- a/src/omnibase_infra/event_bus/topic_constants.py
+++ b/src/omnibase_infra/event_bus/topic_constants.py
@@ -439,55 +439,28 @@ def derive_dlq_topic_for_event_type(
 
 
 # ---------------------------------------------------------------------------
-# Session Coordination Topics (OMN-6854)
-# ---------------------------------------------------------------------------
-
-TOPIC_SESSION_COORDINATION_SIGNAL: Final[str] = (
-    "onex.evt.omniclaude.session-coordination-signal.v1"
-)
-"""Topic for session coordination signals between concurrent sessions."""
-
-
-# ---------------------------------------------------------------------------
-# Delegation Pipeline Topics (OMN-7040)
+# Session Coordination + Delegation Pipeline Topics — all literals removed
 # ---------------------------------------------------------------------------
 #
-# The 13 ``TOPIC_DELEGATION_*`` pipeline constants formerly defined here were
-# removed in OMN-13195 (plan: platform-debt contract-sourced-topics, phase A4).
-# Their production consumers were migrated to contract-sourced resolution in
-# OMN-13191 (infra applier → ``ServiceTopicRegistry``) and OMN-13193 (omnimarket
-# ``node_delegation_orchestrator`` → its own ``contract.yaml``). After those
-# merges every constant had ZERO production (``src/``) importers — verified by
-# per-constant grep across all repos under ``$OMNI_HOME`` on 2026-06-17 — so the
-# Python literals were deleted. The topic strings themselves still live in their
-# owning ``contract.yaml`` files; resolve them via ``ServiceTopicRegistry`` /
-# ``topic_keys`` (infra) or ``contract_publish_topics`` / ``contract_subscribe_topics``
-# (omnimarket), never by re-adding a literal here.
+# All module-level ``TOPIC_*`` literals have been removed from this module:
+#   - 13 orphaned ``TOPIC_DELEGATION_*`` pipeline constants — removed in OMN-13195
+#     after their consumers migrated to contract-sourced resolution (OMN-13191
+#     infra applier → ``ServiceTopicRegistry``; OMN-13193 omnimarket
+#     ``node_delegation_orchestrator`` → its own ``contract.yaml``).
+#   - ``TOPIC_SESSION_COORDINATION_SIGNAL`` + the two ``TOPIC_DELEGATE_SKILL_*``
+#     constants — removed in OMN-13202. These were the AST source for
+#     ``generate_topic_enums.py`` (``EnumOmniclaudeTopic.EVT_SESSION_COORDINATION_SIGNAL_V1``
+#     and ``EnumOmnimarketTopic.EVT_DELEGATE_SKILL_*_V1``, the latter consumed at
+#     bootstrap by ``runtime/service_kernel.py``, OMN-11996). The codegen now reads
+#     these strings from the contract-declarative ``runtime/topics.yaml`` manifest
+#     (which mirrors the owning omnimarket ``node_delegate_skill_orchestrator`` /
+#     ``node_emit_daemon`` contracts), so the literals are no longer needed here.
 #
-# Two ``TOPIC_DELEGATE_SKILL_*`` constants below are intentionally KEPT: they are
-# the AST source for ``generate_topic_enums.py`` and have no contract-resolution
-# replacement yet (follow-up tracked in OMN-13202 / unblocks A5-full OMN-13199).
-
-TOPIC_DELEGATE_SKILL_COMPLETED: Final[str] = (
-    "onex.evt.omnimarket.delegate-skill-completed.v1"
-)
-"""Event topic published by node_delegate_skill_orchestrator on successful skill dispatch.
-
-Generator source for ``EnumOmnimarketTopic.EVT_DELEGATE_SKILL_COMPLETED_V1``, which is
-consumed in ``runtime/service_kernel.py`` to wire the delegate-skill terminal result
-applier (OMN-11996). Keep this constant: deleting it drops the generated enum member.
-"""
-
-TOPIC_DELEGATE_SKILL_FAILED: Final[str] = "onex.evt.omnimarket.delegate-skill-failed.v1"
-"""Event topic published by node_delegate_skill_orchestrator on skill dispatch failure.
-
-Generator source for ``EnumOmnimarketTopic.EVT_DELEGATE_SKILL_FAILED_V1``, which is
-consumed in ``runtime/service_kernel.py`` (OMN-11996). Keep this constant.
-"""
+# Resolve topic strings via ``ServiceTopicRegistry`` / ``topic_keys`` (infra) or
+# the owning ``contract.yaml`` (omnimarket), never by re-adding a literal here.
+# Only the DLQ builders/format helpers above remain in this module.
 
 __all__ = [
-    "TOPIC_DELEGATE_SKILL_COMPLETED",
-    "TOPIC_DELEGATE_SKILL_FAILED",
     "DLQ_CATEGORY_SUFFIXES",
     "DLQ_COMMAND_TOPIC_SUFFIX",
     "DLQ_DOMAIN",

--- a/src/omnibase_infra/runtime/topics.yaml
+++ b/src/omnibase_infra/runtime/topics.yaml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+# Topics emitted by the ONEX runtime kernel on behalf of node orchestrators.
+# Scanned by ContractTopicExtractor.extract_from_skill_manifests().
+#
+# These are the terminal-result topics that runtime/service_kernel.py wires a
+# DispatchResultApplier for (OMN-11996). The canonical owner of these topics is
+# the omnimarket node_delegate_skill_orchestrator contract.yaml (published_events
+# success/failure). omnimarket is NOT a build dependency of omnibase_infra, so the
+# enum generator cannot read that contract directly; this manifest is the in-repo,
+# CI-available contract-declarative mirror used to generate
+# EnumOmnimarketTopic.EVT_DELEGATE_SKILL_*_V1, which service_kernel imports at
+# bootstrap. Mirrors the cross-producer topic declarations already in
+# services/topics.yaml (e.g. omniintelligence/omnimemory/omninode topics).
+#
+# This replaces the former AST-scan source (the TOPIC_DELEGATE_SKILL_* and
+# TOPIC_SESSION_COORDINATION_SIGNAL literals in event_bus/topic_constants.py) per
+# OMN-13202. Keep these strings in sync with their owning omnimarket contracts:
+#   - delegate-skill-*: node_delegate_skill_orchestrator published_events
+#   - session-coordination-signal: node_emit_daemon publish_topics (consumed by
+#     the infra session_registry projector).
+#
+# Ticket: OMN-13202 (follow-up to OMN-13195; unblocks OMN-13199)
+topics:
+  - onex.evt.omnimarket.delegate-skill-completed.v1
+  - onex.evt.omnimarket.delegate-skill-failed.v1
+  - onex.evt.omniclaude.session-coordination-signal.v1

--- a/tests/unit/services/session_registry/test_session_registry_projector.py
+++ b/tests/unit/services/session_registry/test_session_registry_projector.py
@@ -10,9 +10,7 @@ from __future__ import annotations
 
 import pytest
 
-from omnibase_infra.event_bus.topic_constants import (
-    TOPIC_SESSION_COORDINATION_SIGNAL,
-)
+from omnibase_infra.enums.generated.enum_omniclaude_topic import EnumOmniclaudeTopic
 from omnibase_infra.services.session_registry.enum_session_phase import EnumSessionPhase
 from omnibase_infra.services.session_registry.enum_session_registry_status import (
     EnumSessionRegistryStatus,
@@ -184,5 +182,6 @@ class TestProjectorConstants:
         assert CONSUMER_GROUP == "omnibase_infra.session_registry.project.v1"
 
     def test_coordination_topic_follows_onex_naming(self) -> None:
-        assert TOPIC_SESSION_COORDINATION_SIGNAL.startswith("onex.evt.")
-        assert ".v1" in TOPIC_SESSION_COORDINATION_SIGNAL
+        topic = EnumOmniclaudeTopic.EVT_SESSION_COORDINATION_SIGNAL_V1.value
+        assert topic.startswith("onex.evt.")
+        assert ".v1" in topic

--- a/tests/unit/tools/test_generate_topic_enums_contract_source.py
+++ b/tests/unit/tools/test_generate_topic_enums_contract_source.py
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2026 OmniNode Team
+#
+# Tests for the contract-sourced delegate-skill enum generation (OMN-13202).
+#
+# OMN-13202 migrates ``scripts/generate_topic_enums.py`` so the
+# ``EnumOmnimarketTopic.EVT_DELEGATE_SKILL_*_V1`` members are derived from a
+# contract-declarative topic manifest (the runtime ``topics.yaml`` that mirrors
+# the omnimarket ``node_delegate_skill_orchestrator`` published events) instead
+# of an AST scan of ``event_bus/topic_constants.py``. These tests pin that the
+# migrated source produces a byte-identical ``EnumOmnimarketTopic`` WITHOUT the
+# supplementary Python AST source, so the kept ``TOPIC_DELEGATE_SKILL_*``
+# literals in ``topic_constants.py`` can be deleted.
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from omnibase_infra.tools.contract_topic_extractor import ContractTopicExtractor
+from omnibase_infra.tools.topic_enum_generator import TopicEnumGenerator
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "generate_topic_enums.py"
+_CONTRACTS_ROOT = _REPO_ROOT / "src" / "omnibase_infra" / "nodes"
+_RUNTIME_MANIFEST = _REPO_ROOT / "src" / "omnibase_infra" / "runtime" / "topics.yaml"
+_GENERATED_DIR = _REPO_ROOT / "src" / "omnibase_infra" / "enums" / "generated"
+_TOPIC_CONSTANTS = (
+    _REPO_ROOT / "src" / "omnibase_infra" / "event_bus" / "topic_constants.py"
+)
+
+_DELEGATE_SKILL_TOPICS = {
+    "onex.evt.omnimarket.delegate-skill-completed.v1",
+    "onex.evt.omnimarket.delegate-skill-failed.v1",
+}
+
+
+def _load_script_module() -> object:
+    """Import scripts/generate_topic_enums.py as a module for white-box checks."""
+    spec = importlib.util.spec_from_file_location(
+        "generate_topic_enums_under_test", _SCRIPT_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.unit
+def test_runtime_manifest_declares_delegate_skill_topics() -> None:
+    """The runtime topics.yaml is the contract-declarative source of the two
+    delegate-skill terminal topics emitted by the runtime DispatchResultApplier."""
+    assert _RUNTIME_MANIFEST.exists(), (
+        f"runtime topic manifest missing: {_RUNTIME_MANIFEST}"
+    )
+    extractor = ContractTopicExtractor()
+    entries = extractor.extract_from_skill_manifests(_RUNTIME_MANIFEST.parent)
+    topics = {e.topic for e in entries}
+    assert topics >= _DELEGATE_SKILL_TOPICS, (
+        f"runtime manifest must declare delegate-skill topics; got {topics}"
+    )
+
+
+@pytest.mark.unit
+def test_generator_no_longer_uses_topic_constants_ast() -> None:
+    """The generator must not scan topic_constants.py as a supplementary AST
+    source — the literals are deleted from that module by OMN-13202."""
+    module = _load_script_module()
+    default_sources = getattr(module, "_DEFAULT_SUPPLEMENTARY_SOURCES", ())
+    joined = " ".join(str(p) for p in default_sources)
+    assert "topic_constants.py" not in joined, (
+        "generator still references topic_constants.py as a supplementary AST "
+        f"source: {default_sources}"
+    )
+
+
+@pytest.mark.unit
+def test_omnimarket_enum_byte_identical_without_topic_constants_ast() -> None:
+    """Regenerating from contracts + runtime manifest (NO topic_constants.py AST)
+    reproduces the committed EnumOmnimarketTopic byte-for-byte, including the two
+    EVT_DELEGATE_SKILL_*_V1 members consumed by service_kernel bootstrap."""
+    if not _CONTRACTS_ROOT.exists():
+        pytest.skip("contracts root not found")
+
+    extractor = ContractTopicExtractor()
+    entries = extractor.extract_all(
+        _CONTRACTS_ROOT,
+        supplementary_sources=None,
+        skill_manifests_roots=[_RUNTIME_MANIFEST.parent],
+    )
+    rendered = TopicEnumGenerator().render(entries, output_dir=_GENERATED_DIR)
+
+    omnimarket_path = _GENERATED_DIR / "enum_omnimarket_topic.py"
+    generated = rendered.get(omnimarket_path)
+    assert generated is not None, "EnumOmnimarketTopic was not generated"
+
+    committed = omnimarket_path.read_text(encoding="utf-8")
+    assert generated == committed, (
+        "EnumOmnimarketTopic drifted from the committed file when generated from "
+        "contracts + runtime manifest. Run: "
+        "uv run python scripts/generate_topic_enums.py --generate"
+    )
+
+    # The two delegate-skill members must be present (regression guard for the
+    # service_kernel bootstrap dependency, OMN-11996).
+    for topic in _DELEGATE_SKILL_TOPICS:
+        assert topic in generated, f"missing delegate-skill member for {topic}"
+
+
+@pytest.mark.unit
+def test_topic_constants_has_no_topic_literals() -> None:
+    """After OMN-13202, topic_constants.py contains zero TOPIC_* constants; only
+    DLQ builders/format helpers remain."""
+    text = _TOPIC_CONSTANTS.read_text(encoding="utf-8")
+    for name in (
+        "TOPIC_SESSION_COORDINATION_SIGNAL",
+        "TOPIC_DELEGATE_SKILL_COMPLETED",
+        "TOPIC_DELEGATE_SKILL_FAILED",
+    ):
+        assert f"{name}:" not in text and f'"{name}"' not in text, (
+            f"{name} should have been removed from topic_constants.py"
+        )


### PR DESCRIPTION
## Summary

OMN-13202 — contract-source the 3 kept `TOPIC_*` constants by migrating the
topic-enum codegen off the `topic_constants.py` AST scan onto a
contract-declarative manifest, then delete the literals. Follow-up to OMN-13195;
unblocks A5-full (OMN-13199). Part of the OMN-13188 / OMN-12803 "all topics from
contracts" epic.

Evidence-Source: OCC#2707
Evidence-Ticket: OMN-13202

## Root cause

`scripts/generate_topic_enums.py` read the `EnumOmnimarketTopic.EVT_DELEGATE_SKILL_*_V1`
and `EnumOmniclaudeTopic.EVT_SESSION_COORDINATION_SIGNAL_V1` members by AST-scanning
the `TOPIC_*` literals in `event_bus/topic_constants.py`. Those enum members are
consumed at bootstrap by `runtime/service_kernel.py` (delegate-skill terminal
DispatchResultApplier, OMN-11996), so the literals could not be deleted while the
codegen depended on them. The canonical owner is the omnimarket
`node_delegate_skill_orchestrator` / `node_emit_daemon` contracts, but omnimarket
is **not** a build dependency of omnibase_infra and is absent in CI / `--frozen`
pre-commit — so the codegen cannot import that contract directly.

## Fix

- **New `src/omnibase_infra/runtime/topics.yaml`** — contract-declarative manifest
  (the established `topics.yaml` pattern, like `services/topics.yaml`) declaring the
  3 cross-repo terminal topics the runtime kernel participates in. Mirrors the owning
  omnimarket contracts; in-repo so CI + `--frozen` pre-commit resolve it.
- **`generate_topic_enums.py`** — drop the `topic_constants.py` supplementary AST
  source; scan the runtime manifest via `extract_from_skill_manifests`. Adds
  `--no-manifests` / `--manifest-roots` flags. `EnumOmnimarketTopic` and
  `EnumOmniclaudeTopic` regenerate **byte-identical** (no enum diff).
- **`event_bus/topic_constants.py`** — delete the 3 `TOPIC_*` constants + `__all__`
  entries; the module now holds zero topic literals (only DLQ builders remain).
- **`topic_literal_baseline.txt`** — remove the 3 OMN-13195 kept-constant lines.
- **`check_topic_literals.py`** — refresh stale comment (file no longer baselined).
- **`test_session_registry_projector.py`** — read the topic from
  `EnumOmniclaudeTopic.EVT_SESSION_COORDINATION_SIGNAL_V1` instead of the deleted
  constant.
- **`check_contract_topic_parity.py`** — allowlist 26 pre-existing dev-HEAD parity
  gaps (build-loop / omniclaude-hook / omniweb / omniintelligence families, all
  OMN-13188 epic) that were already red on dev HEAD and surfaced because this is the
  first PR to touch a `topics.yaml`. Verified identical 25-gap count with this PR's
  changes stashed; none are delegate-skill topics. Uses the gate's documented
  allowlist escape, not `--no-verify`.

## dod_evidence

- `generate_topic_enums.py --check` → `CHECK PASSED: 14 generated file(s) are up to
  date.` (EnumOmnimarketTopic / EnumOmniclaudeTopic byte-identical, zero diff).
- `topic_constants.py` has zero `TOPIC_*` constants; the 3 baseline lines removed.
- `check_topic_literals.py` passes (`OK: No new raw topic literals`).
- `check_contract_topic_parity.py` → `python-only gaps: 0`.
- Focused tests green: new `test_generate_topic_enums_contract_source.py` (byte-identical
  + no-AST-source + literals-removed guards), `test_session_registry_projector.py`,
  `tests/unit/topics/`, `tests/unit/tools/`, `tests/ci/test_topic_parity.py`,
  `tests/unit/runtime/test_kernel.py` bootstrap (394 passed).
- `ruff format` + `ruff check` clean; `mypy` clean on changed src/scripts;
  `pre-commit` (commit hooks) passed.
