### PR TITLE
fix(OMN-13210): [B1] repoint hostile_reviewer skill_mapping to node_hostile_reviewer_orchestrator

### DIFF
--- a/src/omnibase_infra/cli/skill_mapping.yaml
+++ b/src/omnibase_infra/cli/skill_mapping.yaml
@@ -134,8 +134,8 @@ skills:
       - {name: omni-home, payload_field: omni_home, arg_type: string}
       - {name: checks, payload_field: checks, arg_type: string_list}
   - skill_name: hostile_reviewer
-    node_name: node_hostile_reviewer
-    result_model: omnimarket.nodes.node_hostile_reviewer.models.model_hostile_reviewer_completed_event.ModelHostileReviewerCompletedEvent
+    node_name: node_hostile_reviewer_orchestrator
+    result_model: omnimarket.nodes.node_hostile_reviewer_orchestrator.models.model_hostile_reviewer_completed_event.ModelHostileReviewerCompletedEvent
     args:
       - {name: pr-number, payload_field: pr_number, arg_type: integer}
       - {name: repo, payload_field: repo, arg_type: string}


### PR DESCRIPTION
Evidence-Source: OCC#2734
Evidence-Ticket: OMN-13210

## OMN-13210 — [B1] Repoint hostile_reviewer skill_mapping (omnibase_infra)

Epic: OMN-13205. Part of B1 (OMN-13210). Pairs with omnimarket PR #1260 and OCC PR #2734.

`node_hostile_reviewer` was rebuilt canonically as `node_hostile_reviewer_orchestrator` (omnimarket, OMN-13210/B1). This repoints the `hostile_reviewer` skill mapping:
- `node_name`: `node_hostile_reviewer` → `node_hostile_reviewer_orchestrator`
- `result_model`: `omnimarket.nodes.node_hostile_reviewer_orchestrator.models.model_hostile_reviewer_completed_event.ModelHostileReviewerCompletedEvent`

So `uv run onex skill hostile_reviewer` dispatches the rebuilt orchestrator. The output shape (`ModelHostileReviewerCompletedEvent`) and topics are preserved across the rebuild.

### OCC recipe
(OCC#2734 carries the OMN-13210 contract + dod receipts; the backing rebuild ships in omnimarket PR #1260.)