### PR TITLE
feat(OMN-13131): add 'ui' cross-renderer producer to topic-naming allowlist (W5)

### DIFF
--- a/scripts/validation/lint_topic_names.py
+++ b/scripts/validation/lint_topic_names.py
@@ -65,6 +65,13 @@ _VALID_VERSION_PATTERN = re.compile(r"^v[1-9]\d*$|^v1$")
 
 # Allowlist of known producer segments — must match the emitting repo (OMN-8507).
 # Any structurally-valid producer not in this set is rejected with "unknown producer".
+#
+# "ui" (OMN-13131) is a cross-renderer producer domain, not a repo: the UI
+# renderer effect nodes (ui.effect.web / ui.effect.cli / ui.effect.ios) thin-publish
+# command envelopes onto the bus and are intentionally not owned by any single
+# backend repo. The first such topic is onex.cmd.ui.renderer-capability-declared.v1
+# (consumed by omnimarket node_renderer_capability_projection). Anchored by the
+# OMN-13131 OCC contract, which names this exact topic.
 _KNOWN_PRODUCERS: frozenset[str] = frozenset(
     {
         "omnimarket",
@@ -76,6 +83,7 @@ _KNOWN_PRODUCERS: frozenset[str] = frozenset(
         "omnibase-compat",
         "github",
         "platform",
+        "ui",
     }
 )
 _KNOWN_SNAPSHOT_PRODUCERS: frozenset[str] = frozenset({"platform", "projection"})

--- a/tests/unit/scripts/validation/test_lint_topic_names.py
+++ b/tests/unit/scripts/validation/test_lint_topic_names.py
@@ -197,6 +197,18 @@ def test_known_producer_accepted() -> None:
 
 
 @pytest.mark.unit
+def test_ui_cross_renderer_producer_accepted() -> None:
+    """OMN-13131: 'ui' is a canonical cross-renderer producer domain.
+
+    The renderer effect nodes (ui.effect.*) thin-publish capability declarations
+    onto onex.cmd.ui.renderer-capability-declared.v1; the producer 'ui' must be
+    accepted (not rejected as 'unknown producer').
+    """
+    result = lint_topic("onex.cmd.ui.renderer-capability-declared.v1")
+    assert result.is_valid, f"Expected valid but got violations: {result.violations}"
+
+
+@pytest.mark.unit
 def test_all_known_producers_accepted() -> None:
     """All entries in _KNOWN_PRODUCERS must produce valid 5-segment topics."""
     for producer in _KNOWN_PRODUCERS:
@@ -219,6 +231,7 @@ def test_known_producers_allowlist_complete() -> None:
         "omnibase-compat",
         "github",
         "platform",
+        "ui",
     }
     assert expected.issubset(_KNOWN_PRODUCERS), (
         f"Missing producers: {expected - _KNOWN_PRODUCERS}"


### PR DESCRIPTION
Evidence-Source: OCC#2751
Evidence-Ticket: OMN-13131

## What

Adds `ui` to the canonical `_KNOWN_PRODUCERS` allowlist in `scripts/validation/lint_topic_names.py` (the topic-naming-lint gate's source of truth, consumed cross-repo by omnimarket CI).

## Why

`ui` is a cross-renderer producer domain, not a single repo: the UI renderer effect nodes (`ui.effect.web` / `ui.effect.cli` / `ui.effect.ios`) thin-publish command envelopes onto the bus and are intentionally not owned by any backend repo. The first such topic is `onex.cmd.ui.renderer-capability-declared.v1`, consumed by the omnimarket `node_renderer_capability_projection` reducer (OMN-13131 / W5, epic OMN-13129). The OMN-13131 OCC contract names this exact topic.

Without this, `topic-naming-lint` rejects producer `ui` as "unknown producer", blocking the W5 capability-projection node PR in omnimarket (whose CI clones omnibase_infra dev for the lint script).

## Changes

- `scripts/validation/lint_topic_names.py`: add `ui` to `_KNOWN_PRODUCERS` (additive).
- `tests/unit/scripts/validation/test_lint_topic_names.py`: explicit `ui` cmd-topic acceptance test + expected-allowlist update.

## Verification

- `uv run pytest tests/unit/scripts/validation/test_lint_topic_names.py` -> 13 passed
- `uv run python scripts/validation/lint_topic_names.py --topic onex.cmd.ui.renderer-capability-declared.v1` -> OK
- ruff format/check clean; pre-commit run on changed files all green.

OCC receipt: `drift/dod_receipts/OMN-13131/dod-omnibase-infra-pr-2028/` (merged in OCC#2751).
