### PR TITLE
fix(OMN-13212): [B2] repoint pr_review skill_mapping to node_pr_review_orchestrator

### DIFF
--- a/src/omnibase_infra/cli/skill_mapping.yaml
+++ b/src/omnibase_infra/cli/skill_mapping.yaml
@@ -197,8 +197,8 @@ skills:
       - {name: no-automerge, payload_field: no_automerge, arg_type: boolean, default: false}
       - {name: dry-run, payload_field: dry_run, arg_type: boolean, default: false}
   - skill_name: pr_review
-    node_name: node_pr_review_bot
-    result_model: omnimarket.nodes.node_pr_review_bot.models.models.ReviewVerdict
+    node_name: node_pr_review_orchestrator
+    result_model: omnimarket.review.pr_review_io.ReviewVerdict
     args:
       - {name: pr-number, payload_field: pr_number, arg_type: integer, required: true}
       - {name: repo, payload_field: repo, arg_type: string, required: true}
@@ -208,8 +208,8 @@ skills:
       - {name: max-findings-per-pr, payload_field: max_findings_per_pr, arg_type: integer}
       - {name: dry-run, payload_field: dry_run, arg_type: boolean, default: false}
   - skill_name: pr_review_bot
-    node_name: node_pr_review_bot
-    result_model: omnimarket.nodes.node_pr_review_bot.models.models.ReviewVerdict
+    node_name: node_pr_review_orchestrator
+    result_model: omnimarket.review.pr_review_io.ReviewVerdict
     args:
       - {name: pr-number, payload_field: pr_number, arg_type: integer, required: true}
       - {name: repo, payload_field: repo, arg_type: string, required: true}


### PR DESCRIPTION
Evidence-Source: OCC#2741
Evidence-Ticket: OMN-13212

## OMN-13212 [B2] — Repoint pr_review skill_mapping to node_pr_review_orchestrator

`node_pr_review_bot` `workflow` shell was rebuilt as `node_pr_review_orchestrator` (omnimarket PR #1263, epic OMN-13205). This repoints both `skill_mapping.yaml` entries (`pr_review` + `pr_review_bot`):

- `node_name`: `node_pr_review_bot` → `node_pr_review_orchestrator`
- `result_model`: `omnimarket.nodes.node_pr_review_bot.models.models.ReviewVerdict` → `omnimarket.review.pr_review_io.ReviewVerdict` (the re-homed verdict shape)

The `onex.cmd.omnimarket.pr-review-bot-start.v1` command topic is preserved, so the omniclaude skill dispatch is unchanged.

### Verification
- `pre-commit run --files src/omnibase_infra/cli/skill_mapping.yaml`: **PASS**
