### PR TITLE
fix(OMN-13220): deploy-runtime cold-start crash-loop + missing intelligence-migration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,6 +69,27 @@ repos:
       - id: check-merge-conflict
       - id: check-added-large-files
         args: [--maxkb=1000]
+  # OMN-13220: shellcheck the deploy surface this repo owns. Scoped to
+  # deploy-runtime.sh + its runtime_build sibling scripts (the deploy crash-loop
+  # blast radius) rather than all 56 scripts/*.sh, so the gate enforces real
+  # defects without a 56-script pre-existing-cleanup detour. SC1091 (sourced
+  # host-env files shellcheck cannot follow) is silenced in .shellcheckrc.
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
+    hooks:
+      - id: shellcheck
+        name: shellcheck (deploy-runtime surface)
+        files: ^scripts/(deploy-runtime\.sh|runtime_build/.*\.sh)$
+        stages: [pre-commit]
+  # actionlint (GitHub Actions linting) is intentionally NOT wired as a
+  # repo-wide pre-commit hook in this PR: a baseline run flags pre-existing
+  # findings across ~20 unrelated workflows (embedded-shellcheck style nits +
+  # an actionlint secret-name case-normalization quirk in
+  # dependency-cascade.yml). This PR touches no workflow files, so adding the
+  # gate here would ship a hook that is red on day one over code this ticket
+  # did not author — detection without a clean baseline, which Rule 5 prohibits.
+  # actionlint is run ad-hoc in CI verification for OMN-13220; wiring it as a
+  # required gate is tracked as its own workflow-cleanup follow-up.
   # ONEX Python Development Hooks (from shared templates)
   # Order: ruff format → ruff check → mypy (formatting before linting before type checking)
   # Note: ruff replaces both black and isort (10-100x faster)

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,9 @@
+# shellcheck configuration (OMN-13220)
+#
+# SC1091: "Not following: <file> was not specified as input." Our deploy scripts
+# source host-resolved env files (docker/runtime-policy.env, ~/.omnibase/.env)
+# that exist only at runtime on the deploy host, never in the repo. shellcheck
+# cannot follow them and the warning is pure noise — it says nothing about the
+# correctness of the sourcing script. Disable it globally so the shellcheck gate
+# fails only on real defects.
+disable=SC1091

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -141,6 +141,15 @@ x-runtime-env: &runtime-env
   KAFKA_BOOTSTRAP_SERVERS: "redpanda:9092"
   # Allowlist lets service_kernel.py's denylist accept Docker-internal redpanda: hostname
   KAFKA_BROKER_ALLOWLIST: "redpanda:"
+  # OMN-13220: per-consumer Kafka consumer-start budget. On a fully-cold lane the
+  # kernel joins a consumer group per subscribed topic; with 1300+ topics on a
+  # freshly-provisioned broker the default 30s blew on the slow group-coordinator
+  # tail and the kernel recycled before reaching healthy. deploy-runtime.sh
+  # exports a raised COLD_START_KAFKA_TIMEOUT_SECONDS before the restart; the
+  # :-30 default preserves the prior steady-state value when the var is unset
+  # (e.g. a plain `docker compose up` outside the deploy script). Mapped to
+  # ModelKafkaEventBusConfig.timeout_seconds (le=300) via apply_environment_overrides.
+  KAFKA_TIMEOUT_SECONDS: ${KAFKA_TIMEOUT_SECONDS:-30}
   BUS_ID: "local"
   ONEX_CONTRACTS_DIR: /app/contracts
   ONEX_STATE_ROOT: /app/data/.onex_state

--- a/scripts/deploy-runtime.sh
+++ b/scripts/deploy-runtime.sh
@@ -77,10 +77,45 @@ readonly RUNTIME_SERVICES=(
     intelligence-api
     omninode-contract-resolver
 )
+# Migration services refreshed (one-shot) before the --no-deps runtime restart.
+# Order matters: forward-migration applies the omnibase_infra schema, then
+# intelligence-migration applies the omniintelligence schema, then migration-gate
+# stamps db_metadata.migrations_complete and stays up as a healthcheck keepalive.
+#
+# OMN-13220: intelligence-migration was MISSING here. The compose file gates
+# omninode-runtime on `intelligence-migration: condition: service_completed_successfully`,
+# but restart_services() uses `up -d --no-deps`, which bypasses depends_on. On a
+# fresh-DB lane that left public.db_metadata for omniintelligence unstamped, so
+# the runtime crash-looped. The preflight must run it explicitly.
+#
+# One-shot services (run-to-completion, exit 0) are listed in
+# RUNTIME_MIGRATION_ONESHOTS so the preflight can `docker wait` on them; the
+# keepalive migration-gate is deliberately excluded from that wait set.
 readonly RUNTIME_MIGRATION_SERVICES=(
     forward-migration
+    intelligence-migration
     migration-gate
 )
