### PR TITLE
fix(OMN-13215): remove codex-cli shell-out from inference effect; canonical HTTP ceiling

### DIFF
--- a/scripts/check_lane_attestation.py
+++ b/scripts/check_lane_attestation.py
@@ -41,18 +41,34 @@ import subprocess
 import sys
 from pathlib import Path
 
-# Pattern that identifies lane-boundary attestation language in file content.
-# A "lane attestation" is any line that declares or documents a lane boundary.
+# Patterns that identify lane-boundary attestation language in ANY file.
+# A "lane attestation" is content that declares or documents a lane boundary.
+# These are path-independent because their shape is specific to lane attestation
+# language (a lane table row referencing the omnibase-infra compose family, or the
+# generated lane-table block marker) and cannot collide with ordinary content.
 _LANE_ATTESTATION_PATTERNS = [
     # Markdown lane table rows — e.g. "| dev | `omnibase-infra` |"
     re.compile(r"^\|[^|]+\|\s*`omnibase-infra[^`]*`", re.MULTILINE),
+    # Generated lane table block header (CLAUDE.md)
+    re.compile(r"<!-- GENERATED_LANE_TABLE", re.MULTILINE),
+]
+
+# Patterns that are ONLY meaningful inside a lane-census manifest file. A bare
+# 2-space-indented YAML key (``^  name:``) and a ``compose_project:`` line occur
+# in countless ordinary node contracts (``  handlers:``, ``  tags:``), so applying
+# them everywhere mis-fired the gate on every edited node contract (OMN-13215).
+# Scope them to the lane-manifest path so the gate guards real lane attestations
+# without flagging unrelated YAML.
+_LANE_MANIFEST_ONLY_PATTERNS = [
     # Lane manifest compose_project declarations
     re.compile(r"^\s+compose_project:\s+\S+", re.MULTILINE),
     # Lane manifest lane keys (top-level lane names)
     re.compile(r"^  [a-z][a-z0-9-]+:\s*$", re.MULTILINE),
-    # Generated lane table block header (CLAUDE.md)
-    re.compile(r"<!-- GENERATED_LANE_TABLE", re.MULTILINE),
 ]
+
+# Path marker identifying a lane-census manifest/snapshot file. The lane-key /
+# compose_project patterns only apply to these files.
+_LANE_MANIFEST_PATH_PATTERN = re.compile(r"lane-census/|lane-manifest")
 
 # Pattern for the required verified annotation. Accepts:
 #   verified: 2026-06-12 via <command>
@@ -77,8 +93,12 @@ def _is_exempt(path: str) -> bool:
     return any(p.search(path) for p in _EXEMPT_PATH_PATTERNS)
 
 
-def _has_lane_attestation(content: str) -> bool:
-    return any(p.search(content) for p in _LANE_ATTESTATION_PATTERNS)
+def _has_lane_attestation(content: str, path: str) -> bool:
+    if any(p.search(content) for p in _LANE_ATTESTATION_PATTERNS):
+        return True
+    if _LANE_MANIFEST_PATH_PATTERN.search(path):
+        return any(p.search(content) for p in _LANE_MANIFEST_ONLY_PATTERNS)
+    return False
 
 
 def _has_verified_annotation(content: str) -> bool:
@@ -98,7 +118,7 @@ def check_file(path: Path) -> list[str]:
     except OSError:
         return violations  # file disappeared between staging and check
 
-    if not _has_lane_attestation(content):
+    if not _has_lane_attestation(content, rel):
         return violations
 
     if not _has_verified_annotation(content):

--- a/src/omnibase_infra/configs/routing_tiers.yaml
+++ b/src/omnibase_infra/configs/routing_tiers.yaml
@@ -83,19 +83,12 @@ tiers:
   # CLI agent delegation tier (OMN-10137)
   # Models dispatched via subprocess rather than HTTP API.
   # Availability confirmed at dispatch time via shutil.which inside HandlerLlmCliSubprocess.
