### PR TITLE
fix(OMN-13214): enqueue + verify armed PRs into merge queue (port from omnimarket)

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -13,6 +13,19 @@
 # Stacked PRs target feature branches that do not have protected-branch
 # auto-merge rules. Treat those as an expected no-op instead of failing
 # the required auto-merge enrollment check.
+#
+# OMN-13214: Arming auto-merge is NOT the same as enqueuing. During the
+# 2026-06-17 dev merge wave, CLEAN + all-required-green + armed PRs sat
+# OUTSIDE the merge queue for hours and each needed a manual
+# enqueuePullRequest to land. The previous "--auto --squash" arming is also
+# REJECTED on the queue-controlled dev branch ("The merge strategy for dev is
+# set by the merge queue") so the PR never even armed. This workflow now
+# (a) arms bare --auto, (b) runs gh pr update-branch first on strict-update
+# repos when the PR is BEHIND, (c) explicitly calls enqueuePullRequest, and
+# (d) VERIFIES the PR actually entered the queue — failing loudly if a
+# green+armed PR is not enqueued, so the gap surfaces instead of stalling
+# silently. The classify/verify decision logic is unit-tested in
+# scripts/ci/merge_queue_enqueue.py.
 name: Auto-Merge
 
 on:
@@ -84,16 +97,26 @@ jobs:
           DEFAULT_BRANCH="$(gh repo view "$GH_REPO" --json defaultBranchRef --jq '.defaultBranchRef.name')"
           if [ "$BASE_REF" != "$DEFAULT_BRANCH" ]; then
             echo "PR #$PR targets '$BASE_REF', not default '$DEFAULT_BRANCH'; skipping auto-merge enrollment for stacked PR"
-            echo "pr=$PR" >> "$GITHUB_OUTPUT"
-            echo "actor=$ACTOR" >> "$GITHUB_OUTPUT"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "pr=$PR"
+              echo "actor=$ACTOR"
+              echo "skip=true"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          echo "pr=$PR" >> "$GITHUB_OUTPUT"
-          echo "actor=$ACTOR" >> "$GITHUB_OUTPUT"
-          echo "skip=false" >> "$GITHUB_OUTPUT"
+          {
+            echo "pr=$PR"
+            echo "actor=$ACTOR"
+            echo "skip=false"
+          } >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@v6
+
+      - name: Set up Python 3.12
+        if: steps.resolve.outputs.skip != 'true' && steps.resolve.outputs.actor == 'jonahgabriel'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
 
       - name: Enable auto-merge
         if: steps.resolve.outputs.skip != 'true' && steps.resolve.outputs.actor == 'jonahgabriel'
@@ -103,13 +126,136 @@ jobs:
           PR: ${{ steps.resolve.outputs.pr }}
         run: |
           set -euo pipefail
-          if output=$(gh pr merge "$PR" --repo "$GH_REPO" --auto --squash 2>&1); then
+          # OMN-13214: dev is queue-controlled — the merge method is set by the merge
+          # queue, so passing an explicit --squash is rejected ("The merge strategy for
+          # dev is set by the merge queue") and the PR is NEVER enqueued (sits CLEAN +
+          # auto-merge armed forever). Use bare --auto and let the queue pick the method.
+          # Arming alone does not enqueue — the explicit enqueue + verify step below
+          # closes that gap. Do NOT exit here on success.
+          if output=$(gh pr merge "$PR" --repo "$GH_REPO" --auto 2>&1); then
             echo "auto-merge enabled: $output"
-            exit 0
-          fi
-          if echo "$output" | grep -qiE "already enqueued|already queued|auto-merge already enabled"; then
+          elif echo "$output" | grep -qiE "already enqueued|already queued|auto-merge already enabled"; then
             echo "auto-merge not newly enabled (expected): $output"
-            exit 0
+          else
+            echo "auto-merge failed: $output"
+            exit 1
           fi
