### PR TITLE
fix(OMN-13199): A5 — un-allowlist topic_constants.py from topic-literal gate (fail-closed)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,8 +38,11 @@ repos:
   # OMN-13195 (phase A4): dropped the redundant `event_bus/topic_constants.py`
   # exclude — the hook already approves that basename via its internal
   # APPROVED_BASENAMES (check_hardcoded_topics.py), so the path-regex exclude was
-  # a no-op. The 3 remaining kept literals in that file stay covered by the hook's
-  # basename approval; full removal is the A5-full follow-up (OMN-13199).
+  # a no-op.
+  # OMN-13199 (phase A5): topic_constants.py is now fully un-allowlisted from the
+  # local topic-literal gate (check_topic_literals.py) after OMN-13202 deleted its
+  # last TOPIC_* literals. The file holds DLQ builders only and the gate now fails
+  # closed on any reintroduced literal — A5-full is complete.
   - repo: https://github.com/OmniNode-ai/onex_change_control
     rev: 8d7e85bc00e7f1b1306d1cb40949be1ab6e7e91a # pragma: allowlist secret
     hooks:
@@ -455,13 +458,17 @@ repos:
         always_run: true
         stages: [pre-commit]
       # OMN-3254: Topic enum drift check — verify generated enums include all topics
-      # from contracts AND supplementary sources (topic_constants.py)
+      # from contracts and the contract-declarative runtime/topics.yaml manifest.
+      # OMN-13199 (phase A5): dropped the `topic_constants.py` trigger — OMN-13202
+      # emptied generate_topic_enums.py's _DEFAULT_SUPPLEMENTARY_SOURCES, so the
+      # codegen no longer reads that file's AST; re-running the drift check on
+      # topic_constants.py changes was a dead trigger.
       - id: topic-enum-drift-check
         name: Topic Enum Drift Check
         entry: uv run --frozen python scripts/generate_topic_enums.py --check
         language: system
         types_or: [yaml, python]
-        files: (contract.*\.yaml|topic_constants\.py|enums/generated/)
+        files: (contract.*\.yaml|topics\.yaml|enums/generated/)
         pass_filenames: false
         stages: [pre-commit]
       # OMN-3777: Block cloud bus references in source code

--- a/scripts/validation/check_topic_literals.py
+++ b/scripts/validation/check_topic_literals.py
@@ -17,8 +17,9 @@
 #   - topics.py                           (canonical topic definition file)
 #   - platform_topic_suffixes.py          (canonical platform topic registry)
 #   - contract.yaml                       (contract definitions, not Python)
-#   NOTE: topic_constants.py is NO LONGER whole-file excluded (OMN-13195/A4); its
-#   3 remaining kept literals are suppressed per-line in the baseline instead.
+#   NOTE: topic_constants.py is fully scanned (OMN-13195/A4 narrowed the exemption;
+#   OMN-13202 deleted its last literals; OMN-13199/A5 finished the un-allowlisting).
+#   It holds DLQ builders only; the gate fails closed on any reintroduced literal.
 #
 # Pre-existing violations that were present before OMN-3343 are suppressed
 # via `scripts/validation/topic_literal_baseline.txt`. New violations added
@@ -57,10 +58,12 @@ _TOPIC_PATTERN = re.compile(r"^onex\.(evt|cmd)\.[a-z][a-z0-9._-]*$")
 # file (TOPIC_SESSION_COORDINATION_SIGNAL + the two TOPIC_DELEGATE_SKILL_*
 # codegen-AST sources) after migrating the enum codegen to read the
 # contract-declarative ``runtime/topics.yaml`` manifest, and removed their per-line