+readonly RUNTIME_MIGRATION_ONESHOTS=(
+    forward-migration
+    intelligence-migration
+)
+# Broker readiness services brought up (and waited on) before the runtime
+# restart. redpanda-partition-cap raises topic_partitions_per_shard so the cold
+# 1300+-topic provisioning burst on first boot does not exhaust the default
+# single-shard partition ceiling (OMN-11886 / OMN-13220). Because the runtime
+# restart is `--no-deps`, the compose depends_on chain (which includes
+# redpanda-partition-cap as service_completed_successfully) is bypassed, so the
+# preflight must apply the cap explicitly before the kernel provisions topics.
+readonly BROKER_READINESS_SERVICE="redpanda"
+readonly BROKER_PARTITION_CAP_SERVICE="redpanda-partition-cap"
+# Cold-start consumer-group join budget (OMN-13220). On a fully-cold lane the
+# kernel joins a consumer group per subscribed topic; with 1300+ topics on a
+# freshly-provisioned broker the default 30s per-consumer KAFKA_TIMEOUT_SECONDS
+# blew on the slow group-coordinator tail and the kernel recycled before it
+# reached healthy. Raise the per-consumer start budget for the restart-driven
+# boot. Operator-overridable; clamped to the config field bound (le=300).
+readonly COLD_START_KAFKA_TIMEOUT_SECONDS="${COLD_START_KAFKA_TIMEOUT_SECONDS:-180}"
 readonly REQUIRED_PROJECTION_TABLES=(
     delegation_events
     node_service_registry
@@ -1598,6 +1633,58 @@ build_images() {
 # Restart -- bring up runtime services only
 # =============================================================================
 
+warm_broker_topic_provisioning() {
+    # Bring the broker + partition cap to readiness before the --no-deps runtime
+    # restart so the cold-start topic-provisioning burst does not crash-loop the
+    # kernel (OMN-13220). The runtime restart bypasses depends_on, so the
+    # compose-declared redpanda-partition-cap gate never fires on a restart-only
+    # deploy — apply it here, explicitly, before the kernel boots.
+    local deploy_target="$1"
+    local compose_project="$2"
+    local compose_file="${deploy_target}/docker/docker-compose.infra.yml"
+
+    log_step "Broker Topic-Provisioning Warmup"
+
+    # 1. Ensure the broker itself is up and healthy. `up -d` is a no-op when it
+    # is already running; the --wait flag blocks until the healthcheck passes so
+    # the partition-cap rpk calls below do not race a still-starting broker.
+    local broker_up_cmd=(
+        docker compose
+        -p "${compose_project}"
+        -f "${compose_file}"
+        --profile "${COMPOSE_PROFILE}"
+        up -d --no-deps --wait
+        "${BROKER_READINESS_SERVICE}"
+    )
+    log_info "Ensuring broker is healthy: ${BROKER_READINESS_SERVICE}"
+    log_cmd "${broker_up_cmd[*]}"
+    "${broker_up_cmd[@]}"
+
+    # 2. Apply the partition cap (run-to-completion). force-recreate re-runs the
+    # one-shot even if a prior run left an exited container behind.
+    local cap_up_cmd=(
+        docker compose
+        -p "${compose_project}"
+        -f "${compose_file}"
+        --profile "${COMPOSE_PROFILE}"
+        up -d --no-deps --force-recreate
+        "${BROKER_PARTITION_CAP_SERVICE}"
+    )
+    log_info "Applying broker partition cap: ${BROKER_PARTITION_CAP_SERVICE}"
+    log_cmd "${cap_up_cmd[*]}"
+    "${cap_up_cmd[@]}"
+
+    local cap_container="${compose_project}-${BROKER_PARTITION_CAP_SERVICE}"
+    local cap_wait_cmd=(docker wait "${cap_container}")
+    log_cmd "${cap_wait_cmd[*]}"
+    if [[ "$("${cap_wait_cmd[@]}")" != "0" ]]; then
+        log_error "${BROKER_PARTITION_CAP_SERVICE} did not complete successfully."
+        log_error "Broker partition cap not applied; cold-start topic provisioning may crash-loop the runtime."
+        return 1
+    fi
+    log_info "Broker partition cap applied."
+}
+
 run_runtime_migration_preflight() {
     # Run bounded migration services before --no-deps runtime restarts.
     local deploy_target="$1"
@@ -1618,18 +1705,29 @@ run_runtime_migration_preflight() {
         log_info "Refreshing migration service: ${service}"
         log_cmd "${cmd[*]}"
         "${cmd[@]}"
-        if [[ "${service}" == "forward-migration" ]]; then
-            # Derive the container name from the compose project so the wait
-            # targets the lane being deployed, not a fixed name. The base
-            # compose names it <compose-project>-forward-migration and each
-            # lane overlay follows the same form (OMN-12987), so this resolves
-            # to omnibase-infra-forward-migration for dev and
-            # omnibase-infra-stability-test-forward-migration for stability.
-            local forward_migration_container="${compose_project}-forward-migration"
-            local wait_cmd=(docker wait "${forward_migration_container}")
+        # One-shot migrations (forward-migration, intelligence-migration) run to
+        # completion and must exit 0 before the dependent schema/runtime work
+        # proceeds. migration-gate is a long-running healthcheck keepalive, NOT a
+        # one-shot, so it is deliberately excluded from the wait set
+        # (OMN-13220). Deriving the container name from the compose project keeps
+        # the wait pointed at the lane being deployed (OMN-12987): the base
+        # compose names it <compose-project>-<service> and each lane overlay
+        # follows the same form (e.g. omnibase-infra-intelligence-migration for
+        # dev, omnibase-infra-stability-test-intelligence-migration for stability).
+        local is_oneshot=false
+        local oneshot
+        for oneshot in "${RUNTIME_MIGRATION_ONESHOTS[@]}"; do
+            if [[ "${service}" == "${oneshot}" ]]; then
+                is_oneshot=true
+                break
+            fi
+        done
+        if [[ "${is_oneshot}" == true ]]; then
+            local migration_container="${compose_project}-${service}"
+            local wait_cmd=(docker wait "${migration_container}")
             log_cmd "${wait_cmd[*]}"
             if [[ "$("${wait_cmd[@]}")" != "0" ]]; then
-                log_error "forward-migration did not complete successfully."
+                log_error "${service} did not complete successfully."
                 return 1
             fi
         fi
@@ -2041,6 +2139,27 @@ main() {
 
     # Phase 11: Restart (optional)
     if [[ "${RESTART}" == true ]]; then
+        # Raise the per-consumer Kafka consumer-start budget for the restart-driven
+        # cold boot (OMN-13220). x-runtime-env reads KAFKA_TIMEOUT_SECONDS from the
+        # shell environment (default 30s when unset); exporting it here propagates
+        # the raised cold-start value to every runtime container compose recreates.
+        # Validate + clamp to ModelKafkaEventBusConfig.timeout_seconds bounds
+        # (ge=1, le=300) so an operator override cannot produce a config the
+        # kernel rejects at boot.
+        local cold_start_timeout="${COLD_START_KAFKA_TIMEOUT_SECONDS}"
+        if [[ ! "${cold_start_timeout}" =~ ^[0-9]+$ ]]; then
+            log_error "COLD_START_KAFKA_TIMEOUT_SECONDS must be a positive integer (got: '${cold_start_timeout}')."
+            return 1
+        fi
+        if (( cold_start_timeout < 1 )); then
+            cold_start_timeout=1
+        elif (( cold_start_timeout > 300 )); then
+            log_warn "COLD_START_KAFKA_TIMEOUT_SECONDS=${cold_start_timeout} exceeds the config max (300); clamping to 300."
+            cold_start_timeout=300
+        fi
+        export KAFKA_TIMEOUT_SECONDS="${cold_start_timeout}"
+        log_info "Cold-start Kafka consumer-start budget: KAFKA_TIMEOUT_SECONDS=${KAFKA_TIMEOUT_SECONDS}s"
+        warm_broker_topic_provisioning "${deploy_target}" "${compose_project}"
         run_runtime_migration_preflight "${deploy_target}" "${compose_project}"
         restart_services "${deploy_target}" "${compose_project}"
     fi

--- a/scripts/validation/validate_clean_root.py
+++ b/scripts/validation/validate_clean_root.py
@@ -79,6 +79,8 @@ ALLOWED_ROOT_FILES: frozenset[str] = frozenset(
         ".flake8",
         ".pylintrc",
         ".isort.cfg",
+        # shellcheck reads .shellcheckrc only from the project root (OMN-13220).
+        ".shellcheckrc",
         # Markdown link validation
         ".markdown-link-check.json",
         # Standard documentation

--- a/tests/scripts/test_deploy_runtime_coldstart.py
+++ b/tests/scripts/test_deploy_runtime_coldstart.py
@@ -1,0 +1,185 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Regression coverage for the OMN-13220 cold-start crash-loop fixes.
+
+Two distinct fresh-DB / cold-lane failure modes are guarded here:
+
+1. Missing intelligence-migration. The compose file gates omninode-runtime on
+   ``intelligence-migration: condition: service_completed_successfully``, but
+   restart_services() uses ``up -d --no-deps`` which bypasses depends_on. On a
+   fresh-DB lane that left public.db_metadata for omniintelligence unstamped, so
+   the runtime crash-looped. deploy-runtime.sh's migration preflight must run
+   intelligence-migration (and ``docker wait`` on it as a one-shot).
+
+2. Cold-start consumer-timeout crash-loop. On a fully-cold lane the kernel joins
+   a consumer group per subscribed topic; with 1300+ topics on a freshly
+   provisioned broker the default 30s per-consumer KAFKA_TIMEOUT_SECONDS blew on
+   the slow group-coordinator tail and the kernel recycled before reaching
+   healthy. The deploy must (a) apply the broker partition cap before the kernel
+   provisions topics (the ``--no-deps`` restart bypasses the compose
+   redpanda-partition-cap gate) and (b) raise KAFKA_TIMEOUT_SECONDS for the
+   restart-driven boot.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEPLOY_SCRIPT = REPO_ROOT / "scripts" / "deploy-runtime.sh"
+COMPOSE_FILE = REPO_ROOT / "docker" / "docker-compose.infra.yml"
+
+
+def _deploy_script_text() -> str:
+    return DEPLOY_SCRIPT.read_text(encoding="utf-8")
+
+
+def _deploy_script_noncomment() -> str:
+    """deploy-runtime.sh with comment-only lines stripped.
+
+    Assertions about *active* behavior must not be satisfied by a comment that
+    merely mentions the token, so the active-code checks run against this view.
+    """
+    lines = [
+        line
+        for line in _deploy_script_text().splitlines()
+        if not line.lstrip().startswith("#")
+    ]
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Fix 1: intelligence-migration in the migration preflight
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_intelligence_migration_in_runtime_migration_services() -> None:
+    """RUNTIME_MIGRATION_SERVICES must include intelligence-migration (fresh-DB)."""
+    text = _deploy_script_noncomment()
+    match = re.search(
+        r"RUNTIME_MIGRATION_SERVICES=\((?P<body>.*?)\)",
+        text,
+        re.DOTALL,
+    )
+    assert match is not None, "RUNTIME_MIGRATION_SERVICES array not found"
+    services = match.group("body").split()
+    assert "intelligence-migration" in services, (
+        "intelligence-migration missing from RUNTIME_MIGRATION_SERVICES. The "
+        "compose file gates omninode-runtime on it via "
+        "service_completed_successfully, but the --no-deps restart bypasses "
+        "depends_on, so the preflight must run it or fresh-DB lanes crash-loop "
+        "(OMN-13220)."
+    )
+    # Order must keep migration-gate last: it stamps migrations_complete after
+    # both schema migrations have applied.
+    assert services.index("intelligence-migration") < services.index(
+        "migration-gate"
+    ), "intelligence-migration must run before migration-gate stamps completion."
+
+
+@pytest.mark.unit
+def test_intelligence_migration_is_waited_on_as_oneshot() -> None:
+    """The preflight must docker wait on intelligence-migration completion."""
+    text = _deploy_script_noncomment()
+    match = re.search(
+        r"RUNTIME_MIGRATION_ONESHOTS=\((?P<body>.*?)\)",
+        text,
+        re.DOTALL,
+    )
+    assert match is not None, "RUNTIME_MIGRATION_ONESHOTS array not found"
+    oneshots = match.group("body").split()
+    assert "forward-migration" in oneshots
+    assert "intelligence-migration" in oneshots
+    # migration-gate is a long-running healthcheck keepalive, not a one-shot; a
+    # docker wait on it would block the deploy forever.
+    assert "migration-gate" not in oneshots, (
+        "migration-gate is a keepalive, not a one-shot; it must not be in the "
+        "docker-wait set or the deploy hangs."
+    )
+    # The wait loop must actually consult the one-shot set.
+    assert "RUNTIME_MIGRATION_ONESHOTS" in text
+    assert "docker wait" in text
+
+
+# ---------------------------------------------------------------------------
+# Fix 2a: broker partition-cap warmup before the kernel boots
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_warm_broker_runs_before_migration_and_restart() -> None:
+    """warm_broker_topic_provisioning must run before migrations and restart.
+
+    The ``--no-deps`` runtime restart bypasses the compose
+    redpanda-partition-cap depends_on gate, so the deploy must apply the cap
+    explicitly before the kernel provisions 1300+ topics on a cold broker.
+    """
+    text = _deploy_script_text()
+    warm_idx = text.find('warm_broker_topic_provisioning "${deploy_target}"')
+    migration_idx = text.find('run_runtime_migration_preflight "${deploy_target}"')
+    restart_idx = text.find('restart_services "${deploy_target}"')
+
+    assert warm_idx != -1, "warm_broker_topic_provisioning is not called in main()"
+    assert migration_idx != -1, "run_runtime_migration_preflight is not called"
+    assert restart_idx != -1, "restart_services is not called"
+    assert warm_idx < migration_idx < restart_idx, (
+        "Order must be warmup -> migration preflight -> restart so the broker "
+        "partition cap and schema are ready before the kernel boots (OMN-13220)."
+    )
+
+
+@pytest.mark.unit
+def test_warm_broker_applies_partition_cap_and_waits() -> None:
+    """The warmup must bring up the partition cap and verify it completed."""
+    text = _deploy_script_text()
+    assert "warm_broker_topic_provisioning()" in text
+    assert 'BROKER_PARTITION_CAP_SERVICE="redpanda-partition-cap"' in text
+    # The broker must be brought to a healthy state before the cap rpk calls.
+    assert "--wait" in text
+    # The cap is a one-shot; the deploy must fail if it does not exit 0.
+    assert 'cap_container="${compose_project}-${BROKER_PARTITION_CAP_SERVICE}"' in text
+    assert "did not complete successfully." in text
+
+
+# ---------------------------------------------------------------------------
+# Fix 2b: raised per-consumer Kafka start timeout for the cold boot
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_cold_start_kafka_timeout_exported_before_restart() -> None:
+    """The deploy must export a raised KAFKA_TIMEOUT_SECONDS for the cold boot."""
+    text = _deploy_script_text()
+    assert "COLD_START_KAFKA_TIMEOUT_SECONDS" in text
+    assert 'export KAFKA_TIMEOUT_SECONDS="${cold_start_timeout}"' in text
+    # Active (non-comment) code must perform the export, not just mention it.
+    assert "export KAFKA_TIMEOUT_SECONDS" in _deploy_script_noncomment()
+
+
+@pytest.mark.unit
+def test_cold_start_timeout_clamped_to_config_bound() -> None:
+    """The exported timeout must be clamped to the config max (le=300)."""
+    text = _deploy_script_noncomment()
+    # Reject non-integers and clamp the upper bound so the kernel never receives
+    # a KAFKA_TIMEOUT_SECONDS its config validation rejects.
+    assert "must be a positive integer" in _deploy_script_text()
+    assert "cold_start_timeout=300" in text
+    assert "300" in text
+
+
+@pytest.mark.unit
+def test_compose_runtime_env_reads_kafka_timeout_seconds() -> None:
+    """x-runtime-env must read KAFKA_TIMEOUT_SECONDS so the export reaches containers."""
+    text = COMPOSE_FILE.read_text(encoding="utf-8")
+    # An exported shell var only reaches a container if the service env block
+    # interpolates it; x-runtime-env is the shared anchor for runtime services.
+    assert "KAFKA_TIMEOUT_SECONDS: ${KAFKA_TIMEOUT_SECONDS:-30}" in text, (
+        "x-runtime-env must declare KAFKA_TIMEOUT_SECONDS with a 30s default so "
+        "the deploy-script export propagates to runtime containers while a plain "
+        "`docker compose up` keeps the prior steady-state value (OMN-13220)."
+    )


### PR DESCRIPTION
Evidence-Source: OCC#2737
Evidence-Ticket: OMN-13220

## OMN-13220 — deploy-runtime.sh cold-start crash-loop + missing intelligence-migration

### Problem
Fresh-DB / fully-cold redeploys of the dev runtime lane crash-looped two ways (diagnosed during the OMN-13215 redeploy, `.onex_state/dev-redeploy-OMN-13215-DIAGNOSIS.md`):

1. **Missing intelligence-migration.** `docker-compose.infra.yml` gates `omninode-runtime` on `intelligence-migration: condition: service_completed_successfully`, but `restart_services()` uses `up -d --no-deps`, which **bypasses `depends_on`**. On a fresh-DB lane that left `public.db_metadata` for omniintelligence unstamped, so the kernel crash-looped. The diagnosis required running intelligence-migration by hand.
2. **Cold-start consumer-timeout crash-loop.** On a fully-cold lane the kernel joins a consumer group per subscribed topic; with 1300+ topics on a freshly-provisioned broker the default 30s per-consumer `KAFKA_TIMEOUT_SECONDS` blew on the slow group-coordinator tail (`Timeout starting consumer for topic ... after 30s`) and the kernel recycled before reaching healthy.

### Fix (deploy-runtime.sh + docker-compose.infra.yml)
1. Add `intelligence-migration` to `RUNTIME_MIGRATION_SERVICES` (ordered before the `migration-gate` keepalive). A new `RUNTIME_MIGRATION_ONESHOTS` set drives `docker wait` on the run-to-completion migrations (`forward-migration`, `intelligence-migration`); `migration-gate` (long-running healthcheck keepalive) is deliberately excluded from the wait set.
2. Break the cold-start crash-loop:
   - `warm_broker_topic_provisioning()` brings `redpanda` to a healthy state (`--wait`) and applies `redpanda-partition-cap` (run-to-completion, `docker wait`) **before** the kernel boots. The `--no-deps` runtime restart bypasses the compose `redpanda-partition-cap` `service_completed_successfully` gate, so the cap is applied explicitly so the 1300+-topic provisioning burst does not exhaust the partition ceiling.
   - Export a raised `KAFKA_TIMEOUT_SECONDS` (`COLD_START_KAFKA_TIMEOUT_SECONDS`, default 180s; validated as a positive integer and clamped to the `ModelKafkaEventBusConfig.timeout_seconds` `le=300` bound) for the restart-driven boot. Wired through a new `KAFKA_TIMEOUT_SECONDS: ${KAFKA_TIMEOUT_SECONDS:-30}` entry in the `x-runtime-env` anchor so the export reaches runtime containers while a plain `docker compose up` keeps the prior 30s steady-state default. The env var maps to `timeout_seconds` via `apply_environment_overrides`.
   - Ordering in `main()`: warmup -> migration preflight -> restart.

### Enforcement + tests (shellcheck + regression)
- New **shellcheck** pre-commit hook (shellcheck-py v0.11.0.1) scoped to the deploy-runtime surface (`scripts/deploy-runtime.sh` + `scripts/runtime_build/*.sh`); `deploy-runtime.sh` is shellcheck-clean. `.shellcheckrc` disables SC1091 (sourced host-env files shellcheck cannot follow) and is allowlisted in `validate_clean_root.py` (shellcheck reads it only from the project root).
- actionlint is intentionally NOT wired repo-wide here (a baseline run flags pre-existing findings across ~20 unrelated workflows this PR does not touch; documented inline). It was run ad-hoc for verification.
- `tests/scripts/test_deploy_runtime_coldstart.py` (7 tests): intelligence-migration in the migration services + before migration-gate; one-shot wait set includes the two migrations and excludes migration-gate; warmup runs before migration preflight before restart; partition-cap applied + waited; cold-start timeout exported + clamped; `x-runtime-env` reads `KAFKA_TIMEOUT_SECONDS`.

### Evidence (dod_evidence)
- `uv run pytest tests/scripts/ -q` → 144 passed (incl. the 7 new cold-start tests + 20 existing deploy-runtime tests).
- `uv run pytest tests/ -k clean_root -q` → 69 passed (validate_clean_root allowlist change).
- `bash -n scripts/deploy-runtime.sh` clean; `shellcheck scripts/deploy-runtime.sh` (repo .shellcheckrc) → exit 0; `pre-commit run` on staged files (shellcheck, yamlfmt, ruff, SPDX, clean-root, all ONEX validators) → pass.
- Functional dry-run: `deploy-runtime.sh --print-compose-cmd` with a fake docker emits compose commands without error.
- Scope: DEV lane only (omninode-runtime :8085 / runtime-effects :8086). This PR does NOT deploy, restart runtime, mutate stability-test/prod/judge, or publish live traffic.

OMN-13220

---
Evidence-Ticket: OMN-13220