+  #
+  # OMN-13215: the shelled ``codex-cli`` model was REMOVED from this tier. The
+  # delegation ceiling executes over the canonical HTTP path (claude tier ->
+  # cloud-sonnet) — there is no codex subprocess inference path anywhere.
   - name: cli_agents
     models:
-      - id: codex-cli
-        backend_id: cli-codex
-        max_context_tokens: 200000
-        use_for:
-          - agent_delegation
-          - code_generation
-          - complex_reasoning
-          - reasoning
-          - planning
-          - test
-          - research
       - id: claude-cli
         backend_id: cli-claude
         max_context_tokens: 200000

--- a/src/omnibase_infra/nodes/node_llm_inference_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_llm_inference_effect/contract.yaml
@@ -6,7 +6,10 @@
 #   fields (e.g. chat_template_kwargs.enable_thinking) merged in _build_payload
 #   without overriding declared fields (2026-06-07)
 # OMN-13158: HandlerLlmCliSubprocess resolves OAuth/subscription CLI backends
-#   from request.model (codex-cli, claude-cli, gemini-cli, opencode-cli).
+#   from request.model (claude-cli, gemini-cli, opencode-cli).
+# OMN-13215: the codex-cli shell-execution path was REMOVED. The delegation
+#   ceiling executes over the canonical HTTP inference path; no codex subprocess
+#   operation or backend remains.
 # OMN-13204: HandlerLlmOpenaiCompatible Protocol Conformance Note corrected to
 #   the real protocol I/O types — ProtocolHandler.execute(ModelProtocolRequest)
 #   -> ModelProtocolResponse and ProtocolMessageHandler.handle(ModelEventEnvelope)
@@ -84,12 +87,9 @@ handler_routing:
         name: "HandlerLlmCliSubprocess"
         module: "omnibase_infra.nodes.node_llm_inference_effect.handlers.handler_llm_cli_subprocess"
       description: "Execute LLM inference via Gemini CLI subprocess (gemini -p)"
-    # Codex CLI Subprocess Handler
-    - operation: "inference.codex_cli"
-      handler:
-        name: "HandlerLlmCliSubprocess"
-        module: "omnibase_infra.nodes.node_llm_inference_effect.handlers.handler_llm_cli_subprocess"
-      description: "Execute LLM inference via Codex CLI subprocess (codex exec)"
+    # OMN-13215: the Codex CLI subprocess operation (inference.codex_cli) was
+    # REMOVED. The delegation ceiling executes over the canonical HTTP inference
+    # path (HandlerLlmOpenaiCompatible) — no codex shell-out remains.
     # Claude CLI Subprocess Handler (OMN-10137)
     - operation: "inference.claude_cli"
       handler:

--- a/src/omnibase_infra/nodes/node_llm_inference_effect/handlers/handler_llm_cli_subprocess.py
+++ b/src/omnibase_infra/nodes/node_llm_inference_effect/handlers/handler_llm_cli_subprocess.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
-"""CLI subprocess handler for LLM inference via Gemini CLI and Codex CLI.
+"""CLI subprocess handler for LLM inference via Gemini / Claude / opencode CLI.
 
 Generalizes the proven subprocess dispatch pattern from the hostile reviewer
 aggregator (aggregate_reviews.py) into an ONEX handler that accepts
@@ -18,6 +18,8 @@ CLI subprocess handlers distinguish these failure classes:
 Related:
     - OMN-7106: Add Gemini CLI and Codex CLI as subprocess LLM handlers
     - OMN-7103: Node-Based LLM Delegation Workflow
