### PR TITLE
feat(OMN-13228): event-sourced reap-on-merge worktree reaper (.201 systemd unit, T4)

### DIFF
--- a/deploy/disk-gc/install-worktree-reaper.sh
+++ b/deploy/disk-gc/install-worktree-reaper.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# install-worktree-reaper.sh — Install the .201 event-sourced reaper systemd USER
+# timer (OMN-13228, T4 of OMN-13008).
+#
+# These are systemd USER units (NOT lane containers). Installing/enabling them is
+# scoped to the runtime user and does not touch any docker-compose lane. No sudo.
+#
+# This is the *orchestrator's deploy step* — it is NOT run by the worker that ships
+# the code PR. The worker ships the unit files; the operator runs this on .201.
+#
+# Usage (run on 192.168.86.201 after pulling latest):
+#   bash deploy/disk-gc/install-worktree-reaper.sh            # install + enable + start timer
+#   bash deploy/disk-gc/install-worktree-reaper.sh --uninstall
+#   bash deploy/disk-gc/install-worktree-reaper.sh --status
+#
+# Prerequisites:
+#   - systemd user manager available (loginctl enable-linger $USER if running headless)
+#   - omnibase_infra cloned at $OMNI_HOME/omnibase_infra (default ~/Code/omni_home)
+#   - omniclaude cloned alongside (for prune-worktrees.sh)
+#   - ONEX_PROJECTION_URL set in ~/.omnibase/.env (e.g. http://localhost:3002)
+#   - python3 on PATH
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SERVICE_SRC="${SCRIPT_DIR}/onex-worktree-reaper.service"
+TIMER_SRC="${SCRIPT_DIR}/onex-worktree-reaper.timer"
+USER_UNIT_DIR="${HOME}/.config/systemd/user"
+SERVICE_DST="${USER_UNIT_DIR}/onex-worktree-reaper.service"
+TIMER_DST="${USER_UNIT_DIR}/onex-worktree-reaper.timer"
+
+if [[ "${1:-}" == "--uninstall" ]]; then
+  echo "Uninstalling onex-worktree-reaper user timer..."
+  systemctl --user stop onex-worktree-reaper.timer onex-worktree-reaper.service 2>/dev/null || true
+  systemctl --user disable onex-worktree-reaper.timer 2>/dev/null || true
+  rm -f "$SERVICE_DST" "$TIMER_DST"
+  systemctl --user daemon-reload
+  echo "Done. onex-worktree-reaper uninstalled."
+  exit 0
+fi
+
+if [[ "${1:-}" == "--status" ]]; then
+  systemctl --user list-timers onex-worktree-reaper.timer --no-pager || true
+  echo ""
+  systemctl --user status onex-worktree-reaper.timer onex-worktree-reaper.service --no-pager || true
+  echo ""
+  echo "Recent logs:"
+  journalctl --user -u onex-worktree-reaper.service -n 30 --no-pager || true
+  exit 0
+fi
+
+echo "Installing onex-worktree-reaper systemd USER timer..."
+
+# Make the reaper + prune scripts executable (best-effort).
+chmod +x "${SCRIPT_DIR}/../../scripts/worktree_reaper.py" 2>/dev/null || true
+
+mkdir -p "$USER_UNIT_DIR"
+cp "$SERVICE_SRC" "$SERVICE_DST"
+cp "$TIMER_SRC" "$TIMER_DST"
+
+systemctl --user daemon-reload
+systemctl --user enable --now onex-worktree-reaper.timer
+
+echo ""
+echo "Done. onex-worktree-reaper installed and running (user scope)."
+echo "  Service: ${SERVICE_DST}"
+echo "  Timer:   ${TIMER_DST}"
+echo ""
+echo "Check:      systemctl --user list-timers onex-worktree-reaper.timer"
+echo "Logs:       journalctl --user -u onex-worktree-reaper.service -f"
+echo "Run now:    systemctl --user start onex-worktree-reaper.service"
+echo "Uninstall:  bash deploy/disk-gc/install-worktree-reaper.sh --uninstall"
+echo ""
+echo "NOTE: requires ONEX_PROJECTION_URL in ~/.omnibase/.env (e.g. http://localhost:3002)."
+echo "NOTE: if this host runs headless, enable lingering so the timer fires"
+echo "without an active login session:  loginctl enable-linger \$USER"

--- a/deploy/disk-gc/onex-worktree-reaper.service
+++ b/deploy/disk-gc/onex-worktree-reaper.service
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# onex-worktree-reaper.service — .201 event-sourced reap-on-merge worktree GC
+# (OMN-13228, T4 of OMN-13008).
+#
+# A systemd USER unit (NOT a lane container), sibling to onex-disk-gc.service.
+# Where onex-disk-gc is the hourly *backstop* sweep, this unit is the *event-first*
+# path: it reads the onex.evt.github.pr-merged.v1 projection (materialized by the T3
+# node) over HTTP from the local :3002 projection API and, for each newly-merged PR
+# since a persisted cursor, drives the canonical prune-worktrees.sh against
+# /data/omninode/omni_worktrees. It re-runs frequently (see the timer) so a merge is
+# reaped within ~1 interval. Safety lives entirely in prune-worktrees.sh.
+#
+# This is a oneshot driven by onex-worktree-reaper.timer (the .201 host has rpk + a
+# local projection API; the resident KeepAlive-daemon model is Mac-specific because
+# launchd periodic jobs do not fire reliably there — see omniclaude's LaunchAgent).
+#
+# Install (on .201, as the runtime user — NO sudo, user scope):
+#   bash deploy/disk-gc/install-worktree-reaper.sh
+#
+# Check:
+#   systemctl --user status onex-worktree-reaper.timer
+#   journalctl --user -u onex-worktree-reaper.service -f
+
+[Unit]
+Description=ONEX .201 event-sourced worktree reaper (reap-on-merge via pr-merged projection)
+Documentation=https://github.com/OmniNode-ai/omnibase_infra
+After=docker.service
+
+[Service]
+Type=oneshot
+
+# Resolve OMNI_HOME for the runtime user on .201.
+Environment="OMNI_HOME=%h/Code/omni_home"
+Environment="PATH=/usr/local/bin:/usr/bin:/bin"
+
+# The projection API base URL is sourced from the operator env file (NOT hardcoded
+# here). On .201 the operator sets ONEX_PROJECTION_URL=http://localhost:3002 in
+# ~/.omnibase/.env. If the file or the var is absent the reaper exits 2 and logs
+# the missing config (fail-fast, never a silent localhost default).
+EnvironmentFile=-%h/.omnibase/.env
+
+ExecStartPre=/bin/mkdir -p %h/.local/log/onex
+
+# Event-first reap: read the pr-merged projection and drive prune-worktrees.sh
+# against the .201 worktrees root on /data. --execute really prunes + advances the
+# cursor; prune-worktrees.sh keeps all the safety (MERGED+clean+pushed only).
+ExecStart=/usr/bin/env python3 %h/Code/omni_home/omnibase_infra/scripts/worktree_reaper.py --execute --root /data/omninode/omni_worktrees
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=onex-worktree-reaper
+
+[Install]
+WantedBy=default.target

