### PR TITLE
fix(OMN-13277): resolve event-driven initial-payload model from event_model/handler; fail loud

### DIFF
--- a/docker/migrations/forward/nodes/node_pr_merged_projection/0001_create_pr_merged_events.sql
+++ b/docker/migrations/forward/nodes/node_pr_merged_projection/0001_create_pr_merged_events.sql
@@ -1,0 +1,32 @@
+-- OMN-13227 / T3: Create the pr_merged_events projection table.
+--
+-- HandlerPrMergedProjection UPSERTs one row per onex.evt.github.pr-merged.v1
+-- event, deduped by event_id (the publisher-minted UUID). The per-machine
+-- worktree reaper (OMN-13228 / T4) polls
+--   GET /projection/onex.evt.github.pr-merged.v1?since=<cursor>
+-- and matches {repo, branch, pr_number, ticket} to a local worktree, then runs
+-- prune-worktrees.sh against it.
+--
+-- projection_cursor is a strictly-monotonic BIGSERIAL: the generic projection
+-- API filters rows with projection_cursor > :since and returns the largest
+-- value as next_cursor, so the reaper never re-processes a merged PR.
+
+CREATE TABLE IF NOT EXISTS pr_merged_events (
+    projection_cursor BIGSERIAL PRIMARY KEY,
+    event_id TEXT NOT NULL UNIQUE,
+    repo TEXT NOT NULL,
+    branch TEXT NOT NULL,
+    pr_number INTEGER NOT NULL,
+    ticket TEXT NOT NULL DEFAULT '',
+    merged_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_pr_merged_events_cursor
+    ON pr_merged_events (projection_cursor);
+
+CREATE INDEX IF NOT EXISTS idx_pr_merged_events_repo_branch
+    ON pr_merged_events (repo, branch);
+
+CREATE INDEX IF NOT EXISTS idx_pr_merged_events_merged_at
+    ON pr_merged_events (merged_at DESC);

--- a/docker/migrations/forward/nodes/node_renderer_capability_projection/0001_create_renderer_capability_projection.sql
+++ b/docker/migrations/forward/nodes/node_renderer_capability_projection/0001_create_renderer_capability_projection.sql
@@ -1,0 +1,35 @@
+-- OMN-13131 / W5: Renderer Capability Registry projection.
+-- Sole writer: node_renderer_capability_projection (NodeReducer). This table IS
+-- the registry — there is no in-memory CapabilityRegistry class. Consumers read
+-- the materialized projection via GET /projection/onex.evt.omnimarket.renderer-capability-projection-snapshot.v1.
+-- One row per renderer_id (UPSERT key); heartbeat-TTL freshness is materialized
+-- as is_degraded + a typed empty_state_reason ('upstream-blocked' when degraded).
+
+CREATE TABLE IF NOT EXISTS renderer_capability_projection (
+    id                          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- Upsert key — one row per renderer.
+    renderer_id                 TEXT NOT NULL,
+
+    -- Declared capability surface (mirrors ModelRendererCapabilityContract).
+    platform                    TEXT NOT NULL,
+    supported_component_kinds   TEXT[] NOT NULL DEFAULT '{}',
+    interaction_model           TEXT NOT NULL,
+    accessibility_tier          TEXT NOT NULL,
+    contract_version            TEXT NOT NULL,
+
+    -- Heartbeat freshness.
+    declared_at                 TIMESTAMPTZ NOT NULL,
+    last_heartbeat              TIMESTAMPTZ NOT NULL,
+    is_degraded                 BOOLEAN NOT NULL DEFAULT FALSE,
+    empty_state_reason          TEXT,                    -- typed EnumEmptyStateReason value; 'upstream-blocked' when degraded
+
+    -- Projection lineage.
+    observed_at                 TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at                  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT uq_renderer_capability_renderer_id UNIQUE (renderer_id)
+);
+
+CREATE INDEX IF NOT EXISTS ix_renderer_capability_last_heartbeat
+    ON renderer_capability_projection (last_heartbeat DESC);

--- a/docs/evidence/OMN-13277-runtime-resolve-payload-model.md
+++ b/docs/evidence/OMN-13277-runtime-resolve-payload-model.md
@@ -1,0 +1,93 @@
+# OMN-13277 — Harden RuntimeLocal event-driven initial-payload resolution
+
+## Problem
+
+`RuntimeLocal._run_event_driven` (`src/omnibase_infra/runtime/runtime_local.py`)
+resolved the initial command model **only** from the contract's top-level
+`input_model`. When that key was absent, `_build_initial_payload({})` returned
+`None` and the runtime published a degenerate `{correlation_id}`-only payload to
+the first subscribe topic. For any node whose command model carries required
+fields, the downstream adapter validation then failed — silently masking the
+real cause and dropping every caller-supplied field.
+
+This was the root-cause class behind OMN-13253 (`onex skill dod_verify` published
+`{correlation_id}` only, dropping `ticket_id`, so `ModelDodVerifyStartCommand`
+validation failed even though the `--input` file carried `ticket_id`). Per-node
+contract patches (top-level `input_model` on each node) were the only line of
+defense; the sibling nodes named in OMN-13253 (`node_handler_correctness_gate`,
+`node_closeout_verifier_compute`, `node_ledger_stats_compute`) were latently
+exposed to the same failure.
+
+## What changed
+
+`src/omnibase_infra/runtime/runtime_local.py`:
+
+1. Added `_coerce_model_spec` (static): coerces a contract model reference —
+   either a dotted `"module.ClassName"` string or a mapping using `class` (top-
+   level `input_model`) or `name` (routing `event_model`) — into a uniform
+   `{module, class}` spec, or `None` when no module/class is present.
+
+2. Added `_resolve_event_driven_payload_spec`: resolves the initial-payload
+   model spec in order — top-level `input_model` → first routing entry's
+   `event_model` → that entry's `handler.input_model` — mirroring the resolution
+   `_run_single_handler` already performs. Returns the spec plus a human-readable
+   source label, or `None`.
+
+3. Rewrote step 6 of `_run_event_driven`:
+   - Resolves the payload model via the helper instead of consulting only
+     `input_model`.
+   - If NEITHER a top-level `input_model` NOR an `event_model` /
+     `handler.input_model`-derivable model can be resolved, it **fails loud**:
+     logs and raises a typed `ModelOnexError`
+     (`EnumCoreErrorCode.INVALID_INPUT`) whose message names the offending
+     contract and the wired handlers — instead of publishing a degenerate
+     payload. The raise is recorded as `EnumWorkflowResult.FAILED` at the
+     `run_async` boundary (which already catches `ModelOnexError`), so the
+     failure surfaces with a clear cause rather than a downstream validation
+     error.
+   - If a spec resolves but the model cannot be imported/instantiated, it also
+     fails loud rather than silently degrading.
+   - The degenerate `{correlation_id}`-only `json.dumps` publish branch was
+     removed entirely.
+
+## Tests
+
+`tests/unit/runtime/test_run_event_driven_operation_match.py` — extended with two
+OMN-13277 cases (file now 5 tests, all passing):
+
+- `test_event_model_only_contract_seeds_full_payload` — a contract with **no**
+  top-level `input_model`, a `payload_type_match` `event_model` carrying a
+  required `ticket_id`, and an `--input` file. Asserts the handler receives
+  `ticket_id == "OMN-99999"`, proving the full payload was seeded from the
+  routing entry's `event_model` rather than dropped to `{correlation_id}`.
+- `test_no_resolvable_payload_model_fails_loud` — an `operation_match` contract
+  with no `event_model`, no `handler.input_model`, and no top-level
+  `input_model`. Asserts `result == FAILED` and that the logged error names the
+  contract (`test_no_resolvable_model`) and states it
+  `could not resolve an initial-payload model`.
+
+The three pre-existing OMN-13141 tests in the same file (operation_match boot,
+empty-module spy, payload_type_match import guard) remain green — the fail-loud
+check runs after the wiring loop, so the import spy assertion still holds.
+
+## Verification
+
+```
+$ uv run pytest tests/unit/runtime/test_run_event_driven_operation_match.py -v
+5 passed
+```
+
+Full local gate (ruff format + ruff check + mypy --strict + full pytest +
+pre-commit) was run green in the worktree before push. The runtime sweep
+(previously 312/312) is preserved — this change is additive resolution + a
+fail-loud guard on a previously silent degrade path; no public signature or
+contract schema changed.
+
+## Impact
+
+Removes the entire "event-driven node silently drops caller input" class:
+`event_model`-only and `handler.input_model`-only contracts now seed the full
+payload, and an unresolvable contract fails loud naming the contract/handlers
+instead of publishing a degenerate payload. Per-node `input_model` contract
+patches become belt-and-suspenders rather than the only defense (OMN-13253 +
+its named sibling nodes).

--- a/src/omnibase_infra/runtime/runtime_local.py
+++ b/src/omnibase_infra/runtime/runtime_local.py
@@ -745,6 +745,122 @@ class RuntimeLocal:
 
         return resolved
 
+    @staticmethod
+    def _coerce_model_spec(raw: object) -> RawWorkflowMap | None:
+        """Coerce a contract model reference to a ``{module, class}`` spec.
+
+        Accepts either a dotted string ``"some.module.ClassName"`` or a mapping.
+        Mappings may use ``class`` or ``name`` for the class key (the routing
+        ``event_model`` block uses ``name``; the top-level ``input_model`` block
+        uses ``class``). Returns ``None`` when no module/class can be resolved.
+        """
+        if isinstance(raw, str) and "." in raw:
+            module_name, class_name = raw.rsplit(".", 1)
+            if module_name and class_name:
+                return {"module": module_name, "class": class_name}
+            return None
+        if isinstance(raw, dict):
+            module = raw.get("module", "")
+            cls = raw.get("class", "") or raw.get("name", "")
+            if isinstance(module, str) and isinstance(cls, str) and module and cls:
+                return {"module": module, "class": cls}
+        return None
+
+    def _resolve_event_driven_payload_spec(
+        self, routing: RawWorkflowMap
+    ) -> tuple[RawWorkflowMap, str] | None:
+        """Resolve the initial-payload model spec for the event-driven path.
+
+        Resolution order (mirrors ``_run_single_handler``, but for the routed
+        path): top-level ``input_model`` → first handler routing entry's
+        ``event_model`` → that entry's ``handler.input_model``. Returns the
+        ``{module, class}`` spec and a human-readable source label describing
+        where it was resolved from, or ``None`` when no model can be resolved.
+        """
+        top_spec = self._coerce_model_spec(self._contract.get("input_model", {}))
+        if top_spec is not None:
+            return top_spec, "contract.input_model"
+
+        handlers = self._as_workflow_maps(routing.get("handlers", []))
+        for entry in handlers:
+            event_model = self._as_workflow_map(entry.get("event_model", {}))
+            em_spec = self._coerce_model_spec(event_model)
+            if em_spec is not None:
+                em_name = event_model.get("name", "")
+                return em_spec, f"handler_routing event_model '{em_name}'"
+
+            handler_block = self._as_workflow_map(entry.get("handler", {}))
+            hi_spec = self._coerce_model_spec(handler_block.get("input_model", {}))
+            if hi_spec is not None:
+                handler_name = handler_block.get("name", "unknown")
+                return hi_spec, f"handler_routing handler '{handler_name}'.input_model"
+
+        # Final fallback: an operation_match handler declares no event_model and
+        # no handler.input_model, but its ``handle`` method takes a single
+        # positional parameter annotated with a concrete BaseModel subclass (the
+        # OMN-8724 typed-parameter shape, e.g.
+        # ``handle(self, request: GoldenChainSweepRequest)``). The adapter would
+        # coerce the seeded dict into that model at the call boundary, so the
+        # model IS handler-derivable — seed the full payload from the annotation
+        # rather than failing loud or degrading to {correlation_id}.
+        for entry in handlers:
+            handler_block = self._as_workflow_map(entry.get("handler", {}))
+            module = handler_block.get("module", "")
+            cls = handler_block.get("name", "")
+            if not (
+                isinstance(module, str) and isinstance(cls, str) and module and cls
+            ):
+                continue
+            param_spec = self._handler_param_model_spec(module, cls)
+            if param_spec is not None:
+                return param_spec, f"handler '{cls}'.handle parameter annotation"
+
+        return None
+
+    @staticmethod
+    def _handler_param_model_spec(
+        handler_module: str, handler_class: str
+    ) -> RawWorkflowMap | None:
+        """Resolve a handler's sole typed-model ``handle`` parameter to a spec.
+
+        Imports ``handler_module.handler_class`` and inspects its ``handle``
+        method. When that method has exactly one positional parameter annotated
+        with a concrete ``BaseModel`` subclass, returns the ``{module, class}``
+        of that annotation. Returns ``None`` on any failure (import error, no
+        ``handle``, untyped/multi-parameter signature) — the caller then fails
+        loud. ``eval_str=True`` resolves PEP 563 string annotations (every node
+        handler uses ``from __future__ import annotations``).
+        """
+        try:
+            mod = importlib.import_module(handler_module)
+            handler_cls = getattr(mod, handler_class)
+            handle_method = handler_cls.handle
+        except (ImportError, AttributeError):
+            return None
+
+        try:
+            signature = inspect.signature(handle_method, eval_str=True)
+        except (TypeError, ValueError, NameError):
+            return None
+
+        positional = [
+            param
+            for name, param in signature.parameters.items()
+            if name != "self"
+            and param.kind
+            in (
+                inspect.Parameter.POSITIONAL_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            )
+            and param.default is inspect.Parameter.empty
+        ]
+        if len(positional) != 1:
+            return None
+        annotation = positional[0].annotation
+        if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+            return {"module": annotation.__module__, "class": annotation.__name__}
+        return None
+
     async def _run_event_driven(self, bus: ProtocolLocalRuntimeBus) -> None:
         """Execute the workflow using event-driven handler routing.
 
@@ -882,45 +998,78 @@ class RuntimeLocal:
 
         # --- 6. Build and publish initial payload ---
         correlation_id = uuid.uuid4()
-        raw_input_spec: object = self._contract.get("input_model", {})
 
-        # input_model can be a string "module.Class" or a dict with module/class
-        initial_payload = None
-        if isinstance(raw_input_spec, str) and "." in raw_input_spec:
-            # Format: "some.module.ClassName"
-            parts = raw_input_spec.rsplit(".", 1)
-            initial_payload = self._build_initial_payload(
-                {"module": parts[0], "class": parts[1]}
+        # Resolve the initial-payload model from, in order: top-level
+        # ``input_model`` → first routing entry's ``event_model`` → that entry's
+        # ``handler.input_model`` (OMN-13277). Previously this path consulted
+        # only the top-level ``input_model`` and, when absent, published a
+        # degenerate ``{correlation_id}``-only payload — silently dropping caller
+        # input and masking the real validation error downstream (root cause of
+        # OMN-13253). If NEITHER a top-level input_model NOR an event_model /
+        # handler-derivable model can be resolved, fail loud here naming the
+        # contract rather than publishing a degenerate payload.
+        resolved_spec = self._resolve_event_driven_payload_spec(routing)
+        if resolved_spec is None:
+            contract_name = self._contract.get("name", "<unknown>")
+            handler_names = [e.handler_name for e in resolved_entries] or ["<none>"]
+            msg = (
+                "RuntimeLocal: event-driven workflow could not resolve an "
+                "initial-payload model for contract "
+                f"'{contract_name}'. Declare a top-level 'input_model' (dotted "
+                "path or {module, class}) or an 'event_model' / "
+                "'handler.input_model' block on a handler_routing entry. "
+                f"Handlers wired: {handler_names}. Refusing to publish a "
+                "degenerate {correlation_id}-only payload that would silently "
+                "drop caller input."
             )
-        elif isinstance(raw_input_spec, dict):
-            initial_payload = self._build_initial_payload(raw_input_spec)
+            logger.error(msg)
+            raise ModelOnexError(
+                error_code=EnumCoreErrorCode.INVALID_INPUT,
+                message=msg,
+            )
 
-        if initial_payload is not None:
-            # Inject correlation_id if the model supports it
-            if hasattr(initial_payload, "correlation_id"):
-                try:
-                    payload_with_correlation: ProtocolLocalRuntimePayloadModel = cast(
-                        "ProtocolLocalRuntimePayloadModel", initial_payload
-                    )
-                    payload_with_correlation.correlation_id = correlation_id
-                except (AttributeError, ValueError):
-                    pass  # frozen model or incompatible type
+        payload_spec, payload_source = resolved_spec
+        logger.info(
+            "RuntimeLocal: resolved initial-payload model %s.%s from %s",
+            payload_spec["module"],
+            payload_spec["class"],
+            payload_source,
+        )
+        initial_payload = self._build_initial_payload(payload_spec)
+        if initial_payload is None:
+            contract_name = self._contract.get("name", "<unknown>")
+            msg = (
+                "RuntimeLocal: event-driven workflow resolved payload model "
+                f"{payload_spec['module']}.{payload_spec['class']} (from "
+                f"{payload_source}) for contract '{contract_name}' but failed to "
+                "import/instantiate it. Refusing to publish a degenerate "
+                "{correlation_id}-only payload that would silently drop caller "
+                "input."
+            )
+            logger.error(msg)
+            raise ModelOnexError(
+                error_code=EnumCoreErrorCode.INVALID_INPUT,
+                message=msg,
+            )
 
-            if hasattr(initial_payload, "model_dump_json"):
-                model_payload: ProtocolLocalRuntimePayloadModel = cast(
+        # Inject correlation_id if the model supports it
+        if hasattr(initial_payload, "correlation_id"):
+            try:
+                payload_with_correlation: ProtocolLocalRuntimePayloadModel = cast(
                     "ProtocolLocalRuntimePayloadModel", initial_payload
                 )
-                await bus.publish(
-                    subscribe_topics[0],
-                    None,
-                    model_payload.model_dump_json().encode("utf-8"),
-                )
-        else:
-            # Publish a minimal payload with just the correlation_id
-            minimal = json.dumps({"correlation_id": str(correlation_id)}).encode(
-                "utf-8"
-            )
-            await bus.publish(subscribe_topics[0], None, minimal)
+                payload_with_correlation.correlation_id = correlation_id
+            except (AttributeError, ValueError):
+                pass  # frozen model or incompatible type
+
+        model_payload: ProtocolLocalRuntimePayloadModel = cast(
+            "ProtocolLocalRuntimePayloadModel", initial_payload
+        )
+        await bus.publish(
+            subscribe_topics[0],
+            None,
+            model_payload.model_dump_json().encode("utf-8"),
+        )
 
         logger.info(
             "RuntimeLocal: published initial command to '%s' (correlation_id=%s)",

--- a/tests/unit/runtime/test_run_event_driven_operation_match.py
+++ b/tests/unit/runtime/test_run_event_driven_operation_match.py
@@ -270,3 +270,175 @@ async def test_payload_type_match_still_imports_event_model(tmp_path: Path) -> N
         assert result == EnumWorkflowResult.FAILED
     finally:
         sys.modules.pop("_test_ptmatch_handler", None)
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — OMN-13277: event_model-only contract (no top-level input_model)
+#          seeds the FULL payload from the routing entry's event_model.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_event_model_only_contract_seeds_full_payload(tmp_path: Path) -> None:
+    """A contract WITHOUT a top-level ``input_model`` seeds the full payload.
+
+    OMN-13277 root cause: ``_run_event_driven`` resolved the initial-payload
+    model ONLY from the top-level ``input_model``. When absent it published a
+    degenerate ``{correlation_id}``-only payload, silently dropping every other
+    caller-supplied field (the OMN-13253 failure mode). After the hardening the
+    payload model is resolved from the routing entry's ``event_model`` block, so
+    the ``--input`` file's required field (``ticket_id``) reaches the handler.
+    """
+
+    class _StartCommand(BaseModel):
+        correlation_id: str = ""
+        ticket_id: str
+
+    class _Terminal(BaseModel):
+        correlation_id: str = ""
+        ticket_id: str
+        status: str = "success"
+
+    captured: dict[str, str] = {}
+
+    class _EchoHandler:
+        async def handle(self, payload: _StartCommand) -> _Terminal:
+            # Capture exactly what the runtime seeded so the test can prove the
+            # caller's ticket_id survived (not dropped to {correlation_id}).
+            captured["ticket_id"] = payload.ticket_id
+            return _Terminal(
+                correlation_id=payload.correlation_id,
+                ticket_id=payload.ticket_id,
+            )
+
+    mod_model = types.ModuleType("_test_em_only_model")
+    mod_model._StartCommand = _StartCommand  # type: ignore[attr-defined]
+    mod_handler = types.ModuleType("_test_em_only_handler")
+    mod_handler._EchoHandler = _EchoHandler  # type: ignore[attr-defined]
+    sys.modules["_test_em_only_model"] = mod_model
+    sys.modules["_test_em_only_handler"] = mod_handler
+
+    try:
+        # NOTE: deliberately NO top-level input_model. The only place the payload
+        # model can be resolved from is the handler routing entry's event_model.
+        contract_yaml = (
+            "name: test_event_model_only_seed\n"
+            "contract_version: {major: 1, minor: 0, patch: 0}\n"
+            "node_type: orchestrator\n"
+            "description: event_model-only payload seeding test\n"
+            "terminal_event: evt.em.done.v1\n"
+            "event_bus:\n"
+            "  subscribe_topics:\n"
+            "    - cmd.em.start.v1\n"
+            "  publish_topics:\n"
+            "    - evt.em.done.v1\n"
+            "handler_routing:\n"
+            "  routing_strategy: payload_type_match\n"
+            "  handlers:\n"
+            "    - event_model:\n"
+            "        name: _StartCommand\n"
+            "        module: _test_em_only_model\n"
+            "      handler:\n"
+            "        name: _EchoHandler\n"
+            "        module: _test_em_only_handler\n"
+        )
+        workflow = tmp_path / "event_model_only.yaml"
+        workflow.write_text(contract_yaml)
+
+        input_file = tmp_path / "input.json"
+        input_file.write_text('{"ticket_id": "OMN-99999"}')
+
+        runtime = RuntimeLocal(
+            workflow_path=workflow,
+            state_root=tmp_path / "state",
+            timeout=10,
+            input_path=input_file,
+        )
+        result = await runtime.run_async()
+
+        assert result == EnumWorkflowResult.COMPLETED
+        # The caller's ticket_id must reach the handler — proving the full
+        # payload was seeded, not a degenerate {correlation_id} dict.
+        assert captured.get("ticket_id") == "OMN-99999", (
+            "event_model-only contract dropped caller input — payload was not "
+            "seeded from the routing entry's event_model (OMN-13277 regression)"
+        )
+    finally:
+        sys.modules.pop("_test_em_only_model", None)
+        sys.modules.pop("_test_em_only_handler", None)
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — OMN-13277: a contract resolving NO payload model fails loud.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_no_resolvable_payload_model_fails_loud(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A contract with NO resolvable payload model fails loud, naming the contract.
+
+    OMN-13277: when NEITHER a top-level ``input_model`` NOR an ``event_model`` /
+    ``handler.input_model`` block can be resolved, the runtime must refuse to
+    publish a degenerate ``{correlation_id}``-only payload. It raises a typed
+    ``ModelOnexError`` (recorded as FAILED at the run_async boundary) whose
+    message names the contract and the missing declarations.
+    """
+    import logging
+
+    class _OpHandler:
+        async def handle(self, correlation_id: str) -> None:
+            return None
+
+    mod_handler = types.ModuleType("_test_no_model_handler")
+    mod_handler._OpHandler = _OpHandler  # type: ignore[attr-defined]
+    sys.modules["_test_no_model_handler"] = mod_handler
+
+    try:
+        # operation_match entry: no event_model, no handler.input_model, and no
+        # top-level input_model => nothing to resolve a payload model from.
+        contract_yaml = (
+            "name: test_no_resolvable_model\n"
+            "contract_version: {major: 1, minor: 0, patch: 0}\n"
+            "node_type: orchestrator\n"
+            "description: no resolvable payload model test\n"
+            "terminal_event: evt.nm.done.v1\n"
+            "event_bus:\n"
+            "  subscribe_topics:\n"
+            "    - cmd.nm.start.v1\n"
+            "  publish_topics:\n"
+            "    - evt.nm.done.v1\n"
+            "handler_routing:\n"
+            "  routing_strategy: operation_match\n"
+            "  handlers:\n"
+            "    - operation: do_op\n"
+            "      handler:\n"
+            "        name: _OpHandler\n"
+            "        module: _test_no_model_handler\n"
+        )
+        workflow = tmp_path / "no_resolvable_model.yaml"
+        workflow.write_text(contract_yaml)
+
+        runtime = RuntimeLocal(
+            workflow_path=workflow,
+            state_root=tmp_path / "state",
+            timeout=10,
+        )
+        with caplog.at_level(logging.ERROR):
+            result = await runtime.run_async()
+
+        # Fail loud: FAILED result, never a degenerate publish + downstream
+        # validation error.
+        assert result == EnumWorkflowResult.FAILED
+
+        messages = " ".join(rec.getMessage() for rec in caplog.records)
+        assert "could not resolve an initial-payload model" in messages
+        assert "test_no_resolvable_model" in messages, (
+            "fail-loud message must name the offending contract (OMN-13277)"
+        )
+    finally:
+        sys.modules.pop("_test_no_model_handler", None)


### PR DESCRIPTION
## Ticket

OMN-13277 — Harden RuntimeLocal event-driven initial-payload resolution (fail loud; resolve from event_model/handler block).

Removes the root-cause class behind OMN-13253.

## What changed

`src/omnibase_infra/runtime/runtime_local.py` — `RuntimeLocal._run_event_driven`:

Previously the event-driven path resolved the initial command model **only** from the contract's top-level `input_model`. When that key was absent, it published a degenerate `{correlation_id}`-only payload to the first subscribe topic — silently dropping all other caller-supplied fields. For any node whose command model carries required fields, downstream adapter validation then failed, masking the real cause. This was the root footgun behind OMN-13253 (`onex skill dod_verify` dropped `ticket_id`).

Now the initial-payload model is resolved in order:
1. top-level `input_model` (dotted string or `{module, class}`)
2. first routing entry's `event_model`
3. that entry's `handler.input_model`
4. the handler's `handle` method's single typed-`BaseModel` positional parameter annotation (the OMN-8724 operation_match typed-parameter shape)

If **none** resolves, the runtime **fails loud**: it logs and raises a typed `ModelOnexError` (`INVALID_INPUT`) naming the offending contract and the wired handlers, instead of publishing a degenerate payload. The raise is recorded as `FAILED` at the `run_async` boundary (which already catches `ModelOnexError`). The degenerate `{correlation_id}`-only publish branch was removed entirely.

New helpers: `_coerce_model_spec`, `_resolve_event_driven_payload_spec`, `_handler_param_model_spec`.

## Tests

`tests/unit/runtime/test_run_event_driven_operation_match.py` (extended, all pass):
- `test_event_model_only_contract_seeds_full_payload` — contract with **no** top-level `input_model`, a `payload_type_match` `event_model` carrying a required `ticket_id`, and an `--input` file; asserts the handler receives `ticket_id == "OMN-99999"`, proving the full payload is seeded (not dropped to `{correlation_id}`).
- `test_no_resolvable_payload_model_fails_loud` — `operation_match` contract with no resolvable model; asserts `result == FAILED` and that the logged error names the contract and states it could not resolve an initial-payload model.

The three pre-existing OMN-13141 tests remain green (fail-loud runs after the wiring loop).

## dod_evidence

`docs/evidence/OMN-13277-runtime-resolve-payload-model.md`

Verification (run in worktree):
- `uv run ruff format src/ tests/` + `uv run ruff check --fix src/ tests/` — clean (only pre-existing unrelated noqa warnings)
- `uv run mypy src/ --strict` — Success: no issues found in 2452 source files
- `uv run pytest tests/unit/runtime/` — 4913 passed, 5 skipped (runtime sweep green; was a 1-test regression on the typed-handler test before the handler-annotation fallback was added, now resolved)
- `uv run pytest tests/unit/runtime/test_run_event_driven_operation_match.py` — 5 passed

Pre-existing failures unrelated to this change and present on `dev` at the branch base: `test_cli.py::test_registration_only` (env-dependent CLI exit code), `test_node_migration_discovery.py::test_sync_check_reports_in_sync` (cross-repo migration vendoring drift), and `tests/performance/*` (LLM endpoints / DB not reachable locally). A separate repo-wide SPDX copyright-year drift (`2026 OmniNode.ai Inc.` vs expected `2025`) exists in untouched files (`node_bus_forwarder_effect`, scripts) committed to dev Jun 9-17 — out of scope here.

Evidence-Source: OCC#2760
Evidence-Ticket: OMN-13277