+    - OMN-13215: codex-cli REMOVED — the delegation ceiling executes over the
+      canonical HTTP inference path; no codex subprocess config remains here.
 """
 
 from __future__ import annotations
@@ -57,12 +59,10 @@ class EnumCliBackendStatus(str, Enum):
     EMPTY_RESPONSE = "empty_response"
 
 
+# OMN-13215: the ``codex-cli`` model config was REMOVED. The delegation ceiling
+# executes over the canonical HTTP inference path — no codex shell-out remains.
 _CLI_CONFIG_BY_MODEL: dict[str, tuple[str, list[str]]] = {
     "gemini-cli": ("gemini", ["-p"]),
-    "codex-cli": (
-        "codex",
-        ["--sandbox", "read-only", "--ask-for-approval", "never", "exec"],
-    ),
     "claude-cli": (
         "claude",
         [

--- a/tests/integration/runtime/test_handler_wiring_entry_keys_integration.py
+++ b/tests/integration/runtime/test_handler_wiring_entry_keys_integration.py
@@ -31,12 +31,12 @@ def _routing_entry(operation: str) -> ModelHandlerRoutingEntry:
 def test_operation_keyed_wiring_keeps_shared_handler_routes_distinct() -> None:
     topic = "onex.cmd.omnimarket.model-route.v1"
     gemini_key = _derive_handler_entry_key(_routing_entry("inference.gemini-cli"))
-    codex_key = _derive_handler_entry_key(_routing_entry("inference.codex-cli"))
+    opencode_key = _derive_handler_entry_key(_routing_entry("inference.opencode-cli"))
 
-    assert gemini_key != codex_key
+    assert gemini_key != opencode_key
     assert _derive_dispatcher_id("node_model_router", gemini_key) != (
-        _derive_dispatcher_id("node_model_router", codex_key)
+        _derive_dispatcher_id("node_model_router", opencode_key)
     )
     assert _derive_route_id("node_model_router", gemini_key, topic) != (
-        _derive_route_id("node_model_router", codex_key, topic)
+        _derive_route_id("node_model_router", opencode_key, topic)
     )

--- a/tests/unit/nodes/node_llm_inference_effect/handlers/test_handler_llm_cli_subprocess_claude_opencode.py
+++ b/tests/unit/nodes/node_llm_inference_effect/handlers/test_handler_llm_cli_subprocess_claude_opencode.py
@@ -60,14 +60,22 @@ def test_cli_agents_tier_contains_claude_cli_model() -> None:
 
 
 @pytest.mark.unit
-def test_cli_agents_tier_contains_codex_cli_model() -> None:
+def test_cli_agents_tier_omits_codex_cli_model() -> None:
+    """OMN-13215: the shelled codex-cli model was removed from cli_agents.
+
+    The delegation ceiling executes over the canonical HTTP path; no codex
+    subprocess model remains in any routing tier.
+    """
     tiers_path = (
         Path(__file__).parents[5] / "src/omnibase_infra/configs/routing_tiers.yaml"
     )
     data = yaml.safe_load(tiers_path.read_text())
     cli_tier = next(t for t in data["tiers"] if t["name"] == "cli_agents")
     model_ids = [m["id"] for m in cli_tier["models"]]
-    assert model_ids[0] == "codex-cli"
+    assert "codex-cli" not in model_ids
+    # No tier anywhere may declare a codex shell-out model.
+    for tier in data["tiers"]:
+        assert "codex-cli" not in [m["id"] for m in tier["models"]]
 
 
 @pytest.mark.unit
@@ -106,15 +114,25 @@ def test_claude_cli_subprocess_unavailable_when_binary_missing() -> None:
 
 
 @pytest.mark.unit
-def test_codex_cli_subprocess_resolves_from_request_model() -> None:
+def test_codex_cli_model_no_longer_resolves_a_subprocess_config() -> None:
+    """OMN-13215: the codex-cli shell-out config was removed.
+
+    A request whose model is ``codex-cli`` must no longer resolve a CLI config —
+    the handler reports UNAVAILABLE (cli not configured) instead of spawning the
+    codex binary. The delegation ceiling runs over the canonical HTTP path.
+    """
     from omnibase_infra.models.llm.model_llm_inference_request import (
         ModelLlmInferenceRequest,
     )
     from omnibase_infra.models.llm.model_llm_message import ModelLlmMessage
     from omnibase_infra.nodes.node_llm_inference_effect.handlers.handler_llm_cli_subprocess import (
+        _CLI_CONFIG_BY_MODEL,
         EnumCliBackendStatus,
         HandlerLlmCliSubprocess,
     )
+
+    # The codex model has no CLI config mapping anymore.
+    assert "codex-cli" not in _CLI_CONFIG_BY_MODEL
 
     handler = HandlerLlmCliSubprocess()
     req = ModelLlmInferenceRequest(
@@ -122,54 +140,12 @@ def test_codex_cli_subprocess_resolves_from_request_model() -> None:
         messages=[ModelLlmMessage(role="user", content="hi")],
         model="codex-cli",
     )
-    with patch("shutil.which", return_value=None):
+    # No subprocess is spawned: with no resolved CLI, the handler fails closed.
+    with patch("subprocess.run") as mock_run:
         _, status, detail = handler.execute_cli_inference(req)
     assert status == EnumCliBackendStatus.UNAVAILABLE
-    assert detail == "codex not found on PATH"
-
-
-@pytest.mark.unit
-def test_codex_cli_subprocess_uses_headless_oauth_safe_argv() -> None:
-    from omnibase_infra.models.llm.model_llm_inference_request import (
-        ModelLlmInferenceRequest,
-    )
-    from omnibase_infra.models.llm.model_llm_message import ModelLlmMessage
-    from omnibase_infra.nodes.node_llm_inference_effect.handlers.handler_llm_cli_subprocess import (
-        EnumCliBackendStatus,
-        HandlerLlmCliSubprocess,
-    )
-
-    handler = HandlerLlmCliSubprocess()
-    req = ModelLlmInferenceRequest(
-        base_url="http://localhost:1",
-        messages=[ModelLlmMessage(role="user", content="hi")],
-        model="codex-cli",
-    )
-    completed = subprocess.CompletedProcess(
-        args=["codex"],
-        returncode=0,
-        stdout="codex response\n",
-        stderr="",
-    )
-    with (
-        patch("shutil.which", return_value="/opt/homebrew/bin/codex"),
-        patch("subprocess.run", return_value=completed) as mock_run,
-    ):
-        response, status, detail = handler.execute_cli_inference(req)
-
-    assert status == EnumCliBackendStatus.SUCCESS
-    assert detail == ""
-    assert response is not None
-    assert response.generated_text == "codex response"
-    assert mock_run.call_args.args[0] == [
-        "codex",
-        "--sandbox",
-        "read-only",
-        "--ask-for-approval",
-        "never",
-        "exec",
-        "hi",
-    ]
+    assert "cli not configured" in detail
+    mock_run.assert_not_called()
 
 
 @pytest.mark.unit
@@ -255,11 +231,16 @@ def test_existing_gemini_cli_entry_still_present() -> None:
 
 
 @pytest.mark.unit
-def test_existing_codex_cli_entry_still_present() -> None:
+def test_codex_cli_operation_removed_from_contract() -> None:
+    """OMN-13215: the inference.codex_cli operation was removed from the contract.
+
+    The codex shell-out is gone; the ceiling executes over the canonical HTTP
+    inference path (HandlerLlmOpenaiCompatible).
+    """
     contract_path = (
         Path(__file__).parents[5]
         / "src/omnibase_infra/nodes/node_llm_inference_effect/contract.yaml"
     )
     data = yaml.safe_load(contract_path.read_text())
     ops = [h["operation"] for h in data["handler_routing"]["handlers"]]
-    assert "inference.codex_cli" in ops
+    assert "inference.codex_cli" not in ops

--- a/tests/unit/runtime/auto_wiring/test_handler_wiring_entry_keys.py
+++ b/tests/unit/runtime/auto_wiring/test_handler_wiring_entry_keys.py
@@ -52,7 +52,7 @@ class TestHandlerEntryKeyDerivation:
 
     @pytest.mark.unit
     def test_dispatcher_id_uses_handler_entry_key(self) -> None:
-        handler_key = _derive_handler_entry_key(_entry("inference.codex-cli"))
+        handler_key = _derive_handler_entry_key(_entry("inference.opencode-cli"))
 
         assert (
             _derive_dispatcher_id("node_model_router", handler_key)
@@ -64,10 +64,10 @@ class TestHandlerEntryKeyDerivation:
         self,
     ) -> None:
         gemini_key = _derive_handler_entry_key(_entry("inference.gemini-cli"))
-        codex_key = _derive_handler_entry_key(_entry("inference.codex-cli"))
+        opencode_key = _derive_handler_entry_key(_entry("inference.opencode-cli"))
 
         assert _derive_dispatcher_id("node_model_router", gemini_key) != (
-            _derive_dispatcher_id("node_model_router", codex_key)
+            _derive_dispatcher_id("node_model_router", opencode_key)
         )
 
     @pytest.mark.unit
@@ -76,10 +76,10 @@ class TestHandlerEntryKeyDerivation:
     ) -> None:
         topic = "onex.cmd.omnimarket.model-route.v1"
         gemini_key = _derive_handler_entry_key(_entry("inference.gemini-cli"))
-        codex_key = _derive_handler_entry_key(_entry("inference.codex-cli"))
+        opencode_key = _derive_handler_entry_key(_entry("inference.opencode-cli"))
 
         assert _derive_route_id("node_model_router", gemini_key, topic) != (
-            _derive_route_id("node_model_router", codex_key, topic)
+            _derive_route_id("node_model_router", opencode_key, topic)
         )
 
 

--- a/tests/unit/runtime/auto_wiring/test_wiring.py
+++ b/tests/unit/runtime/auto_wiring/test_wiring.py
@@ -948,7 +948,7 @@ class TestWireFromManifest:
 
         Mirrors the real node_llm_inference_effect contract which lists
         HandlerLlmCliSubprocess for both ``inference.gemini_cli`` and
-        ``inference.codex_cli``.
+        ``inference.claude_cli``.
         """
         from omnibase_infra.runtime.message_dispatch_engine import (
             MessageDispatchEngine,
@@ -964,7 +964,7 @@ class TestWireFromManifest:
             ModelHandlerRoutingEntry(
                 handler=ModelHandlerRef(name="HandlerShared", module="fake.module"),
                 event_model=None,
-                operation="inference.codex_cli",
+                operation="inference.claude_cli",
             ),
         )
         handler_routing = ModelHandlerRouting(

--- a/tests/unit/scripts/test_check_lane_attestation.py
+++ b/tests/unit/scripts/test_check_lane_attestation.py
@@ -41,6 +41,19 @@ def _write_tmp(content: str, suffix: str = ".md") -> Path:
         return Path(f.name)
 
 
+def _write_tmp_named(content: str, filename: str) -> Path:
+    """Write content under a temp dir using a specific filename.
+
+    Used to exercise path-scoped patterns (lane-manifest detection): the
+    lane-key / compose_project patterns only apply when the path marks a
+    lane-census manifest (OMN-13215).
+    """
+    tmp_dir = Path(tempfile.mkdtemp())
+    path = tmp_dir / filename
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
 # ---------------------------------------------------------------------------
 # Files WITHOUT lane attestation language — always pass
 # ---------------------------------------------------------------------------
@@ -147,7 +160,7 @@ def test_markdown_lane_table_without_verified_fails() -> None:
     path.unlink(missing_ok=True)
 
 
-def test_compose_project_in_yaml_without_verified_fails() -> None:
+def test_compose_project_in_lane_manifest_without_verified_fails() -> None:
     """lane-manifest.yaml with compose_project but no verified: must fail."""
     content = (
         "schema_version: '1.0.0'\n"
@@ -156,11 +169,32 @@ def test_compose_project_in_yaml_without_verified_fails() -> None:
         "    compose_project: omnibase-infra-prod\n"
         "    network: omnibase-infra-prod-network\n"
     )
-    path = _write_tmp(content, suffix=".yaml")
+    path = _write_tmp_named(content, "lane-manifest.yaml")
     violations = MOD.check_file(path)
     assert len(violations) == 1
     assert "verified:" in violations[0]
-    path.unlink(missing_ok=True)
+
+
+def test_compose_project_outside_lane_manifest_does_not_fire() -> None:
+    """OMN-13215: compose_project / bare YAML keys in a NON-lane-manifest file
+    (e.g. an ordinary node contract with ``handlers:`` / ``tags:``) must NOT
+    trip the gate. The lane-key / compose_project patterns are scoped to the
+    lane-census manifest path so the gate stops mis-firing on every edited
+    node contract.
+    """
+    node_contract = (
+        "name: node_example_effect\n"
+        "node_type: EFFECT_GENERIC\n"
+        "handler_routing:\n"
+        "  routing_strategy: operation_match\n"
+        "  handlers:\n"
+        "    - operation: example.op\n"
+        "metadata:\n"
+        "  tags:\n"
+        "    - example\n"
+    )
+    path = _write_tmp_named(node_contract, "contract.yaml")
+    assert MOD.check_file(path) == []
 
 
 def test_generated_block_without_verified_fails() -> None:


### PR DESCRIPTION
## OMN-13215 — Remove codex-cli shell-out from the inference effect (canonical HTTP ceiling)

### Problem
The delegation ceiling executed via a shelled `codex-cli` subprocess that is absent on the .201 dev runtime containers, dead-ending every `code_generation` escalation with `CLI backend unavailable: codex executable not found`. Per the binding user decision (OMN-13215 comment), a shelled-CLI tier is non-canonical and must be removed; the ceiling executes over the canonical HTTP inference path.

This PR removes the codex-cli surfaces in `omnibase_infra` (the parallel `node_llm_inference_effect` CLI inference node). The live delegation-path fix is in the paired omnimarket PR.

### Fix (canonical, root-cause)
- `node_llm_inference_effect/contract.yaml`: delete the `inference.codex_cli` operation (the codex shell-out). Gemini / Claude / opencode CLI operations are unchanged (separate surfaces, not the OMN-13215 ceiling).
- `node_llm_inference_effect/handlers/handler_llm_cli_subprocess.py`: remove the `codex-cli` config from `_CLI_CONFIG_BY_MODEL`. A `codex-cli` request now resolves no CLI config and fails closed (UNAVAILABLE) instead of spawning the codex binary.
- `configs/routing_tiers.yaml`: drop the `codex-cli` model from the `cli_agents` tier. (The infra `claude` tier already maps to the HTTP `cloud-sonnet` backend.)
- `scripts/check_lane_attestation.py`: narrow the over-broad OMN-13034 lane-attestation gate. Bare 2-space YAML keys (`  handlers:`, `  tags:`) and `compose_project:` lines only count as lane attestation inside lane-census manifest paths, so editing an ordinary node contract no longer mis-fires the gate. The CLAUDE.md lane-table and lane-manifest protections are unchanged.

### Evidence (dod_evidence)
- `tests/unit/nodes/node_llm_inference_effect/handlers/test_handler_llm_cli_subprocess_claude_opencode.py`: codex-cli removed from the cli_agents tier and from `_CLI_CONFIG_BY_MODEL`; `inference.codex_cli` removed from the contract; a `codex-cli` request fails closed without spawning a subprocess; gemini/claude/opencode paths still pass.
- `tests/unit/scripts/test_check_lane_attestation.py`: lane-manifest `compose_project` still requires `verified:`; an ordinary node contract with `handlers:` / `tags:` no longer trips the gate (new regression test).
- `uv run pytest tests/unit/nodes/node_llm_inference_effect/ tests/unit/runtime/auto_wiring/ tests/unit/scripts/test_check_lane_attestation.py tests/integration/handlers/test_handler_autowiring_compliance.py tests/integration/runtime/test_handler_wiring_entry_keys_integration.py` → all pass.
- `uv run mypy src/omnibase_infra/nodes/node_llm_inference_effect --strict` and `scripts/check_lane_attestation.py --strict` → clean; `ruff` clean; `pre-commit` (commit mode) → pass on staged files.

OMN-13215

---
Evidence-Source: OCC#2730
Evidence-Ticket: OMN-13215