-# entries from ``topic_literal_baseline.txt``. ``topic_constants.py`` now contains
-# zero raw topic literals and needs no exemption here. Removing it from the
-# ``.pre-commit-config.yaml`` allowlist (if any redundancy remains) is the A5-full
-# follow-up (OMN-13199).
+# entries from ``topic_literal_baseline.txt``. OMN-13199 (phase A5) completed the
+# un-allowlisting: ``topic_constants.py`` is fully scanned by this gate (it is not
+# in ``_EXCLUDED_FILENAMES`` below), holds zero raw topic literals (DLQ builders
+# only), and the gate fails closed on any reintroduced literal — proven by
+# ``tests/unit/scripts/validation/test_check_topic_literals_fail_closed.py``.
+# No ``.pre-commit-config.yaml`` exemption for this file remains.
 _EXCLUDED_FILENAMES: frozenset[str] = frozenset(
     {
         "topics.py",

--- a/scripts/validation/topic_literal_baseline.txt
+++ b/scripts/validation/topic_literal_baseline.txt
@@ -7,9 +7,10 @@
 # exemptions: the TOPIC_SESSION_COORDINATION_SIGNAL and TOPIC_DELEGATE_SKILL_*
 # constants were deleted after the enum codegen was migrated to read the
 # contract-declarative runtime/topics.yaml manifest. topic_constants.py now holds
-# zero TOPIC_* literals (only DLQ builders/format helpers remain). Full
-# un-allowlisting of the file from check_topic_literals.py _EXCLUDED_FILENAMES is
-# tracked separately in OMN-13199 (A5).
+# zero TOPIC_* literals (only DLQ builders/format helpers remain). OMN-13199 (A5)
+# completed the un-allowlisting: topic_constants.py is not in
+# check_topic_literals.py _EXCLUDED_FILENAMES and has no entries in this baseline;
+# the gate fails closed on any reintroduced literal in that file.
 # Total entries: 123 grandfathered
 src/omnibase_infra/cli/git_hook_relay.py:72
 src/omnibase_infra/cli/git_hook_relay.py:74

--- a/tests/unit/scripts/validation/test_check_topic_literals_fail_closed.py
+++ b/tests/unit/scripts/validation/test_check_topic_literals_fail_closed.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Fail-closed proof for the topic-literal gate on topic_constants.py (OMN-13199 / A5).
+
+OMN-13199 (phase A5) completed the un-allowlisting of
+``src/omnibase_infra/event_bus/topic_constants.py`` from the local topic-literal
+gate (``scripts/validation/check_topic_literals.py``). The prerequisite work
+(OMN-13195/A4 narrowing the exemption, OMN-13202 deleting the last ``TOPIC_*``
+literals and migrating the enum codegen to read ``runtime/topics.yaml``) left the
+file holding only DLQ builder logic.
+
+These tests lock that state in permanently:
+
+1. ``topic_constants.py`` is NOT whole-file exempt — its basename is absent from
+   ``_EXCLUDED_FILENAMES``, so the gate actually scans it.
+2. The real ``topic_constants.py`` is literal-free (the gate passes on it today).
+3. The gate FAILS CLOSED — reintroducing a bare topic literal under that basename
+   makes ``main()`` return exit code 1, so a future regression is blocked at CI /
+   pre-commit time rather than silently allowed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.validation.check_topic_literals import (
+    _EXCLUDED_FILENAMES,
+    collect_files,
+    find_topic_literals,
+    main,
+)
+
+_TOPIC_CONSTANTS_BASENAME = "topic_constants.py"
+# Repo root resolved relative to this test file: tests/unit/scripts/validation/ -> repo root
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_REAL_TOPIC_CONSTANTS = (
+    _REPO_ROOT / "src" / "omnibase_infra" / "event_bus" / _TOPIC_CONSTANTS_BASENAME
+)
+
+
+@pytest.mark.unit
+def test_topic_constants_not_whole_file_exempt() -> None:
+    """topic_constants.py must not be in the gate's whole-file exemption set.
+
+    Locks the OMN-13199/A5 outcome: the file is fully un-allowlisted, so any
+    reintroduced literal is scanned (not silently skipped).
+    """
+    assert _TOPIC_CONSTANTS_BASENAME not in _EXCLUDED_FILENAMES
+
+
+@pytest.mark.unit
+def test_topic_constants_is_scanned_by_the_gate() -> None:
+    """The real topic_constants.py is included in the gate's scan set."""
+    if not _REAL_TOPIC_CONSTANTS.exists():
+        pytest.skip(f"{_REAL_TOPIC_CONSTANTS} not found")
+    src_root = _REPO_ROOT / "src"
+    scanned = collect_files(src_root)
+    assert _REAL_TOPIC_CONSTANTS in scanned
+
+
+@pytest.mark.unit
+def test_real_topic_constants_is_literal_free() -> None:
+    """The real topic_constants.py holds no raw topic literals (DLQ builders only)."""
+    if not _REAL_TOPIC_CONSTANTS.exists():
+        pytest.skip(f"{_REAL_TOPIC_CONSTANTS} not found")
+    hits = find_topic_literals(_REAL_TOPIC_CONSTANTS)
+    assert hits == [], f"Unexpected raw topic literals in topic_constants.py: {hits}"
+
+
+@pytest.mark.unit
+def test_gate_fails_closed_on_reintroduced_literal(tmp_path: Path) -> None:
+    """A reintroduced bare topic literal under topic_constants.py fails the gate.
+
+    Copies the real file into a temporary ``src/`` tree, appends a module-level
+    topic literal assignment, and asserts ``main()`` returns 1 (fail-closed).
+    """
+    if not _REAL_TOPIC_CONSTANTS.exists():
+        pytest.skip(f"{_REAL_TOPIC_CONSTANTS} not found")
+
+    src_root = tmp_path / "src" / "omnibase_infra" / "event_bus"
+    src_root.mkdir(parents=True)
+    target = src_root / _TOPIC_CONSTANTS_BASENAME
+    body = _REAL_TOPIC_CONSTANTS.read_text(encoding="utf-8")
+    body += (
+        '\n_OMN13199_FAIL_CLOSED_PROOF = "onex.evt.omnimarket.fail-closed-proof.v1"\n'
+    )
+    target.write_text(body, encoding="utf-8")
+
+    empty_baseline = tmp_path / "baseline.txt"
+    empty_baseline.write_text("# no suppressions\n", encoding="utf-8")
+
+    exit_code = main(src_dir=tmp_path / "src", baseline_path=empty_baseline)
+    assert exit_code == 1, (
+        "gate must FAIL when a literal is reintroduced in topic_constants.py"
+    )
+
+
+@pytest.mark.unit
+def test_gate_passes_on_clean_topic_constants_copy(tmp_path: Path) -> None:
+    """The unmodified topic_constants.py passes the gate in an isolated tree."""
+    if not _REAL_TOPIC_CONSTANTS.exists():
+        pytest.skip(f"{_REAL_TOPIC_CONSTANTS} not found")
+
+    src_root = tmp_path / "src" / "omnibase_infra" / "event_bus"
+    src_root.mkdir(parents=True)
+    target = src_root / _TOPIC_CONSTANTS_BASENAME
+    target.write_text(
+        _REAL_TOPIC_CONSTANTS.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+
+    empty_baseline = tmp_path / "baseline.txt"
+    empty_baseline.write_text("# no suppressions\n", encoding="utf-8")
+
+    exit_code = main(src_dir=tmp_path / "src", baseline_path=empty_baseline)
+    assert exit_code == 0, (
+        "gate must PASS on the clean, literal-free topic_constants.py"
+    )


### PR DESCRIPTION
## Summary

OMN-13199 — phase A5 (LAST) of the contract-sourced-topics platform-debt epic (OMN-13188). Completes the un-allowlisting of `event_bus/topic_constants.py` from the local topic-literal gate so the gate is fully enforced on that file and fails closed on any reintroduced literal.

Evidence-Source: OCC#2713
Evidence-Ticket: OMN-13199

## State on dev before this PR

The ticket's two literal exit criteria were already partially satisfied by upstream phases (both merged to dev):

- **OMN-13195 / A4 (#2006)** removed `topic_constants.py` from `check_topic_literals.py` `_EXCLUDED_FILENAMES` (narrowed the whole-file exemption to per-line baseline entries) and fixed the false-green guard for multiline imports.
- **OMN-13202 (#2017)** deleted the last `TOPIC_*` literals from `topic_constants.py` (migrating the enum codegen to read the contract-declarative `runtime/topics.yaml` manifest) and removed the 3 per-line baseline entries.

So on dev HEAD, `topic_constants.py` is already (a) absent from `_EXCLUDED_FILENAMES`, (b) literal-free, and (c) absent from `topic_literal_baseline.txt`. The residual A5 work was the remaining `.pre-commit-config.yaml` reference, the stale documentation, and the missing fail-closed regression test.

## Fix

- **`.pre-commit-config.yaml`** — dropped the now-dead `topic_constants\.py` trigger from the `topic-enum-drift-check` `files:` regex (OMN-13202 emptied `generate_topic_enums.py`'s `_DEFAULT_SUPPLEMENTARY_SOURCES`, so the codegen no longer reads that file's AST; re-running drift on its changes was a dead trigger). Retargeted to `topics\.yaml` (the real contract-declarative codegen source). Refreshed the stale `no-hardcoded-topics` comment to record A5 completion.
- **`scripts/validation/check_topic_literals.py`** — refreshed the header and `_EXCLUDED_FILENAMES` comments to record that `topic_constants.py` is now fully scanned, holds DLQ builders only, and the gate fails closed.
- **`scripts/validation/topic_literal_baseline.txt`** — refreshed header to reflect A5 done (no `topic_constants.py` entries; none needed).
- **`tests/unit/scripts/validation/test_check_topic_literals_fail_closed.py`** (new) — permanent regression test: (a) `topic_constants.py` not in `_EXCLUDED_FILENAMES`, (b) it is scanned by `collect_files`, (c) the real file is literal-free, (d) reintroducing a bare literal makes `main()` return exit 1 (fail-closed), (e) the clean copy passes.

No code behavior change in `topic_constants.py` itself; this PR closes the gate and proves it fails closed.

## dod_evidence

- **POSITIVE proof** — `uv run python scripts/validation/check_topic_literals.py` → `OK: No new raw topic literals found in 2417 file(s)`, exit 0. `collect_files` includes `src/omnibase_infra/event_bus/topic_constants.py` (scanned: True), `find_topic_literals` returns `[]` for it.
- **NEGATIVE / fail-closed proof** — appending a module-level literal `_OMN13199_FAIL_CLOSED_PROOF = "onex.evt.omnimarket.fail-closed-proof.v1"` to `topic_constants.py` makes the gate print `FAIL: Found 1 new raw topic literal(s)` at line 479 and return **exit 1**; reverting restores exit 0.
- **topic-enum-drift-check** — `uv run python scripts/generate_topic_enums.py --check` → `CHECK PASSED: 14 generated file(s) are up to date`, exit 0 (unchanged with the retargeted `files:` regex).
- **ruff** format + check clean; **mypy** clean on changed `scripts/` + test files.
- **Tests** — 5 new fail-closed tests pass; 182 validation + topic-tooling tests pass (1 pre-existing path-resolution skip).
- **pre-commit** `run --files <all changed>` → all hooks Passed.

## Required-check discipline

This touches required CI status checks (the topic-literal gate is now enforced on `topic_constants.py`). Per house policy: serial, additive-verify-each, no skip tokens. The gate config + hook output are cited above. No `--no-verify`, no `[skip-*]` token used.