-          echo "auto-merge failed: $output"
+
+      - name: Enqueue armed PR and verify it entered the queue
+        if: steps.resolve.outputs.skip != 'true' && steps.resolve.outputs.actor == 'jonahgabriel'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR: ${{ steps.resolve.outputs.pr }}
+        run: |
+          set -euo pipefail
+          OWNER="${GH_REPO%/*}"
+          NAME="${GH_REPO#*/}"
+
+          classify() {
+            python3 scripts/ci/merge_queue_enqueue.py classify \
+              --pr-json "$1" --strict-update "$2"
+          }
+
+          # Is the target (default) branch strict-update? On strict repos a BEHIND
+          # PR cannot enqueue until its branch is updated.
+          DEFAULT_BRANCH="$(gh repo view "$GH_REPO" --json defaultBranchRef --jq '.defaultBranchRef.name')"
+          STRICT="$(gh api "repos/${GH_REPO}/branches/${DEFAULT_BRANCH}/protection/required_status_checks" \
+            --jq '.strict' 2>/dev/null || echo "false")"
+          [ "$STRICT" = "true" ] || STRICT="false"
+          echo "strict-update on '${DEFAULT_BRANCH}': ${STRICT}"
+
+          fetch_pr() {
+            # isInMergeQueue is only on the GraphQL PullRequest object, NOT a
+            # `gh pr view --json` field, so fetch PR state via GraphQL.
+            # shellcheck disable=SC2016  # $owner/$name/$number are GraphQL vars, not shell vars
+            gh api graphql \
+              -f owner="$OWNER" \
+              -f name="$NAME" \
+              -F number="$PR" \
+              -f query='
+                query($owner:String!, $name:String!, $number:Int!) {
+                  repository(owner: $owner, name: $name) {
+                    pullRequest(number: $number) {
+                      isInMergeQueue
+                      mergeStateStatus
+                      mergeable
+                      autoMergeRequest {
+                        enabledAt
+                      }
+                    }
+                  }
+                }' \
+              --jq '.data.repository.pullRequest'
+          }
+
+          PR_JSON="$(fetch_pr)"
+          ACTION="$(classify "$PR_JSON" "$STRICT")"
+          echo "classified action: ${ACTION}"
+
+          case "$ACTION" in
+            already_queued)
+              echo "PR #${PR} already in the merge queue — nothing to do."
+              exit 0
+              ;;
+            wait)
+              echo "PR #${PR} is not enqueueable yet (BLOCKED/DIRTY/DRAFT/UNKNOWN); will re-fire on next event."
+              exit 0
+              ;;
+            blocked)
+              echo "::warning::PR #${PR} in an unrecognised merge state: $(printf '%s' "$PR_JSON" | jq -r '.mergeStateStatus'). Not enqueuing."
+              exit 0
+              ;;
+            update_branch_then_enqueue)
+              echo "PR #${PR} is BEHIND on a strict-update repo — updating branch before enqueue (OMN-13214 branch-behind case)."
+              if ! gh pr update-branch "$PR" --repo "$GH_REPO" 2>&1; then
+                echo "::warning::update-branch reported no change or a benign error; continuing."
+              fi
+              echo "update-branch issued; the resulting check run re-fires this workflow when CI is green."
+              exit 0
+              ;;
+            enqueue)
+              : # fall through to enqueue below
+              ;;
+            *)
+              echo "::error::unexpected action '${ACTION}' from classifier"
+              exit 1
+              ;;
+          esac
+
+          PR_ID="$(gh api graphql -f query='{repository(owner:"'"$OWNER"'",name:"'"$NAME"'"){pullRequest(number:'"$PR"'){id}}}' --jq '.data.repository.pullRequest.id')"
+          if [ -z "$PR_ID" ] || [ "$PR_ID" = "null" ]; then
+            echo "::error::could not resolve PR node id for #${PR}"
+            exit 1
+          fi
+
+          # shellcheck disable=SC2016  # $prId is a GraphQL variable, not a shell var
+          if enq_out=$(gh api graphql -f query='mutation($prId:ID!){enqueuePullRequest(input:{pullRequestId:$prId}){mergeQueueEntry{position}}}' -f prId="$PR_ID" 2>&1); then
+            echo "enqueue issued: ${enq_out}"
+          else
+            if echo "$enq_out" | grep -qiE "merge queue (is )?not enabled|does not have a merge queue|merge_queue_not_enabled"; then
+              echo "repo has no merge queue — arming auto-merge is sufficient: ${enq_out}"
+              exit 0
+            fi
+            if echo "$enq_out" | grep -qiE "already (in|enqueued|queued)|in the merge queue"; then
+              echo "benign enqueue race (already queued): ${enq_out}"
+            else
+              echo "::error::enqueuePullRequest failed for #${PR}: ${enq_out}"
+              exit 1
+            fi
+          fi
+
+          # OMN-13214 ENFORCEMENT: verify the PR actually entered the queue.
+          # Poll briefly — GitHub may take a few seconds to reflect the entry.
+          for attempt in 1 2 3 4 5; do
+            sleep 6
+            PR_AFTER="$(fetch_pr)"
+            if python3 scripts/ci/merge_queue_enqueue.py verify --pr-json "$PR_AFTER"; then
+              echo "VERIFIED: PR #${PR} is in the merge queue."
+              exit 0
+            fi
+            echo "not yet in queue (attempt ${attempt}/5); state=$(printf '%s' "$PR_AFTER" | jq -r '.mergeStateStatus')"
+          done
+
+          echo "::error::PR #${PR} is green + armed but did NOT enter the merge queue after enqueue (OMN-13214 armed-but-not-enqueued). Manual intervention required."
           exit 1