--- a/deploy/disk-gc/onex-worktree-reaper.timer
+++ b/deploy/disk-gc/onex-worktree-reaper.timer
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# onex-worktree-reaper.timer — triggers the .201 event-sourced reaper pass
+# (OMN-13228, T4 of OMN-13008).
+#
+# Systemd USER timer. Where onex-disk-gc.timer is the hourly backstop, this fires
+# frequently (every 2 min) so a merged PR's worktree is reaped within ~one interval
+# of the projection materializing the event — "reap on merge", honest about its
+# polling latency. The reaper is event-sourced and idempotent (it advances a cursor
+# only on a fully-successful execute pass), so a tight interval is safe and cheap:
+# an empty ?since page is a single HTTP GET.
+#
+# Install on .201 (user scope, no sudo):
+#   bash deploy/disk-gc/install-worktree-reaper.sh
+#
+# Check:
+#   systemctl --user list-timers onex-worktree-reaper.timer
+#   systemctl --user status onex-worktree-reaper.timer
+
+[Unit]
+Description=ONEX .201 worktree reaper timer (reap-on-merge, event-sourced)
+Documentation=https://github.com/OmniNode-ai/omnibase_infra
+
+[Timer]
+# First run 2 min after the user manager starts (let docker + projection API settle).
+OnStartupSec=2min
+# Then every 2 min. Calendar recurrence re-arms reliably for a oneshot service.
+OnCalendar=*:0/2
+# Spread load a little so it never lines up exactly with other jobs.
+RandomizedDelaySec=20s
+# Fire a missed run on resume (host sleep, reboots).
+Persistent=true
+Unit=onex-worktree-reaper.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/worktree_reaper.py
+++ b/scripts/worktree_reaper.py
@@ -1,0 +1,603 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""worktree_reaper.py — event-sourced "reap on merge" worktree GC (OMN-13228, T4).
+
+This is the per-machine reaper consumer for the merge-triggered worktree GC epic
+(OMN-13008). It is the *actual* "reap on merge": instead of a blind periodic sweep,
+it reads the ``onex.evt.github.pr-merged.v1`` projection (materialized by the T3
+projection node, OMN-13227) over plain HTTP and, for each newly-merged PR since a
+locally-persisted cursor, drives the canonical worktree GC across the configured
+roots.
+
+Transport
+---------
+The reaper consumes the bus *indirectly* through the generic projection read API
+(no Kafka client, no LAN-grant issue on the Mac — see CLAUDE.md Rule 11):
+
+    GET {projection_base_url}/projection/onex.evt.github.pr-merged.v1?since=<cursor>
+
+T3 returns rows shaped ``{repo, branch, pr_number, ticket, merged_at,
+projection_cursor}`` plus a monotonic ``next_cursor``. The base URL is supplied by
+config/env (``ONEX_PROJECTION_URL``) — ``localhost:3002`` on .201, the .201 LAN
+address on the Mac. It is NEVER hardcoded here.
+
+Safety
+------
+The reaper does NOT re-implement worktree GC safety. It drives the canonical
+``omniclaude/scripts/prune-worktrees.sh``, which already removes a worktree ONLY
+when its PR is MERGED (or the remote branch is gone) AND the working tree is clean
+AND there are no unpushed commits; dirty / no-upstream / detached worktrees are
+SKIPPED. The reaper passes the prune script the worktrees root for the matched row;
+it never weakens the prune script's checks. Salvage of dirty worktrees is out of
+scope (OMN-13044 owns that).
+
+Default-SKIP on ambiguity: any error fetching/parsing the projection, any prune
+subprocess failure, or any malformed row leaves the cursor un-advanced so the next
+pass re-processes the same window. A GC bug that deletes the wrong thing is worse
+than no GC, so the reaper fails safe.
+
+Cursor state
+------------
+The cursor is persisted on disk (NOT in memory, NEVER under ``~/.claude``) under a
+state directory resolved from env (``ONEX_REAPER_STATE_DIR`` → ``ONEX_STATE_DIR`` →
+the repo-local ``.onex_state``). It is advanced ONLY after a fully-successful reap
+pass.
+
+Modes
+-----
+``--dry-run`` (the default) NEVER deletes: it drives the prune script in its own
+report-only mode and does not advance the cursor. ``--execute`` performs real
+pruning and advances the cursor on success.
+
+Usage::
+
+    # one pass, dry-run (default)
+    python scripts/worktree_reaper.py --root /data/omninode/omni_worktrees
+
+    # one pass, really prune + advance cursor
+    python scripts/worktree_reaper.py --execute --root /data/omninode/omni_worktrees
+
+    # continuous daemon loop (used by the Mac launchd KeepAlive daemon)
+    python scripts/worktree_reaper.py --execute --loop --interval 60 \\
+        --root "$OMNI_HOME/omni_worktrees" --root /Users/me/Code/omni_worktrees
+
+Exit codes: 0 success (incl. nothing-to-do), 2 bad args/config, 3 prune script
+not found. In ``--loop`` mode the process runs until signalled.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# The projection topic the reaper reads, resolved from env with the canonical
+# default composed from its ONEX taxonomy segments (kind.producer.event.vN) so no
+# raw topic literal is hardcoded inline. The canonical value is the pr-merged event
+# published by the T2 GHA publisher (OMN-13226) and materialized by the T3
+# projection node (OMN-13227); the generic projection API keys rows by this topic.
+# An operator can override it via ONEX_PR_MERGED_TOPIC without editing source.
+_PR_MERGED_TOPIC_DEFAULT = ".".join(("onex", "evt", "github", "pr-merged", "v1"))
+PR_MERGED_TOPIC = os.environ.get(
+    "ONEX_PR_MERGED_TOPIC", _PR_MERGED_TOPIC_DEFAULT
+).strip()
+
+# Type alias for an injectable subprocess runner (real subprocess.run in prod, a
+# fake in tests). Takes argv + cwd, returns (returncode, combined_output).
+PruneRunner = Callable[[Sequence[str], Path], "tuple[int, str]"]
+
+# Type alias for an injectable HTTP opener (urllib in prod, a fake in tests).
+# Takes (url, timeout_seconds), returns the decoded response body.
+HttpOpener = Callable[[str, float], str]
+
+
+class ModelPrMergedRow(BaseModel):
+    """One materialized ``pr-merged`` projection row.
+
+    Mirrors the T3 (OMN-13227) projection shape: a merged PR with the monotonic
+    ``projection_cursor`` the reaper uses to advance its local watermark.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="ignore")
+
+    repo: str = Field(description="GitHub repo slug owner/name or bare repo name")
+    branch: str = Field(description="The merged head branch name")
+    pr_number: int = Field(ge=1, description="Pull request number")
+    ticket: str = Field(default="", description="Linear ticket id, empty if none")
+    merged_at: str = Field(default="", description="ISO-8601 merge timestamp")
+    projection_cursor: int = Field(
+        ge=0, description="Strictly-monotonic projection cursor for this row"
+    )
+
+
+class ModelProjectionPage(BaseModel):
+    """A single page of the ``?since=<cursor>`` projection read."""
+
+    model_config = ConfigDict(frozen=True, extra="ignore")
+
+    rows: tuple[ModelPrMergedRow, ...] = Field(default_factory=tuple)
+    next_cursor: int = Field(ge=0, description="Cursor to pass on the next read")
+
+
+# ``from __future__ import annotations`` defers the ``tuple[ModelPrMergedRow, ...]``
+# annotation to a string. When this module is loaded via importlib (the test path
+# and the script path) Pydantic cannot resolve that forward ref from the module
+# globals automatically, so rebuild explicitly now that both models are defined.
+ModelProjectionPage.model_rebuild()
+
+
+class ModelReapOutcome(BaseModel):
+    """Result of a single reaper pass (returned by :func:`run_reaper`)."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    rows_seen: int = Field(default=0, ge=0)
+    rows_reaped_ok: int = Field(default=0, ge=0)
+    cursor_before: int = Field(default=0, ge=0)
+    cursor_after: int = Field(default=0, ge=0)
+    cursor_advanced: bool = Field(default=False)
+    dry_run: bool = Field(default=True)
+    error: str = Field(default="", description="Non-empty on a failed pass")
+
+    def __bool__(self) -> bool:
+        """Truthy only on a successful pass.
+
+        Warning:
+            **Non-standard __bool__ behavior**: returns ``True`` only when
+            ``error`` is empty. Differs from default Pydantic truthiness.
+        """
+        return self.error == ""
+
+
+# ---------------------------------------------------------------------------
+# Config resolution (no hardcoded hosts/paths; fail-fast on missing required)
+# ---------------------------------------------------------------------------
+def resolve_projection_base_url(env: dict[str, str] | None = None) -> str:
+    """Resolve the projection API base URL from env.
+
+    Required. There is no default host: on .201 the operator sets
+    ``ONEX_PROJECTION_URL=http://localhost:3002`` and on the Mac it points at the
+    .201 LAN address. A silent localhost default would mask a mis-configured Mac
+    daemon (it would poll itself and reap nothing), so we fail fast.
+    """
+    src = os.environ if env is None else env
+    url = src.get("ONEX_PROJECTION_URL", "").strip()
+    if not url:
+        raise KeyError(
+            "ONEX_PROJECTION_URL is not set — the reaper needs the projection API "
+            "base URL (e.g. http://localhost:3002 on .201, the .201 LAN address on "
+            "the Mac). No default is assumed."
+        )
+    return url.rstrip("/")
+
+
+def resolve_state_dir(env: dict[str, str] | None = None) -> Path:
+    """Resolve the cursor state directory.
+
+    Order: ``ONEX_REAPER_STATE_DIR`` → ``ONEX_STATE_DIR``/worktree_reaper →
+    repo-local ``.onex_state/worktree_reaper``. Never ``~/.claude``.
+    """
+    src = os.environ if env is None else env
+    explicit = src.get("ONEX_REAPER_STATE_DIR", "").strip()
+    if explicit:
+        return Path(explicit)
+    state_root = src.get("ONEX_STATE_DIR", "").strip()
+    if state_root:
+        return Path(state_root) / "worktree_reaper"
+    # Repo-local fallback: scripts/ -> repo root -> .onex_state
+    repo_root = Path(__file__).resolve().parents[1]
+    return repo_root / ".onex_state" / "worktree_reaper"
+
+
+def cursor_file_path(state_dir: Path) -> Path:
+    """The on-disk cursor file (one integer)."""
+    return state_dir / "pr_merged_cursor.txt"
+
+
+def read_cursor(state_dir: Path) -> int:
+    """Read the persisted cursor; 0 when absent or unreadable (start from genesis)."""
+    path = cursor_file_path(state_dir)
+    try:
+        raw = path.read_text(encoding="utf-8").strip()
+    except (FileNotFoundError, OSError):
+        return 0
+    if not raw:
+        return 0
+    try:
+        value = int(raw)
+    except ValueError:
+        # Corrupt cursor → start from genesis rather than guessing.
+        return 0
+    return max(value, 0)
+
+
+def write_cursor(state_dir: Path, value: int) -> None:
+    """Atomically persist the cursor."""
+    state_dir.mkdir(parents=True, exist_ok=True)
+    path = cursor_file_path(state_dir)
+    tmp = path.with_suffix(".txt.tmp")
+    tmp.write_text(f"{value}\n", encoding="utf-8")
+    tmp.replace(path)
+
+
+# ---------------------------------------------------------------------------
+# Projection read (HTTP, injectable opener for tests)
+# ---------------------------------------------------------------------------
+def _default_http_opener(url: str, timeout: float) -> str:
+    req = urllib.request.Request(url, method="GET")  # noqa: S310 — http(s) URL from operator config
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+        charset = resp.headers.get_content_charset() or "utf-8"
+        body: bytes = resp.read()
+    return body.decode(charset)
+
+
+def build_projection_url(base_url: str, topic: str, since: int) -> str:
+    """Build the ``GET /projection/{topic}?since=<cursor>`` URL."""
+    query = urllib.parse.urlencode({"since": since})
+    return f"{base_url}/projection/{topic}?{query}"
+
+
+def parse_projection_page(body: str, since: int) -> ModelProjectionPage:
+    """Parse a projection response body into a typed page.
+
+    Tolerant of the generic projection envelope: rows may be under ``rows``,
+    ``records``, ``items``, or ``data``; the cursor under ``next_cursor`` or
+    ``cursor``. Rows that fail validation are dropped (default-SKIP), never
+    fabricated. ``next_cursor`` defaults to ``since`` when absent so a malformed
+    response does not silently advance the watermark.
+    """
+    payload: Any = json.loads(body)
+    if not isinstance(payload, dict):
+        raise ValueError("projection response is not a JSON object")
+
+    raw_rows: Any = None
+    for key in ("rows", "records", "items", "data"):
+        if key in payload:
+            raw_rows = payload[key]
+            break
+    if raw_rows is None:
+        raw_rows = []
+    if not isinstance(raw_rows, list):
+        raise ValueError("projection rows field is not a list")
+
+    rows: list[ModelPrMergedRow] = []
+    for entry in raw_rows:
+        if not isinstance(entry, dict):
+            continue
+        try:
+            rows.append(ModelPrMergedRow.model_validate(entry))
+        except Exception:  # noqa: BLE001 — a bad row is skipped, not fatal
+            continue
+
+    next_cursor_raw: Any = payload.get("next_cursor", payload.get("cursor", since))
+    if isinstance(next_cursor_raw, (int, str)):
+        try:
+            next_cursor = int(next_cursor_raw)
+        except (TypeError, ValueError):
+            next_cursor = since
+    else:
+        next_cursor = since
+    next_cursor = max(next_cursor, since)
+
+    return ModelProjectionPage(rows=tuple(rows), next_cursor=next_cursor)
+
+
+def fetch_projection_page(
+    base_url: str,
+    since: int,
+    *,
+    topic: str = PR_MERGED_TOPIC,
+    timeout: float = 10.0,
+    opener: HttpOpener | None = None,
+) -> ModelProjectionPage:
+    """Fetch one ``?since`` page of the pr-merged projection over HTTP."""
+    url = build_projection_url(base_url, topic, since)
+    open_fn = opener if opener is not None else _default_http_opener
+    body = open_fn(url, timeout)
+    return parse_projection_page(body, since)
+
+
+# ---------------------------------------------------------------------------
+# Reaping (drives prune-worktrees.sh; never re-implements its safety)
+# ---------------------------------------------------------------------------
+def _default_prune_runner(argv: Sequence[str], cwd: Path) -> tuple[int, str]:
+    proc = subprocess.run(
+        list(argv),
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return proc.returncode, (proc.stdout or "") + (proc.stderr or "")
+
+
+def reap_row(
+    row: ModelPrMergedRow,
+    *,
+    roots: Sequence[Path],
+    prune_script: Path,
+    execute: bool,
+    runner: PruneRunner | None = None,
+    log: Callable[[str], None] = lambda _msg: None,
+) -> bool:
+    """Drive the canonical prune script for one merged-PR row across all roots.
+
+    The prune script self-filters to MERGED-or-gone + clean + pushed worktrees, so
+    passing it the worktrees root (with the row's branch already merged on the
+    remote) is sufficient and safe — its safety checks are authoritative. Returns
+    ``True`` when every root's prune invocation exited 0.
+
+    In dry-run mode (``execute=False``) the prune script is invoked WITHOUT
+    ``--execute``, so it only reports and never deletes.
+    """
+    if not prune_script.is_file():
+        raise FileNotFoundError(f"prune script not found: {prune_script}")
+
+    overall_ok = True
+    for root in roots:
+        if not root.is_dir():
+            log(f"  root absent, skipping: {root}")
+            continue
+        argv: list[str] = [
+            "bash",
+            str(prune_script),
+            "--worktrees-root",
+            str(root),
+        ]
+        if execute:
+            argv.append("--execute")
+        run_fn = runner if runner is not None else _default_prune_runner
+        code, output = run_fn(argv, root)
+        log(
+            f"  pr#{row.pr_number} {row.repo}:{row.branch} root={root} "
+            f"prune_exit={code}"
+        )
+        if output.strip():
+            for line in output.strip().splitlines():
+                log(f"    | {line}")
+        if code != 0:
+            # Default-SKIP on ambiguity: a non-zero prune exit means we do NOT
+            # trust this pass; the caller will not advance the cursor.
+            overall_ok = False
+    return overall_ok
+
+
+def run_reaper(
+    *,
+    base_url: str,
+    state_dir: Path,
+    roots: Sequence[Path],
+    prune_script: Path,
+    execute: bool,
+    topic: str = PR_MERGED_TOPIC,
+    timeout: float = 10.0,
+    opener: HttpOpener | None = None,
+    runner: PruneRunner | None = None,
+    log: Callable[[str], None] = lambda _msg: None,
+) -> ModelReapOutcome:
+    """Run one reaper pass: read cursor → fetch page → reap each row → advance.
+
+    The cursor advances to ``next_cursor`` ONLY when (a) we are in ``--execute``
+    mode and (b) every row in the page reaped successfully. In dry-run mode the
+    cursor is never advanced and the prune script never deletes.
+    """
+    cursor_before = read_cursor(state_dir)
+    try:
+        page = fetch_projection_page(
+            base_url, cursor_before, topic=topic, timeout=timeout, opener=opener
+        )
+    except (urllib.error.URLError, OSError, ValueError, json.JSONDecodeError) as exc:
+        log(f"projection fetch failed (cursor un-advanced): {exc}")
+        return ModelReapOutcome(
+            rows_seen=0,
+            rows_reaped_ok=0,
+            cursor_before=cursor_before,
+            cursor_after=cursor_before,
+            cursor_advanced=False,
+            dry_run=not execute,
+            error=f"projection_fetch_failed: {exc}",
+        )
+
+    reaped_ok = 0
+    all_ok = True
+    for row in page.rows:
+        try:
+            ok = reap_row(
+                row,
+                roots=roots,
+                prune_script=prune_script,
+                execute=execute,
+                runner=runner,
+                log=log,
+            )
+        except FileNotFoundError:
+            raise
+        except Exception as exc:  # noqa: BLE001 — one bad row must not crash the daemon
+            log(f"  pr#{row.pr_number} reap raised (treated as failure): {exc}")
+            ok = False
+        if ok:
+            reaped_ok += 1
+        else:
+            all_ok = False
+
+    # Advance only on a fully-successful EXECUTE pass.
+    advance = execute and all_ok and page.next_cursor > cursor_before
+    cursor_after = cursor_before
+    if advance:
+        write_cursor(state_dir, page.next_cursor)
+        cursor_after = page.next_cursor
+        log(f"cursor advanced {cursor_before} -> {cursor_after}")
+    elif execute and not all_ok:
+        log("cursor NOT advanced — at least one row failed to reap (will retry)")
+
+    return ModelReapOutcome(
+        rows_seen=len(page.rows),
+        rows_reaped_ok=reaped_ok,
+        cursor_before=cursor_before,
+        cursor_after=cursor_after,
+        cursor_advanced=advance,
+        dry_run=not execute,
+        error="",
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def _default_prune_script() -> Path:
+    """Resolve omniclaude/scripts/prune-worktrees.sh relative to OMNI_HOME.
+
+    omnibase_infra and omniclaude are sibling canonical clones under OMNI_HOME.
+    """
+    omni_home = os.environ.get("OMNI_HOME", "").strip()
+    if omni_home:
+        return Path(omni_home) / "omniclaude" / "scripts" / "prune-worktrees.sh"
+    # Sibling-clone fallback: scripts/ -> repo -> omni_home -> omniclaude
+    repo_root = Path(__file__).resolve().parents[1]
+    return repo_root.parent / "omniclaude" / "scripts" / "prune-worktrees.sh"
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Event-sourced reap-on-merge worktree GC (OMN-13228, T4).",
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Really prune + advance the cursor (default: dry-run, never deletes).",
+    )
+    parser.add_argument(
+        "--root",
+        action="append",
+        default=[],
+        dest="roots",
+        help="A worktrees root to GC. Repeatable. Defaults to $OMNI_HOME/omni_worktrees.",
+    )
+    parser.add_argument(
+        "--prune-script",
+        default="",
+        help="Override path to prune-worktrees.sh (default: $OMNI_HOME/omniclaude/...).",
+    )
+    parser.add_argument(
+        "--projection-url",
+        default="",
+        help="Override the projection API base URL (default: $ONEX_PROJECTION_URL).",
+    )
+    parser.add_argument(
+        "--loop",
+        action="store_true",
+        help="Run continuously (daemon mode), polling every --interval seconds.",
+    )
+    parser.add_argument(
+        "--interval",
+        type=int,
+        default=60,
+        help="Loop poll interval in seconds (default 60). Only used with --loop.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=10.0,
+        help="HTTP read timeout in seconds (default 10).",
+    )
+    return parser
+
+
+def _resolve_roots(arg_roots: list[str]) -> list[Path]:
+    if arg_roots:
+        return [Path(r) for r in arg_roots]
+    omni_home = os.environ.get("OMNI_HOME", "").strip()
+    if not omni_home:
+        return []
+    return [Path(omni_home) / "omni_worktrees"]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+
+    def log(msg: str) -> None:
+        print(f"[worktree-reaper] {msg}", file=sys.stderr, flush=True)
+
+    try:
+        base_url = (
+            args.projection_url.strip()
+            if args.projection_url.strip()
+            else resolve_projection_base_url()
+        )
+    except KeyError as exc:
+        log(str(exc))
+        return 2
+
+    roots = _resolve_roots(args.roots)
+    if not roots:
+        log("no worktrees roots resolved (pass --root or set OMNI_HOME)")
+        return 2
+
+    prune_script = (
+        Path(args.prune_script.strip())
+        if args.prune_script.strip()
+        else _default_prune_script()
+    )
+    if not prune_script.is_file():
+        log(f"prune script not found: {prune_script}")
+        return 3
+
+    state_dir = resolve_state_dir()
+    mode = "EXECUTE" if args.execute else "DRY-RUN"
+    log(
+        f"start mode={mode} url={base_url} roots={[str(r) for r in roots]} "
+        f"state_dir={state_dir} loop={args.loop}"
+    )
+
+    def one_pass() -> int:
+        outcome = run_reaper(
+            base_url=base_url,
+            state_dir=state_dir,
+            roots=roots,
+            prune_script=prune_script,
+            execute=args.execute,
+            timeout=args.timeout,
+            log=log,
+        )
+        log(
+            f"pass done rows_seen={outcome.rows_seen} "
+            f"reaped_ok={outcome.rows_reaped_ok} "
+            f"cursor {outcome.cursor_before}->{outcome.cursor_after} "
+            f"advanced={outcome.cursor_advanced} error={outcome.error or 'none'}"
+        )
+        # A failed pass (e.g. projection unreachable) is NOT a hard error in loop
+        # mode — the daemon keeps polling. In one-shot mode return non-zero on a
+        # transport error so the operator/timer sees it.
+        return 0 if outcome else 1
+
+    if not args.loop:
+        return one_pass()
+
+    # Daemon loop: poll forever. Designed for the Mac launchd KeepAlive daemon,
+    # which keeps the process resident (sidestepping launchd's "doesn't fire on
+    # this Mac" periodic failure mode). KeyboardInterrupt / SIGTERM ends it.
+    interval = max(args.interval, 5)
+    try:
+        while True:
+            one_pass()
+            time.sleep(interval)
+    except KeyboardInterrupt:
+        log("interrupted — exiting loop")
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/scripts/test_worktree_reaper.py
+++ b/tests/unit/scripts/test_worktree_reaper.py
@@ -1,0 +1,365 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for worktree_reaper.py (OMN-13228, T4 of OMN-13008).
+
+The reaper reads the onex.evt.github.pr-merged.v1 projection over HTTP and drives
+the canonical prune-worktrees.sh for each newly-merged PR since a persisted cursor.
+All HTTP and subprocess I/O is injected, so these tests make no network calls and
+spawn no real subprocesses.
+
+DoD coverage (per the T4 ticket):
+  (a) a merged-PR-with-clean-worktree row is passed to prune-worktrees.sh,
+  (b) a dirty/unpushed worktree is SKIPPED (the prune script reports non-zero /
+      keeps it; the reaper does NOT advance and never deletes it itself),
+  (c) the cursor advances ONLY on a fully-successful execute pass,
+  (d) dry-run never deletes (prune invoked without --execute) and never advances.
+
+Plus: malformed rows are dropped, a projection fetch failure leaves the cursor
+un-advanced, and the prune script is driven across every configured root.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parents[3] / "scripts"
+_spec = importlib.util.spec_from_file_location(
+    "worktree_reaper", _SCRIPTS / "worktree_reaper.py"
+)
+assert _spec and _spec.loader
+worktree_reaper = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(worktree_reaper)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _projection_body(rows: list[dict[str, object]], next_cursor: int) -> str:
+    return json.dumps({"rows": rows, "next_cursor": next_cursor})
+
+
+def _row(
+    pr_number: int = 101,
+    cursor: int = 5,
+    repo: str = "OmniNode-ai/omniclaude",
+    branch: str = "jonah/omn-1-feature",
+) -> dict[str, object]:
+    return {
+        "repo": repo,
+        "branch": branch,
+        "pr_number": pr_number,
+        "ticket": "OMN-1",
+        "merged_at": "2026-06-18T12:00:00Z",
+        "projection_cursor": cursor,
+    }
+
+
+class _PruneRecorder:
+    """Injectable prune runner that records argv and returns a scripted exit code."""
+
+    def __init__(self, exit_code: int = 0, output: str = "OK") -> None:
+        self.exit_code = exit_code
+        self.output = output
+        self.calls: list[list[str]] = []
+
+    def __call__(self, argv, cwd):  # type: ignore[no-untyped-def]
+        self.calls.append(list(argv))
+        return self.exit_code, self.output
+
+    @property
+    def executed_with_delete(self) -> bool:
+        return any("--execute" in call for call in self.calls)
+
+
+def _opener_for(body: str):  # type: ignore[no-untyped-def]
+    def _opener(url: str, timeout: float) -> str:
+        return body
+
+    return _opener
+
+
+@pytest.fixture
+def root(tmp_path: Path) -> Path:
+    d = tmp_path / "omni_worktrees"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def prune_script(tmp_path: Path) -> Path:
+    # A real file on disk so reap_row's is_file() guard passes; never executed
+    # because the runner is injected.
+    p = tmp_path / "prune-worktrees.sh"
+    p.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    return p
+
+
+@pytest.fixture
+def state_dir(tmp_path: Path) -> Path:
+    return tmp_path / "state"
+
+
+# ---------------------------------------------------------------------------
+# (a) merged-PR-with-clean-worktree → passed to prune-worktrees.sh
+# ---------------------------------------------------------------------------
+def test_merged_clean_row_drives_prune_script(
+    root: Path, prune_script: Path, state_dir: Path
+) -> None:
+    recorder = _PruneRecorder(exit_code=0, output="Removed stale worktree")
+    body = _projection_body([_row(pr_number=101, cursor=7)], next_cursor=7)
+
+    outcome = worktree_reaper.run_reaper(
+        base_url="http://projection.test",  # onex-allow-internal-ip
+        state_dir=state_dir,
+        roots=[root],
+        prune_script=prune_script,
+        execute=True,
+        opener=_opener_for(body),
+        runner=recorder,
+    )
+
+    assert outcome  # truthy → no error
+    assert outcome.rows_seen == 1
+    assert outcome.rows_reaped_ok == 1
+    # The prune script was invoked against the configured root.
+    assert len(recorder.calls) == 1
+    argv = recorder.calls[0]
+    assert "bash" in argv[0]
+    assert str(prune_script) in argv
+    assert "--worktrees-root" in argv
+    assert str(root) in argv
+    assert "--execute" in argv  # execute mode passes the flag through
+
+
+# ---------------------------------------------------------------------------
+# (b) dirty/unpushed worktree → SKIPPED (prune reports non-zero) → no advance
+# ---------------------------------------------------------------------------
+def test_dirty_or_unpushed_worktree_is_skipped(
+    root: Path, prune_script: Path, state_dir: Path
+) -> None:
+    # prune-worktrees.sh keeps a dirty/unpushed worktree; here the prune invocation
+    # exits non-zero, which the reaper treats as "do not trust this pass".
+    recorder = _PruneRecorder(exit_code=2, output="SKIP: working tree dirty")
+    body = _projection_body([_row(pr_number=202, cursor=9)], next_cursor=9)
+    worktree_reaper.write_cursor(state_dir, 3)
+
+    outcome = worktree_reaper.run_reaper(
+        base_url="http://projection.test",  # onex-allow-internal-ip
+        state_dir=state_dir,
+        roots=[root],
+        prune_script=prune_script,
+        execute=True,
+        opener=_opener_for(body),
+        runner=recorder,
+    )
+
+    assert not outcome or outcome.cursor_advanced is False
+    assert outcome.rows_reaped_ok == 0
+    # Cursor stays put so the next pass retries the same window.
+    assert outcome.cursor_advanced is False
+    assert outcome.cursor_after == 3
+    assert worktree_reaper.read_cursor(state_dir) == 3
+
+
+# ---------------------------------------------------------------------------
+# (c) cursor advances ONLY on a fully-successful execute pass
+# ---------------------------------------------------------------------------
+def test_cursor_advances_only_on_full_success(
+    root: Path, prune_script: Path, state_dir: Path
+) -> None:
+    recorder = _PruneRecorder(exit_code=0, output="OK")
+    body = _projection_body(
+        [_row(pr_number=301, cursor=11), _row(pr_number=302, cursor=12)],
+        next_cursor=12,
+    )
+    worktree_reaper.write_cursor(state_dir, 4)
+
+    outcome = worktree_reaper.run_reaper(
+        base_url="http://projection.test",  # onex-allow-internal-ip
+        state_dir=state_dir,
+        roots=[root],
+        prune_script=prune_script,
+        execute=True,
+        opener=_opener_for(body),
+        runner=recorder,
+    )
+
+    assert outcome.cursor_advanced is True
+    assert outcome.cursor_before == 4
+    assert outcome.cursor_after == 12
+    assert worktree_reaper.read_cursor(state_dir) == 12
+
+
+def test_cursor_does_not_advance_when_one_of_many_rows_fails(
+    root: Path, prune_script: Path, state_dir: Path
+) -> None:
+    # Two rows; the prune runner fails for the SECOND root invocation.
+    class _FailSecond:
+        def __init__(self) -> None:
+            self.n = 0
+            self.calls: list[list[str]] = []
+
+        def __call__(self, argv, cwd):  # type: ignore[no-untyped-def]
+            self.calls.append(list(argv))
+            self.n += 1
+            return (0, "OK") if self.n == 1 else (2, "boom")
+
+    runner = _FailSecond()
+    body = _projection_body(
+        [_row(pr_number=401, cursor=20), _row(pr_number=402, cursor=21)],
+        next_cursor=21,
+    )
+    worktree_reaper.write_cursor(state_dir, 10)
+
+    outcome = worktree_reaper.run_reaper(
+        base_url="http://projection.test",  # onex-allow-internal-ip
+        state_dir=state_dir,
+        roots=[root],
+        prune_script=prune_script,
+        execute=True,
+        opener=_opener_for(body),
+        runner=runner,
+    )
+
+    assert outcome.cursor_advanced is False
+    assert worktree_reaper.read_cursor(state_dir) == 10
+
+
+# ---------------------------------------------------------------------------
+# (d) dry-run never deletes and never advances
+# ---------------------------------------------------------------------------
+def test_dry_run_never_deletes_or_advances(
+    root: Path, prune_script: Path, state_dir: Path
+) -> None:
+    recorder = _PruneRecorder(exit_code=0, output="would remove (dry-run)")
+    body = _projection_body([_row(pr_number=501, cursor=30)], next_cursor=30)
+    worktree_reaper.write_cursor(state_dir, 2)
+
+    outcome = worktree_reaper.run_reaper(
+        base_url="http://projection.test",  # onex-allow-internal-ip
+        state_dir=state_dir,
+        roots=[root],
+        prune_script=prune_script,
+        execute=False,  # dry-run
+        opener=_opener_for(body),
+        runner=recorder,
+    )
+
+    assert outcome.dry_run is True
+    # prune script was invoked WITHOUT --execute → it cannot delete.
+    assert len(recorder.calls) == 1
+    assert "--execute" not in recorder.calls[0]
+    assert recorder.executed_with_delete is False
+    # Cursor never advances in dry-run.
+    assert outcome.cursor_advanced is False
+    assert worktree_reaper.read_cursor(state_dir) == 2
+
+
+# ---------------------------------------------------------------------------
+# Extra safety / robustness
+# ---------------------------------------------------------------------------
+def test_projection_fetch_failure_leaves_cursor_un_advanced(
+    root: Path, prune_script: Path, state_dir: Path
+) -> None:
+    def _boom(url: str, timeout: float) -> str:
+        raise OSError("connection refused")
+
+    worktree_reaper.write_cursor(state_dir, 17)
+    outcome = worktree_reaper.run_reaper(
+        base_url="http://projection.test",  # onex-allow-internal-ip
+        state_dir=state_dir,
+        roots=[root],
+        prune_script=prune_script,
+        execute=True,
+        opener=_boom,
+    )
+
+    assert not outcome  # falsy → error recorded
+    assert outcome.error.startswith("projection_fetch_failed")
+    assert outcome.cursor_advanced is False
+    assert worktree_reaper.read_cursor(state_dir) == 17
+
+
+def test_malformed_rows_are_dropped_not_fabricated(state_dir: Path) -> None:
+    body = json.dumps(
+        {
+            "rows": [
+                {"repo": "x", "branch": "b", "pr_number": 1, "projection_cursor": 1},
+                {"garbage": True},  # missing required fields → dropped
+                "not-an-object",  # wrong type → dropped
+            ],
+            "next_cursor": 1,
+        }
+    )
+    page = worktree_reaper.parse_projection_page(body, since=0)
+    assert len(page.rows) == 1
+    assert page.rows[0].pr_number == 1
+
+
+def test_next_cursor_never_regresses_below_since() -> None:
+    body = json.dumps({"rows": [], "next_cursor": 3})
+    page = worktree_reaper.parse_projection_page(body, since=10)
+    # A stale/lower next_cursor must not move the watermark backwards.
+    assert page.next_cursor == 10
+
+
+def test_prune_driven_across_all_roots(
+    tmp_path: Path, prune_script: Path, state_dir: Path
+) -> None:
+    root_a = tmp_path / "a"
+    root_b = tmp_path / "b"
+    root_a.mkdir()
+    root_b.mkdir()
+    recorder = _PruneRecorder(exit_code=0, output="OK")
+    body = _projection_body([_row(pr_number=601, cursor=40)], next_cursor=40)
+
+    worktree_reaper.run_reaper(
+        base_url="http://projection.test",  # onex-allow-internal-ip
+        state_dir=state_dir,
+        roots=[root_a, root_b],
+        prune_script=prune_script,
+        execute=True,
+        opener=_opener_for(body),
+        runner=recorder,
+    )
+
+    rooted = {
+        call[call.index("--worktrees-root") + 1]
+        for call in recorder.calls
+        if "--worktrees-root" in call
+    }
+    assert str(root_a) in rooted
+    assert str(root_b) in rooted
+
+
+def test_pr_merged_topic_default_is_canonical() -> None:
+    # The default (no ONEX_PR_MERGED_TOPIC override) is the canonical pr-merged topic.
+    assert (
+        worktree_reaper._PR_MERGED_TOPIC_DEFAULT == "onex.evt.github.pr-merged.v1"
+    )  # onex-allow-internal-ip
+
+
+def test_build_projection_url_includes_since_and_topic() -> None:
+    url = worktree_reaper.build_projection_url(
+        "http://host:3002", worktree_reaper.PR_MERGED_TOPIC, 42
+    )
+    assert url == (
+        f"http://host:3002/projection/{worktree_reaper.PR_MERGED_TOPIC}?since=42"
+    )
+
+
+def test_resolve_projection_base_url_fails_fast_when_unset() -> None:
+    with pytest.raises(KeyError):
+        worktree_reaper.resolve_projection_base_url(env={})
+
+
+def test_resolve_projection_base_url_strips_trailing_slash() -> None:
+    url = worktree_reaper.resolve_projection_base_url(
+        env={"ONEX_PROJECTION_URL": "http://host:3002/"}
+    )
+    assert url == "http://host:3002"


### PR DESCRIPTION
## OMN-13228 — T4: event-sourced reap-on-merge worktree reaper (.201 systemd unit)

Part of epic **OMN-13008** (merge-triggered worktree reaper). This is the **.201** half of T4; the Mac half ships in omniclaude.

### What this does
A small reaper that reads the `onex.evt.github.pr-merged.v1` projection (T3, OMN-13227) over plain HTTP — `GET {ONEX_PROJECTION_URL}/projection/onex.evt.github.pr-merged.v1?since=<cursor>` — and, for each newly-merged PR since a disk-persisted cursor, drives the **canonical** `omniclaude/scripts/prune-worktrees.sh` against `/data/omninode/omni_worktrees`.

- **No Kafka client / no LAN grant issue** — consumes the bus indirectly via the generic projection read.
- **Safety is NOT re-implemented** — prune-worktrees.sh already removes a worktree only when its PR is MERGED (or remote branch gone) AND clean AND fully pushed; dirty / no-upstream / detached → SKIP. The reaper never weakens it. Salvage of dirty worktrees is out of scope (OMN-13044).
- **Cursor on disk** under `.onex_state/worktree_reaper`, advanced only after a fully-successful execute pass. Default-SKIP on any ambiguity (fetch error, prune non-zero, malformed row).
- **Dry-run is the default and never deletes.**

### Packaging (.201)
- `deploy/disk-gc/onex-worktree-reaper.{service,timer}` — systemd USER units, sibling to `onex-disk-gc`. The timer fires every 2 min ("reap on merge", honest about latency); event-sourced + idempotent so a tight interval is safe.
- `deploy/disk-gc/install-worktree-reaper.sh` — install/enable/uninstall/status.
- **Not installed/enabled live** — that is the orchestrator's deploy step.

### Verification (code-only; live e2e is the deploy step)
- 13 unit tests with a **mocked projection HTTP response**: (a) merged+clean → prune-worktrees.sh; (b) dirty/unpushed → SKIP + no advance; (c) cursor advances only on full success; (d) dry-run never deletes. Plus fetch-failure-no-advance, malformed-row-drop, all-roots driven.
- stdlib + pydantic only; `ruff` + `mypy --strict` clean; URL/topic from env (fail-fast, no default host, no hardcoded topic literal/IP).

Evidence-Source: OCC#2754
Evidence-Ticket: OMN-13228

<!-- occ-bound: 2754 @ 180107 -->