--- a/scripts/ci/merge_queue_enqueue.py
+++ b/scripts/ci/merge_queue_enqueue.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Reliable merge-queue enqueue decision logic (OMN-13214).
+
+Root cause this module addresses
+--------------------------------
+During the 2026-06-17 dev merge wave, many PRs reached ``mergeStateStatus=CLEAN``
+with all required checks green AND auto-merge armed (by the "Enable Auto-Merge"
+GitHub Actions job), yet never entered the dev merge queue. Each one needed a
+manual ``enqueuePullRequest`` GraphQL mutation (or a disable+re-arm with bare
+``--auto``) to actually land.
+
+Arming auto-merge is **not** the same as enqueuing. On a queue-controlled repo a
+PR can sit CLEAN + armed indefinitely without GitHub ever placing it in the
+queue. The reliable path is an explicit ``enqueuePullRequest`` after arming,
+followed by a verification that the PR actually entered the queue. On
+strict-update (require-branches-up-to-date) repos a branch-behind PR silently
+blocks enqueue with no auto ``update-branch`` step.
+
+This module is the deterministic, unit-tested core of the workflow step. The
+``auto-merge.yml`` workflow shells out to it to decide what action to take and to
+verify the outcome; all the branching that is worth testing in isolation lives
+here rather than in untestable bash.
+
+The module performs **no** network I/O. The workflow is responsible for fetching
+PR JSON via ``gh`` and passing it in; this module only classifies and decides.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from enum import StrEnum
+from typing import Any
+
+
+class EnumEnqueueAction(StrEnum):
+    """The action the workflow should take for a PR, derived from its state."""
+
+    ALREADY_QUEUED = "already_queued"
+    UPDATE_BRANCH_THEN_ENQUEUE = "update_branch_then_enqueue"
+    ENQUEUE = "enqueue"
+    WAIT = "wait"
+    BLOCKED = "blocked"
+
+
+# mergeStateStatus values that mean "GitHub will not let this PR merge / enqueue
+# right now for a reason that is not a transient branch-behind". These are not
+# our bug to fix; the workflow waits and re-fires on the next event.
+_NON_ENQUEUEABLE_STATES = frozenset(
+    {
+        "BLOCKED",  # required checks pending/failing or required review missing
+        "DIRTY",  # merge conflict
+        "DRAFT",  # draft PR
+        "UNKNOWN",  # GitHub still computing mergeability
+    }
+)
+
+# gh / GraphQL error fragments that mean the repo simply has no merge queue.
+# Enqueue is a no-op there; arming auto-merge is sufficient.
+_NO_MERGE_QUEUE_MARKERS = (
+    "does not have a merge queue",
+    "merge queue is not enabled",
+    "merge_queue_not_enabled",
+    "merge queue not enabled",
+)
+
+# gh / GraphQL error fragments that are benign races — the PR is already on its
+# way into the queue, or a concurrent run already enqueued it.
+_BENIGN_ENQUEUE_MARKERS = (
+    "already enqueued",
+    "already queued",
+    "already in the merge queue",
+    "is already queued",
+    "pull request is in the merge queue",
+)
+
+
+def _truthy(value: Any) -> bool:
+    """Coerce a JSON-ish value to bool without surprising falsy strings."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"true", "1", "yes"}
+    return bool(value)
+
+
+def is_no_merge_queue_error(message: str) -> bool:
+    """True when an enqueue error means the repo has no merge queue (benign)."""
+    lowered = message.lower()
+    return any(marker in lowered for marker in _NO_MERGE_QUEUE_MARKERS)
+
+
+def is_benign_enqueue_error(message: str) -> bool:
+    """True when an enqueue error is a benign already-queued race (benign)."""
+    lowered = message.lower()
+    return any(marker in lowered for marker in _BENIGN_ENQUEUE_MARKERS)
+
+
+def is_armed(pr: dict[str, Any]) -> bool:
+    """True when auto-merge is armed on the PR.
+
+    ``gh pr view --json autoMergeRequest`` returns ``null`` when not armed and an
+    object (with ``enabledBy``/``mergeMethod``) when armed.
+    """
+    return pr.get("autoMergeRequest") not in (None, {}, "")
+
+
+def is_in_queue(pr: dict[str, Any]) -> bool:
+    """True when the PR is already in the merge queue."""
+    return _truthy(pr.get("isInMergeQueue"))
+
+
+def is_behind(pr: dict[str, Any]) -> bool:
+    """True when the PR head is behind its base (strict-update would block it).
+
+    ``mergeStateStatus == BEHIND`` is the authoritative GitHub signal. We also
+    treat an explicit ``behind`` integer (from a compare API) as behind.
+    """
+    if str(pr.get("mergeStateStatus", "")).upper() == "BEHIND":
+        return True
+    behind = pr.get("behind")
+    return isinstance(behind, int) and behind > 0
+
+
+def classify_pr(pr: dict[str, Any], *, strict_update: bool) -> EnumEnqueueAction:
+    """Decide what to do with a PR based on its current GitHub state.
+
+    Args:
+        pr: ``gh pr view --json ...`` payload (isInMergeQueue, mergeStateStatus,
+            autoMergeRequest, mergeable, behind).
+        strict_update: True when the target branch requires branches to be up to
+            date before merging (require_status_checks.strict). On such repos a
+            BEHIND PR must be updated before it can enqueue.
+
+    Returns:
+        The action the workflow should take.
+    """
+    if is_in_queue(pr):
+        return EnumEnqueueAction.ALREADY_QUEUED
+
+    state = str(pr.get("mergeStateStatus", "")).upper()
+
+    # A branch-behind PR on a strict-update repo cannot enqueue until updated.
+    # On a non-strict repo BEHIND does not block enqueue, so fall through.
+    if is_behind(pr) and strict_update:
+        return EnumEnqueueAction.UPDATE_BRANCH_THEN_ENQUEUE
+
+    # CLEAN / HAS_HOOKS / UNSTABLE-but-mergeable: ready to enqueue.
+    # (UNSTABLE = non-required checks failing; required checks still green.)
+    if state in {"CLEAN", "HAS_HOOKS", "UNSTABLE"}:
+        return EnumEnqueueAction.ENQUEUE
+
+    # BEHIND on a non-strict repo: GitHub allows the queue to merge it; enqueue.
+    if state == "BEHIND":
+        return EnumEnqueueAction.ENQUEUE
+
+    if state in _NON_ENQUEUEABLE_STATES:
+        # BLOCKED/DIRTY/DRAFT/UNKNOWN: not our bug — wait for the next event.
+        return EnumEnqueueAction.WAIT
+
+    # Unrecognised state: do not silently enqueue; surface as blocked so the
+    # workflow logs it rather than masking a new GitHub state.
+    return EnumEnqueueAction.BLOCKED
+
+
+def verify_enqueued(pr_after: dict[str, Any]) -> bool:
+    """Confirm a PR actually entered the queue after an enqueue attempt.
+
+    This is the enforcement check that distinguishes "armed" from "actually
+    enqueued" — the exact gap OMN-13214 closes.
+    """
+    return is_in_queue(pr_after)
+
+
+def _load_pr(raw: str) -> dict[str, Any]:
+    payload = json.loads(raw)
+    if not isinstance(payload, dict):
+        raise ValueError("PR JSON must be an object")
+    return payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI surface for the workflow.
+
+    Subcommands:
+        classify  --pr-json <json> --strict-update <true|false>
+            Prints the EnumEnqueueAction value to stdout.
+        verify    --pr-json <json>
+            Exit 0 if the PR is in the queue, exit 1 otherwise.
+    """
+    parser = argparse.ArgumentParser(description="Merge-queue enqueue decision logic")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_classify = sub.add_parser("classify", help="Classify a PR into an action")
+    p_classify.add_argument("--pr-json", required=True)
+    p_classify.add_argument("--strict-update", default="false")
+
+    p_verify = sub.add_parser("verify", help="Verify a PR actually entered the queue")
+    p_verify.add_argument("--pr-json", required=True)
+
+    args = parser.parse_args(argv)
+
+    if args.command == "classify":
+        pr = _load_pr(args.pr_json)
+        action = classify_pr(pr, strict_update=_truthy(args.strict_update))
+        sys.stdout.write(action.value + "\n")
+        return 0
+
+    if args.command == "verify":
+        pr = _load_pr(args.pr_json)
+        if verify_enqueued(pr):
+            sys.stdout.write("in_queue\n")
+            return 0
+        sys.stdout.write("not_in_queue\n")
+        return 1
+
+    parser.error(f"unknown command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ci/test_merge_queue_enqueue.py
+++ b/tests/ci/test_merge_queue_enqueue.py
@@ -1,0 +1,190 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for the merge-queue enqueue decision logic (OMN-13214).
+
+These tests pin the exact armed-but-not-enqueued failure modes observed in the
+2026-06-17 dev wave:
+
+* CLEAN + armed but isInMergeQueue=false  -> ENQUEUE (the core bug).
+* CLEAN + already in queue                -> ALREADY_QUEUED (no double-enqueue).
+* BEHIND on a strict-update repo (#1245)  -> UPDATE_BRANCH_THEN_ENQUEUE.
+* BEHIND on a non-strict repo             -> ENQUEUE (GitHub queue updates it).
+* BLOCKED / DIRTY / DRAFT / UNKNOWN       -> WAIT (not our bug).
+* verify_enqueued reflects isInMergeQueue.
+* error-message classification (no-queue / benign race).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[2] / "scripts" / "ci" / "merge_queue_enqueue.py"
+)
+
+
+def _load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("merge_queue_enqueue", _SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+mod = _load_module()
+Action = mod.EnumEnqueueAction
+
+
+def _pr(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "isInMergeQueue": False,
+        "mergeStateStatus": "CLEAN",
+        "autoMergeRequest": {"mergeMethod": "SQUASH", "enabledBy": {"login": "x"}},
+        "mergeable": "MERGEABLE",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestClassifyPr:
+    def test_clean_armed_not_in_queue_enqueues(self) -> None:
+        # The exact #1243/#1244/#1249 state: CLEAN + armed + queue empty.
+        assert mod.classify_pr(_pr(), strict_update=False) is Action.ENQUEUE
+
+    def test_clean_armed_not_in_queue_enqueues_strict(self) -> None:
+        assert mod.classify_pr(_pr(), strict_update=True) is Action.ENQUEUE
+
+    def test_already_in_queue_is_noop(self) -> None:
+        pr = _pr(isInMergeQueue=True)
+        assert mod.classify_pr(pr, strict_update=True) is Action.ALREADY_QUEUED
+
+    def test_in_queue_takes_priority_over_behind(self) -> None:
+        pr = _pr(isInMergeQueue=True, mergeStateStatus="BEHIND")
+        assert mod.classify_pr(pr, strict_update=True) is Action.ALREADY_QUEUED
+
+    def test_behind_strict_update_requires_branch_update(self) -> None:
+        # The #1245 state: behind:3/4 on strict-update omnimarket.
+        pr = _pr(mergeStateStatus="BEHIND", behind=3)
+        assert (
+            mod.classify_pr(pr, strict_update=True) is Action.UPDATE_BRANCH_THEN_ENQUEUE
+        )
+
+    def test_behind_non_strict_enqueues_directly(self) -> None:
+        pr = _pr(mergeStateStatus="BEHIND", behind=3)
+        assert mod.classify_pr(pr, strict_update=False) is Action.ENQUEUE
+
+    def test_behind_integer_signal_without_state(self) -> None:
+        pr = _pr(mergeStateStatus="CLEAN", behind=2)
+        assert (
+            mod.classify_pr(pr, strict_update=True) is Action.UPDATE_BRANCH_THEN_ENQUEUE
+        )
+
+    @pytest.mark.parametrize("state", ["BLOCKED", "DIRTY", "DRAFT", "UNKNOWN"])
+    def test_non_enqueueable_states_wait(self, state: str) -> None:
+        pr = _pr(mergeStateStatus=state)
+        assert mod.classify_pr(pr, strict_update=False) is Action.WAIT
+
+    @pytest.mark.parametrize("state", ["HAS_HOOKS", "UNSTABLE"])
+    def test_mergeable_states_enqueue(self, state: str) -> None:
+        pr = _pr(mergeStateStatus=state)
+        assert mod.classify_pr(pr, strict_update=False) is Action.ENQUEUE
+
+    def test_unrecognised_state_is_blocked_not_silently_enqueued(self) -> None:
+        pr = _pr(mergeStateStatus="SOME_NEW_GITHUB_STATE")
+        assert mod.classify_pr(pr, strict_update=False) is Action.BLOCKED
+
+    def test_unarmed_clean_pr_still_enqueues(self) -> None:
+        # Arming and enqueue are independent; the workflow arms first. classify
+        # only decides enqueue eligibility from merge state, not armed-ness.
+        pr = _pr(autoMergeRequest=None)
+        assert mod.classify_pr(pr, strict_update=False) is Action.ENQUEUE
+
+
+class TestArmedHelpers:
+    def test_is_armed_true_for_object(self) -> None:
+        assert mod.is_armed(_pr()) is True
+
+    def test_is_armed_false_for_null(self) -> None:
+        assert mod.is_armed(_pr(autoMergeRequest=None)) is False
+
+    def test_is_armed_false_for_empty(self) -> None:
+        assert mod.is_armed(_pr(autoMergeRequest={})) is False
+
+
+class TestVerifyEnqueued:
+    def test_verify_true_when_in_queue(self) -> None:
+        assert mod.verify_enqueued({"isInMergeQueue": True}) is True
+
+    def test_verify_false_when_not_in_queue(self) -> None:
+        assert mod.verify_enqueued({"isInMergeQueue": False}) is False
+
+    def test_verify_false_when_field_missing(self) -> None:
+        assert mod.verify_enqueued({}) is False
+
+
+class TestErrorClassification:
+    @pytest.mark.parametrize(
+        "msg",
+        [
+            "Repository does not have a merge queue",
+            "merge queue is not enabled for this branch",
+            "MERGE_QUEUE_NOT_ENABLED",
+        ],
+    )
+    def test_no_queue_markers(self, msg: str) -> None:
+        assert mod.is_no_merge_queue_error(msg) is True
+        assert mod.is_benign_enqueue_error(msg) is False
+
+    @pytest.mark.parametrize(
+        "msg",
+        [
+            "Pull request is already enqueued",
+            "PR is already queued",
+            "pull request is in the merge queue",
+        ],
+    )
+    def test_benign_markers(self, msg: str) -> None:
+        assert mod.is_benign_enqueue_error(msg) is True
+        assert mod.is_no_merge_queue_error(msg) is False
+
+    def test_unrelated_error_is_neither(self) -> None:
+        msg = "GraphQL: Something unexpected happened"
+        assert mod.is_no_merge_queue_error(msg) is False
+        assert mod.is_benign_enqueue_error(msg) is False
+
+
+class TestCli:
+    def test_classify_cli_prints_action(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        rc = mod.main(
+            ["classify", "--pr-json", json.dumps(_pr()), "--strict-update", "false"]
+        )
+        out = capsys.readouterr().out.strip()
+        assert rc == 0
+        assert out == Action.ENQUEUE.value
+
+    def test_classify_cli_strict_behind(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        pr = _pr(mergeStateStatus="BEHIND", behind=1)
+        rc = mod.main(
+            ["classify", "--pr-json", json.dumps(pr), "--strict-update", "true"]
+        )
+        out = capsys.readouterr().out.strip()
+        assert rc == 0
+        assert out == Action.UPDATE_BRANCH_THEN_ENQUEUE.value
+
+    def test_verify_cli_exit_zero_in_queue(self) -> None:
+        rc = mod.main(["verify", "--pr-json", json.dumps({"isInMergeQueue": True})])
+        assert rc == 0
+
+    def test_verify_cli_exit_one_not_in_queue(self) -> None:
+        rc = mod.main(["verify", "--pr-json", json.dumps({"isInMergeQueue": False})])
+        assert rc == 1


### PR DESCRIPTION
## OMN-13214 — Port merge-queue armed-but-not-enqueued fix to omnibase_infra

Propagates the hardened auto-merge enqueue flow from omnimarket (PR #1253, merge commit `8fad5e11`) into omnibase_infra.

### Problem (this repo)
omnibase_infra `dev` is queue-controlled, but `.github/workflows/auto-merge.yml` armed with `gh pr merge --auto --squash`. On a queue-controlled branch GitHub **rejects** an explicit merge method ("The merge strategy for dev is set by the merge queue"), so the arm step failed and the PR was never enqueued — it sat `CLEAN` indefinitely needing a manual `enqueuePullRequest`. This is the same 2026-06-17 dev-wave failure mode OMN-13214 fixed in omnimarket. Even with bare `--auto`, arming alone does **not** enqueue on a queue repo.

### Fix (enforcement, not advisory)
`.github/workflows/auto-merge.yml`:
1. Arms bare `--auto` (queue picks the method; `--squash` is rejected on queue `dev`) and no longer exits on success.
2. Detects strict-update on the default branch; when the PR is `BEHIND`, runs `gh pr update-branch` first and lets the resulting check run re-fire the workflow.
3. Explicitly calls `enqueuePullRequest` after arming.
4. **Verifies** the PR actually entered the queue (polls `isInMergeQueue` via GraphQL) and **fails loudly** (`::error::`) if a green + armed PR is not enqueued — surfacing the gap instead of stalling silently.

Infra-specific workflow shape is preserved: self-hosted/public `runs-on` matrix, stacked-PR `baseRefName` skip, `checkout@v6`.

The classify/verify decision logic is a stdlib-only, unit-tested helper: `scripts/ci/merge_queue_enqueue.py` with 32 unit tests in `tests/ci/test_merge_queue_enqueue.py` covering every wave failure mode (clean+armed+empty-queue → enqueue, already-queued → noop, behind+strict → update-branch, behind+non-strict → enqueue, blocked/dirty/draft/unknown → wait).

### dod_evidence
- `uv run pytest tests/ci/test_merge_queue_enqueue.py` → **32 passed**.
- `uv run mypy --strict scripts/ci/merge_queue_enqueue.py` → clean.
- `uv run ruff check` / `ruff format --check` → clean.
- `actionlint .github/workflows/auto-merge.yml` → exit 0 (also fixed pre-existing SC2129 in the resolve step).
- `pre-commit run --files ...` → exit 0 (full hook set).

### Honest dogfood limitation
This bootstrap PR **cannot** auto-enqueue itself: GitHub's `check_suite` runs the **default-branch** (pre-fix) version of `auto-merge.yml` until this PR merges, so the new enqueue+verify step is not yet active for it. This PR must be **manually enqueued** to land. After merge, the next green + armed PR in omnibase_infra will auto-enqueue via the new flow.

OMN-13214

---
Evidence-Source: 283d2ad1aa8da4e1c67b40d1d1945ab35ad8f37a
Evidence-Ticket: OMN-13214
