### PR TITLE
feat(OMN-13238): contract-declared per-topic config + migrate ALL_PROVISIONED_TOPIC_SPECS

### DIFF
--- a/.github/workflows/dispatcher-route-coverage.yml
+++ b/.github/workflows/dispatcher-route-coverage.yml
@@ -99,7 +99,11 @@ jobs:
             if [[ -n "$CHANGED" ]]; then
               # Convert to absolute paths so the script can match them
               ABS_PATHS=$(echo "$CHANGED" | xargs -I{} realpath --relative-to=. {} 2>/dev/null || echo "$CHANGED")
-              echo "changed_contracts=$ABS_PATHS" >> "$GITHUB_OUTPUT"
+              {
+                echo "changed_contracts<<EOF"
+                echo "$ABS_PATHS"
+                echo "EOF"
+              } >> "$GITHUB_OUTPUT"
               echo "Found changed contracts:"
               echo "$CHANGED" | head -20
             else

--- a/contracts/OMN-13238.yaml
+++ b/contracts/OMN-13238.yaml
@@ -1,0 +1,104 @@
+# OMN-13238 contract file for omnibase_infra deploy-gate.
+# The canonical ticket contract and PASS receipts live in onex_change_control.
+# This file is the per-repo deploy-evidence carrier only.
+schema_version: "1.0.0"
+ticket_id: "OMN-13238"
+title: "feat(OMN-13238): contract-declared per-topic config + migrate ALL_PROVISIONED_TOPIC_SPECS"
+summary: >-
+  Ticket 2 of 2 of epic OMN-12651 (W3/W4). W3 makes per-topic provisioning config
+  (partitions / replication_factor / kafka_config) contract-declared: contracts may
+  carry an optional topic_config block on a structured topic item
+  (published_events[].topic_config, or an event_bus dict-form item the extractor reads).
+  The EXISTING ModelContractTopicEntry (omnibase_infra tools/contract_topic_extractor.py)
+  is extended with partitions|replication_factor|kafka_config (PEP 604, frozen, no new
+  parallel model); _extract_raw_topics_from_contract threads the parsed config onto each
+  entry; service_topic_manager._build_topic_specs maps it onto ModelTopicSpec (which
+  already supports all four fields), falling back to ModelTopicSpec defaults when absent.
+  No topic machinery added to omnibase_core. W4 migrates the config-bearing topics whose
+  OWNING omnibase_infra contract already declares a published_events entry (9 topics across
+  5 contracts) into those contracts' published_events[].topic_config — attaching config to
+  pre-existing entries only, so no new published events are synthesized and orchestrator/
+  effect event-purity invariants stay green. ALL_PROVISIONED_TOPIC_SPECS is NOT deleted:
+  118 of the 141 config-bearing source entries are owned by contracts in other repos
+  (omnimemory/omniintelligence/omnimarket build-loop+delegation/omninode routing), emitted
+  directly by the runtime kernel (no owning node contract), or are cmd/intent topics that
+  must not appear in published_events. Forcing those would require cross-repo PRs + an
+  omnibase_core event_bus schema extension and would compound the active omnimarket<->core
+  pin-drift (OMN-13224). Per AC-8/§3.5, ALL_PROVISIONED_TOPIC_SPECS is therefore explicitly
+  annotated TRANSITIONAL (a warm source pending per-repo migration, NOT a standing
+  provisioning authority; the misleading "single source of truth for topic creation"
+  docstring is corrected) with the per-repo follow-up tickets documented in-source and the
+  deletion tracked under OMN-12651. registry_outcome = transitional. Scope = W3/W4.
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: tests
+    description: >-
+      New W3 unit suite (contract topic_config carried onto ModelContractTopicEntry,
+      mapped onto ModelTopicSpec/NewTopic, defaults when absent, merge keeps declared
+      config) and W4 parity suite (every migrated topic resolves the SAME
+      partitions/replication/kafka_config from its owning contract as the legacy registry;
+      registry marked transitional) pass with NO live broker. Existing extractor + topic
+      parity + orchestrator purity + registration/validation orchestrator suites remain
+      green (no regressions; the per-contract-config change is lossless).
+    command: "uv run pytest tests/unit/tools/test_contract_topic_config.py tests/ci/test_topic_config_contract_parity.py tests/unit/tools/test_contract_topic_extractor.py tests/ci/test_topic_parity.py tests/unit/topics/ tests/unit/event_bus/test_service_topic_manager.py tests/unit/nodes/test_orchestrator_purity.py tests/unit/nodes/test_orchestrator_decision_paths.py -q"
+  - kind: ci
+    description: >-
+      mypy --strict clean on src/ (2452 files); ruff format + check clean; no new onex
+      topic literals in Python (topic_literal_baseline.txt unchanged — new topic config
+      lives in contract YAML only); Topic Contract Parity Gate passes; no new model/enum in
+      omnibase_core; ModelContractTopicEntry extended in omnibase_infra; no backwards-compat
+      re-export of ALL_PROVISIONED_TOPIC_SPECS added.
+    command: "uv run mypy src/ --strict"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: dod-w3-config-carry
+    description: >-
+      AC-2 topic-spec fidelity: a contract declaring topic_config (e.g. partitions=1,
+      retention.ms=604800000) produces a ModelContractTopicEntry and a
+      ModelTopicSpec/NewTopic with those values; a contract with no topic_config falls back
+      to ModelTopicSpec defaults (partitions=6, replication_factor=1, kafka_config=None).
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "uv run pytest tests/unit/tools/test_contract_topic_config.py -q"
+  - id: dod-w4-parity
+    description: >-
+      Every migrated topic (9 infra-owned, pre-existing published_events entry) resolves the
+      same partitions/replication/kafka_config from its owning contract as the legacy
+      ALL_PROVISIONED_TOPIC_SPECS registry — proving the migration is lossless and free of
+      contract drift.
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "uv run pytest tests/ci/test_topic_config_contract_parity.py -q"
+  - id: dod-w4-no-shadow-registry
+    description: >-
+      AC-8 no shadow registry: ALL_PROVISIONED_TOPIC_SPECS is explicitly annotated
+      TRANSITIONAL with a deletion ticket (OMN-12651) and per-repo follow-ups, never left as
+      a second standing provisioning authority. The transitional banner + corrected
+      docstring are asserted by test, and no backwards-compat re-export was added.
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "grep -q 'TRANSITIONAL' src/omnibase_infra/topics/platform_topic_suffixes.py && ! grep -q 'single source of truth for topic creation' src/omnibase_infra/topics/platform_topic_suffixes.py"
+  - id: dod-no-new-topic-literals
+    description: >-
+      AC-7 no topic literals: no new onex.*.v* string literals added to Python source; the
+      topic_literal_baseline.txt is unchanged. New per-topic config lives in contract YAML.
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "git diff origin/dev -- scripts/validation/topic_literal_baseline.txt | grep -q . && exit 1 || exit 0"
+  - id: dod-mypy-strict
+    description: >-
+      mypy --strict is clean across src/ with the extended ModelContractTopicEntry and the
+      service_topic_manager config mapping.
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "uv run mypy src/ --strict"

--- a/docker/migrations/forward/nodes/node_pr_merged_projection/0001_create_pr_merged_events.sql
+++ b/docker/migrations/forward/nodes/node_pr_merged_projection/0001_create_pr_merged_events.sql
@@ -1,0 +1,32 @@
+-- OMN-13227 / T3: Create the pr_merged_events projection table.
+--
+-- HandlerPrMergedProjection UPSERTs one row per onex.evt.github.pr-merged.v1
+-- event, deduped by event_id (the publisher-minted UUID). The per-machine
+-- worktree reaper (OMN-13228 / T4) polls
+--   GET /projection/onex.evt.github.pr-merged.v1?since=<cursor>
+-- and matches {repo, branch, pr_number, ticket} to a local worktree, then runs
+-- prune-worktrees.sh against it.
+--
+-- projection_cursor is a strictly-monotonic BIGSERIAL: the generic projection
+-- API filters rows with projection_cursor > :since and returns the largest
+-- value as next_cursor, so the reaper never re-processes a merged PR.
+
+CREATE TABLE IF NOT EXISTS pr_merged_events (
+    projection_cursor BIGSERIAL PRIMARY KEY,
+    event_id TEXT NOT NULL UNIQUE,
+    repo TEXT NOT NULL,
+    branch TEXT NOT NULL,
+    pr_number INTEGER NOT NULL,
+    ticket TEXT NOT NULL DEFAULT '',
+    merged_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_pr_merged_events_cursor
+    ON pr_merged_events (projection_cursor);
+
+CREATE INDEX IF NOT EXISTS idx_pr_merged_events_repo_branch
+    ON pr_merged_events (repo, branch);
+
+CREATE INDEX IF NOT EXISTS idx_pr_merged_events_merged_at
+    ON pr_merged_events (merged_at DESC);

--- a/docker/migrations/forward/nodes/node_renderer_capability_projection/0001_create_renderer_capability_projection.sql
+++ b/docker/migrations/forward/nodes/node_renderer_capability_projection/0001_create_renderer_capability_projection.sql
@@ -1,0 +1,35 @@
+-- OMN-13131 / W5: Renderer Capability Registry projection.
+-- Sole writer: node_renderer_capability_projection (NodeReducer). This table IS
+-- the registry — there is no in-memory CapabilityRegistry class. Consumers read
+-- the materialized projection via GET /projection/onex.evt.omnimarket.renderer-capability-projection-snapshot.v1.
+-- One row per renderer_id (UPSERT key); heartbeat-TTL freshness is materialized
+-- as is_degraded + a typed empty_state_reason ('upstream-blocked' when degraded).
+
+CREATE TABLE IF NOT EXISTS renderer_capability_projection (
+    id                          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- Upsert key — one row per renderer.
+    renderer_id                 TEXT NOT NULL,
+
+    -- Declared capability surface (mirrors ModelRendererCapabilityContract).
+    platform                    TEXT NOT NULL,
+    supported_component_kinds   TEXT[] NOT NULL DEFAULT '{}',
+    interaction_model           TEXT NOT NULL,
+    accessibility_tier          TEXT NOT NULL,
+    contract_version            TEXT NOT NULL,
+
+    -- Heartbeat freshness.
+    declared_at                 TIMESTAMPTZ NOT NULL,
+    last_heartbeat              TIMESTAMPTZ NOT NULL,
+    is_degraded                 BOOLEAN NOT NULL DEFAULT FALSE,
+    empty_state_reason          TEXT,                    -- typed EnumEmptyStateReason value; 'upstream-blocked' when degraded
+
+    -- Projection lineage.
+    observed_at                 TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at                  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT uq_renderer_capability_renderer_id UNIQUE (renderer_id)
+);
+
+CREATE INDEX IF NOT EXISTS ix_renderer_capability_last_heartbeat
+    ON renderer_capability_projection (last_heartbeat DESC);

--- a/src/omnibase_infra/event_bus/service_topic_manager.py
+++ b/src/omnibase_infra/event_bus/service_topic_manager.py
@@ -193,10 +193,29 @@ class TopicProvisioner:
 
         result_specs: list[ModelTopicSpec] = []
         for entry in contract_entries:
+            # Per-topic config (OMN-13238): when a contract declares a
+            # ``topic_config`` block the extractor carries partitions /
+            # replication_factor / kafka_config; otherwise these stay None and
+            # ModelTopicSpec applies its canonical defaults.
             result_specs.append(
                 ModelTopicSpec(
                     suffix=entry.topic,
                     provisioning_priority=entry.provisioning_priority,
+                    partitions=(
+                        entry.partitions
+                        if entry.partitions is not None
+                        else DEFAULT_EVENT_TOPIC_PARTITIONS
+                    ),
+                    replication_factor=(
+                        entry.replication_factor
+                        if entry.replication_factor is not None
+                        else DEFAULT_EVENT_TOPIC_REPLICATION_FACTOR
+                    ),
+                    kafka_config=(
+                        dict(entry.kafka_config)
+                        if entry.kafka_config is not None
+                        else None
+                    ),
                 )
             )
 

--- a/src/omnibase_infra/nodes/node_llm_inference_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_llm_inference_effect/contract.yaml
@@ -161,12 +161,27 @@ published_events:
   - topic: "onex.evt.omnibase-infra.inference-response.v1"
     event_type: "LlmInferenceResponse"
     description: "Content-bearing successful LLM inference response emitted directly from the effect node"
+    topic_config:
+      partitions: 3
+      replication_factor: 1
+      kafka_config:
+        "retention.ms": "604800000"
+        "cleanup.policy": "delete"
   - topic: "onex.evt.omniintelligence.llm-call-completed.v1"
     event_type: "LlmCallCompletedEvent"
     description: "Per-call metrics emitted after each inference call; may include gpu_seconds, gpu_type, gpu_count, and EnumUsageSource-backed compute_usage_source when the request declares GPU configuration"
+    topic_config:
+      partitions: 3
+      replication_factor: 1
   - topic: "onex.evt.omnibase-infra.llm-call-completed.v1"
     event_type: "LlmCallCompletedInfraEvent"
     description: "Lightweight per-call metrics for infra-owned consumers; mirrors optional GPU usage evidence fields for infra projections"
+    topic_config:
+      partitions: 3
+      replication_factor: 1
+      kafka_config:
+        "retention.ms": "604800000"
+        "cleanup.policy": "delete"
 # Dependencies
 dependencies:
   - name: "protocol_llm_http_transport"

--- a/src/omnibase_infra/nodes/node_registration_orchestrator/contract.yaml
+++ b/src/omnibase_infra/nodes/node_registration_orchestrator/contract.yaml
@@ -510,9 +510,21 @@ published_events:
   - topic: "onex.evt.platform.topic-catalog-response.v1"
     event_type: "TopicCatalogResponse"
     description: "Full catalog snapshot in response to a TopicCatalogQuery"
+    topic_config:
+      partitions: 1
+      replication_factor: 1
+      kafka_config:
+        "retention.ms": "3600000"
+        "cleanup.policy": "delete"
   - topic: "onex.evt.platform.topic-catalog-changed.v1"
     event_type: "TopicCatalogChanged"
     description: "Notification published when the topic catalog version changes"
+    topic_config:
+      partitions: 1
+      replication_factor: 1
+      kafka_config:
+        "retention.ms": "604800000"
+        "cleanup.policy": "delete"
   - topic: "onex.evt.platform.node-registration-initiated.v1"
     event_type: "NodeRegistrationInitiated"
   - topic: "onex.evt.platform.node-registration-accepted.v1"

--- a/src/omnibase_infra/nodes/node_remote_agent_invoke_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_remote_agent_invoke_effect/contract.yaml
@@ -60,6 +60,12 @@ published_events:
   - topic: "onex.evt.omnibase-infra.agent-task-lifecycle.v1"
     event_type: "AgentTaskLifecycleEvent"
     description: "Remote-agent lifecycle event emitted by protocol handlers."
+    topic_config:
+      partitions: 3
+      replication_factor: 1
+      kafka_config:
+        "retention.ms": "604800000"
+        "cleanup.policy": "delete"
 health_check:
   enabled: true
   endpoint: "/health"

--- a/src/omnibase_infra/nodes/node_row_count_diagnostic_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_row_count_diagnostic_effect/contract.yaml
@@ -45,6 +45,12 @@ published_events:
     event_type: "RowCountDiagnosticEvent"
     message_category: "EVENT"
     description: "Periodic database row count diagnostic snapshot"
+    topic_config:
+      partitions: 1
+      replication_factor: 1
+      kafka_config:
+        "retention.ms": "604800000"
+        "cleanup.policy": "delete"
 metadata:
   description: "Publishes periodic PostgreSQL table row count snapshots to the event bus for capacity monitoring"
   author: "OmniNode Team"

--- a/src/omnibase_infra/nodes/node_runner_health_snapshot_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_runner_health_snapshot_effect/contract.yaml
@@ -49,10 +49,22 @@ published_events:
     event_type: "RunnerHealthSnapshotEvent"
     message_category: "EVENT"
     description: "Periodic health snapshot from GitHub Actions runners"
+    topic_config:
+      partitions: 1
+      replication_factor: 1
+      kafka_config:
+        "retention.ms": "604800000"
+        "cleanup.policy": "delete"
   - topic: "onex.evt.omnibase-infra.network-pool-status.v1"
     event_type: "NetworkPoolStatusEvent"
     message_category: "EVENT"
     description: "Periodic Docker subnet-pool occupancy snapshot from runner hosts"
+    topic_config:
+      partitions: 1
+      replication_factor: 1
+      kafka_config:
+        "retention.ms": "604800000"
+        "cleanup.policy": "delete"
 metadata:
   description: "Captures point-in-time health metrics from GitHub Actions runners and publishes snapshots for trend analysis"
   author: "OmniNode Team"

--- a/src/omnibase_infra/tools/contract_topic_extractor.py
+++ b/src/omnibase_infra/tools/contract_topic_extractor.py
@@ -23,11 +23,14 @@ import importlib.resources
 import logging
 import re
 import sys
+from collections.abc import Mapping
+from dataclasses import dataclass
 from pathlib import Path
+from types import MappingProxyType
 from typing import Literal, cast
 
 import yaml
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 from omnibase_infra.utils.util_runtime_packages import (
     get_active_runtime_packages,
@@ -77,7 +80,14 @@ _EVENT_BUS_SECTION_KEYS: tuple[str, ...] = (
 
 
 class ModelContractTopicEntry(BaseModel):
-    """A single validated topic extracted from one or more contract.yaml files."""
+    """A single validated topic extracted from one or more contract.yaml files.
+
+    Per-topic provisioning config (``partitions``, ``replication_factor``,
+    ``kafka_config``) is carried from a contract's optional ``topic_config``
+    block (OMN-13238). When a contract does not declare ``topic_config`` for a
+    topic, these fields stay ``None`` and the provisioner falls back to the
+    ``ModelTopicSpec`` defaults.
+    """
 
     topic: str
     kind: Literal["evt", "cmd", "intent", "dlq"]
@@ -86,11 +96,31 @@ class ModelContractTopicEntry(BaseModel):
     version: str  # e.g. "v1"
     source_contracts: tuple[Path, ...]
     provisioning_priority: int = 100
+    partitions: int | None = None
+    replication_factor: int | None = None
+    kafka_config: Mapping[str, str] | None = None
 
-    model_config = {"frozen": True}
+    model_config = {"frozen": True, "arbitrary_types_allowed": True}
+
+    @field_validator("kafka_config", mode="before")
+    @classmethod
+    def _freeze_kafka_config(
+        cls, v: Mapping[str, str] | None
+    ) -> Mapping[str, str] | None:
+        """Freeze a mutable dict supplied at construction time."""
+        if isinstance(v, dict):
+            return MappingProxyType(dict(v))
+        return v
 
     def merge_sources(self, other: ModelContractTopicEntry) -> ModelContractTopicEntry:
-        """Return a new entry with source_contracts merged (deduped, sorted)."""
+        """Return a new entry with source_contracts merged (deduped, sorted).
+
+        Per-topic config is merged by taking the first non-``None`` value for
+        each field, so a topic declared in two contracts (one carrying
+        ``topic_config``, one not) keeps the declared config. When BOTH carry
+        conflicting config, ``self`` wins (deterministic by topic-string sort
+        order in the caller).
+        """
         combined = tuple(
             sorted(set(self.source_contracts) | set(other.source_contracts))
         )
@@ -100,6 +130,19 @@ class ModelContractTopicEntry(BaseModel):
                 "provisioning_priority": min(
                     self.provisioning_priority,
                     other.provisioning_priority,
+                ),
+                "partitions": (
+                    self.partitions if self.partitions is not None else other.partitions
+                ),
+                "replication_factor": (
+                    self.replication_factor
+                    if self.replication_factor is not None
+                    else other.replication_factor
+                ),
+                "kafka_config": (
+                    self.kafka_config
+                    if self.kafka_config is not None
+                    else other.kafka_config
                 ),
             }
         )
@@ -216,16 +259,82 @@ def _topic_priority(item: dict[object, object]) -> int:
     return 100
 
 
+@dataclass(frozen=True)  # internal-dataclass-ok: topic-parse-intermediate
+class _RawTopicDecl:
+    """Internal parse intermediate: a raw topic string plus its declared config.
+
+    Not a domain model — it carries the per-topic provisioning attributes pulled
+    from a contract's optional ``topic_config`` block (OMN-13238) before they are
+    validated onto :class:`ModelContractTopicEntry`.
+    """
+
+    topic: str
+    provisioning_priority: int = 100
+    partitions: int | None = None
+    replication_factor: int | None = None
+    kafka_config: Mapping[str, str] | None = None
+
+
+def _parse_topic_config(
+    item: dict[object, object], source: Path
+) -> tuple[int | None, int | None, Mapping[str, str] | None]:
+    """Parse an optional ``topic_config`` block from a structured topic item.
+
+    Returns ``(partitions, replication_factor, kafka_config)``. Any field that
+    is absent or malformed is returned as ``None`` (falls back to defaults at
+    spec-build time). ``kafka_config`` values are coerced to strings (Kafka
+    topic configs are always string-valued).
+    """
+    raw = item.get("topic_config")
+    if not isinstance(raw, dict):
+        return (None, None, None)
+
+    partitions: int | None = None
+    partitions_raw = raw.get("partitions")
+    if isinstance(partitions_raw, int) and not isinstance(partitions_raw, bool):
+        partitions = partitions_raw
+    elif partitions_raw is not None:
+        _warn(
+            f"Ignoring non-integer topic_config.partitions={partitions_raw!r} "
+            f"for topic {item.get('topic')!r} in {source}"
+        )
+
+    replication_factor: int | None = None
+    rf_raw = raw.get("replication_factor")
+    if isinstance(rf_raw, int) and not isinstance(rf_raw, bool):
+        replication_factor = rf_raw
+    elif rf_raw is not None:
+        _warn(
+            f"Ignoring non-integer topic_config.replication_factor={rf_raw!r} "
+            f"for topic {item.get('topic')!r} in {source}"
+        )
+
+    kafka_config: Mapping[str, str] | None = None
+    kc_raw = raw.get("kafka_config")
+    if isinstance(kc_raw, dict):
+        kafka_config = {str(k): str(v) for k, v in kc_raw.items()}
+    elif kc_raw is not None:
+        _warn(
+            f"Ignoring non-mapping topic_config.kafka_config={kc_raw!r} "
+            f"for topic {item.get('topic')!r} in {source}"
+        )
+
+    return (partitions, replication_factor, kafka_config)
+
+
 def _extract_raw_topics_from_contract(
     data: dict[str, object], source: Path
-) -> list[tuple[str, int]]:
+) -> list[_RawTopicDecl]:
     """
-    Extract all raw topic strings from a parsed contract YAML dict.
+    Extract all raw topic declarations from a parsed contract YAML dict.
 
     Checks ALL applicable keys — no early break on first match.
     If a field has both 'topic' and 'name' values, extracts both.
+    Structured (dict) topic items may carry an optional ``topic_config`` block
+    (``partitions`` / ``replication_factor`` / ``kafka_config``) which is
+    threaded onto the resulting declaration (OMN-13238).
     """
-    raw_topics: list[tuple[str, int]] = []
+    raw_topics: list[_RawTopicDecl] = []
 
     # --- event_bus.subscribe_topics / event_bus.publish_topics (new-style) ---
     event_bus = data.get("event_bus")
@@ -235,12 +344,21 @@ def _extract_raw_topics_from_contract(
             if isinstance(topics_list, list):
                 for item in topics_list:
                     if isinstance(item, str) and item:
-                        raw_topics.append((item, 100))
+                        raw_topics.append(_RawTopicDecl(topic=item))
                     elif isinstance(item, dict):
-                        # topic: "..." format inside subscribe_topics list
+                        # topic: "..." format inside subscribe/publish list
                         topic_val = item.get("topic")
                         if isinstance(topic_val, str) and topic_val:
-                            raw_topics.append((topic_val, _topic_priority(item)))
+                            partitions, rf, kc = _parse_topic_config(item, source)
+                            raw_topics.append(
+                                _RawTopicDecl(
+                                    topic=topic_val,
+                                    provisioning_priority=_topic_priority(item),
+                                    partitions=partitions,
+                                    replication_factor=rf,
+                                    kafka_config=kc,
+                                )
+                            )
 
     # --- consumed_events / published_events / produced_events ---
     for section_key in _EVENT_SECTION_KEYS:
@@ -250,14 +368,31 @@ def _extract_raw_topics_from_contract(
         for item in section:
             if not isinstance(item, dict):
                 continue
+            partitions, rf, kc = _parse_topic_config(item, source)
             # new-style: topic key
             topic_val = item.get("topic")
             if isinstance(topic_val, str) and topic_val:
-                raw_topics.append((topic_val, _topic_priority(item)))
+                raw_topics.append(
+                    _RawTopicDecl(
+                        topic=topic_val,
+                        provisioning_priority=_topic_priority(item),
+                        partitions=partitions,
+                        replication_factor=rf,
+                        kafka_config=kc,
+                    )
+                )
             # old-style: name key — extract both if both present
             name_val = item.get("name")
             if isinstance(name_val, str) and name_val:
-                raw_topics.append((name_val, _topic_priority(item)))
+                raw_topics.append(
+                    _RawTopicDecl(
+                        topic=name_val,
+                        provisioning_priority=_topic_priority(item),
+                        partitions=partitions,
+                        replication_factor=rf,
+                        kafka_config=kc,
+                    )
+                )
 
     return raw_topics
 
@@ -483,13 +618,19 @@ class ContractTopicExtractor:
 
             raw_topics = _extract_raw_topics_from_contract(raw_yaml, contract_path)
 
-            for raw, provisioning_priority in raw_topics:
+            for decl in raw_topics:
+                raw = decl.topic
                 entry = _parse_topic(raw, contract_path)
                 if entry is None:
                     # Warned inside _parse_topic; skip
                     continue
                 entry = entry.model_copy(
-                    update={"provisioning_priority": provisioning_priority}
+                    update={
+                        "provisioning_priority": decl.provisioning_priority,
+                        "partitions": decl.partitions,
+                        "replication_factor": decl.replication_factor,
+                        "kafka_config": decl.kafka_config,
+                    }
                 )
 
                 if raw in accumulated:
@@ -767,12 +908,18 @@ class ContractTopicExtractor:
 
                 raw_topics = _extract_raw_topics_from_contract(raw_yaml, contract_path)
 
-                for raw, provisioning_priority in raw_topics:
+                for decl in raw_topics:
+                    raw = decl.topic
                     entry = _parse_topic(raw, contract_path)
                     if entry is None:
                         continue
                     entry = entry.model_copy(
-                        update={"provisioning_priority": provisioning_priority}
+                        update={
+                            "provisioning_priority": decl.provisioning_priority,
+                            "partitions": decl.partitions,
+                            "replication_factor": decl.replication_factor,
+                            "kafka_config": decl.kafka_config,
+                        }
                     )
 
                     if raw in accumulated:

--- a/src/omnibase_infra/tools/contract_topic_extractor.py
+++ b/src/omnibase_infra/tools/contract_topic_extractor.py
@@ -260,7 +260,7 @@ def _topic_priority(item: dict[object, object]) -> int:
 
 
 @dataclass(frozen=True)  # internal-dataclass-ok: topic-parse-intermediate
-class _RawTopicDecl:
+class RawTopicDecl:
     """Internal parse intermediate: a raw topic string plus its declared config.
 
     Not a domain model — it carries the per-topic provisioning attributes pulled
@@ -324,7 +324,7 @@ def _parse_topic_config(
 
 def _extract_raw_topics_from_contract(
     data: dict[str, object], source: Path
-) -> list[_RawTopicDecl]:
+) -> list[RawTopicDecl]:
     """
     Extract all raw topic declarations from a parsed contract YAML dict.
 
@@ -334,7 +334,7 @@ def _extract_raw_topics_from_contract(
     (``partitions`` / ``replication_factor`` / ``kafka_config``) which is
     threaded onto the resulting declaration (OMN-13238).
     """
-    raw_topics: list[_RawTopicDecl] = []
+    raw_topics: list[RawTopicDecl] = []
 
     # --- event_bus.subscribe_topics / event_bus.publish_topics (new-style) ---
     event_bus = data.get("event_bus")
@@ -344,14 +344,14 @@ def _extract_raw_topics_from_contract(
             if isinstance(topics_list, list):
                 for item in topics_list:
                     if isinstance(item, str) and item:
-                        raw_topics.append(_RawTopicDecl(topic=item))
+                        raw_topics.append(RawTopicDecl(topic=item))
                     elif isinstance(item, dict):
                         # topic: "..." format inside subscribe/publish list
                         topic_val = item.get("topic")
                         if isinstance(topic_val, str) and topic_val:
                             partitions, rf, kc = _parse_topic_config(item, source)
                             raw_topics.append(
-                                _RawTopicDecl(
+                                RawTopicDecl(
                                     topic=topic_val,
                                     provisioning_priority=_topic_priority(item),
                                     partitions=partitions,
@@ -373,7 +373,7 @@ def _extract_raw_topics_from_contract(
             topic_val = item.get("topic")
             if isinstance(topic_val, str) and topic_val:
                 raw_topics.append(
-                    _RawTopicDecl(
+                    RawTopicDecl(
                         topic=topic_val,
                         provisioning_priority=_topic_priority(item),
                         partitions=partitions,
@@ -385,7 +385,7 @@ def _extract_raw_topics_from_contract(
             name_val = item.get("name")
             if isinstance(name_val, str) and name_val:
                 raw_topics.append(
-                    _RawTopicDecl(
+                    RawTopicDecl(
                         topic=name_val,
                         provisioning_priority=_topic_priority(item),
                         partitions=partitions,

--- a/src/omnibase_infra/topics/platform_topic_suffixes.py
+++ b/src/omnibase_infra/topics/platform_topic_suffixes.py
@@ -2292,6 +2292,45 @@ def _omnimemory_enabled() -> bool:
     }
 
 
+# =============================================================================
+# TRANSITIONAL REGISTRY (OMN-13238) — pending per-owning-contract migration
+# =============================================================================
+# ``ALL_PROVISIONED_TOPIC_SPECS`` is a TRANSITIONAL per-topic config source, not
+# a standing provisioning authority. As of OMN-13238 the runtime provisioner
+# (``service_topic_manager._build_topic_specs``) sources topic NAMES *and* the
+# per-topic config (partitions / replication_factor / kafka_config) from
+# contract YAML via ``ContractTopicExtractor.extract_all`` — see the new
+# ``published_events[].topic_config`` block. 9 config-bearing topics whose OWNING
+# omnibase_infra contract already declared a ``published_events`` entry have been
+# migrated into those contracts in this PR (parity asserted by
+# tests/ci/test_topic_config_contract_parity.py).
+#
+# The remaining entries below stay here for one of these reasons:
+#   1. Their owning contract lives in another repo (omnimemory / omniintelligence
+#      / omnimarket build-loop + delegation / omninode routing) — migrating needs
+#      a cross-repo PR + (for the event_bus declaration site) an omnibase_core
+#      schema extension; deliberately NOT done here to avoid compounding the
+#      active omnimarket<->core pin-drift (OMN-13224).
+#   2. The topic is emitted directly by the runtime kernel (no owning node
+#      contract, e.g. runtime-error) — needs a runtime-owned contract first.
+#   3. The topic is a cmd/intent topic, or an event the owning contract does not
+#      list under ``published_events`` — attaching config there would either
+#      violate orchestrator/effect event-purity (no commands in published_events)
+#      or require declaring a NEW published event, both out of scope for this
+#      lossless config migration.
+#
+# Follow-up migration tickets are tracked under epic OMN-12651:
+#   - omnibase_core: extend ModelEventBusSubcontract / ModelTopicMeta so
+#     event_bus topic_config is contract-loadable cross-repo (unblocks the
+#     event_bus.publish_topics declaration site for cmd/intent + non-event topics).
+#   - omnimemory: migrate omnimemory-owned topic config into omnimemory contracts.
+#   - omniintelligence: migrate omniintelligence-owned topic config.
+#   - omnimarket: migrate build-loop + delegation owned topic config.
+#   - omnibase_infra: declare runtime-emitted topics (runtime-error, etc.) in a
+#     runtime-owned contract so their config is contract-sourced too.
+#
+# DO NOT add new entries here. Declare per-topic config in the owning contract's
+# ``published_events[].topic_config`` block instead.
 ALL_PROVISIONED_TOPIC_SPECS: tuple[ModelTopicSpec, ...] = (
     ALL_PLATFORM_TOPIC_SPECS
     + (
@@ -2309,11 +2348,17 @@ ALL_PROVISIONED_TOPIC_SPECS: tuple[ModelTopicSpec, ...] = (
     + ALL_OMNINODE_ROUTING_TOPIC_SPECS
     + (ALL_OMNICLAUDE_TOPIC_SPECS if is_runtime_package_active("omniclaude") else ())
 )
-"""All topic specs to be provisioned by TopicProvisioner at startup.
+"""TRANSITIONAL per-topic config registry (OMN-13238) — NOT the runtime authority.
 
-Combines platform-reserved, domain plugin, and OmniClaude skill topic specs
-into a single registry consumed by service_topic_manager.py. This is the single
-source of truth for topic creation.
+The live runtime topic-creation authority is contract YAML extracted by
+``ContractTopicExtractor.extract_all`` and consumed by
+``service_topic_manager._build_topic_specs`` (names AND per-topic config). This
+registry is retained as a transitional warm source for topics whose owning
+contract has not yet been migrated to ``published_events[].topic_config`` (see
+the banner above for the per-repo follow-up tickets). It is consumed today only
+by the ``omni-infra list-topics`` CLI and the topic-parity CI tests — NOT by any
+runtime provisioning path. It must be fully deleted once the follow-up
+migrations land; it must never become a second standing provisioning authority.
 
 OmniMemory topics (ALL_OMNIMEMORY_TOPIC_SPECS) are included only when
 OMNIMEMORY_ENABLED is set to a truthy value ("1", "true", "yes", "on").

--- a/tests/ci/test_topic_config_contract_parity.py
+++ b/tests/ci/test_topic_config_contract_parity.py
@@ -1,0 +1,155 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""W4 (OMN-13238): contract<->registry per-topic config parity.
+
+Every config-bearing topic that was migrated out of
+``ALL_PROVISIONED_TOPIC_SPECS`` into its owning omnibase_infra contract
+(``published_events[].topic_config``) must resolve, from contract YAML, the
+SAME partitions / replication_factor / kafka_config the legacy registry
+declares. This guards against contract drift and proves the migration is
+lossless.
+
+The remaining (un-migrated) registry entries are owned by contracts in other
+repos or are emitted directly by the runtime kernel; they stay in the
+transitional registry (see the banner in platform_topic_suffixes.py) and are
+NOT asserted here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnibase_infra.tools.contract_topic_extractor import ContractTopicExtractor
+from omnibase_infra.topics import platform_topic_suffixes as pts
+
+# The config-bearing topics whose owning contract lives in omnibase_infra AND
+# which already had a ``published_events`` entry (so attaching ``topic_config``
+# does not synthesize a new published event — preserving orchestrator/effect
+# event-purity invariants). Each was migrated into the owning contract's
+# existing ``published_events[].topic_config`` block in this PR.
+#
+# Config-bearing infra-owned topics that did NOT have a pre-existing
+# published_events entry (or are cmd/intent topics that must not appear in
+# published_events) stay in the transitional registry — migrating them requires
+# either a new published event (a purity change out of scope here) or the
+# omnibase_core event_bus schema extension tracked as a follow-up.
+MIGRATED_TOPICS: frozenset[str] = frozenset(
+    {
+        "onex.evt.omnibase-infra.runner-health-snapshot.v1",
+        "onex.evt.omnibase-infra.network-pool-status.v1",
+        "onex.evt.omnibase-infra.row-count-diagnostic.v1",
+        "onex.evt.omnibase-infra.llm-call-completed.v1",
+        "onex.evt.omnibase-infra.agent-task-lifecycle.v1",
+        "onex.evt.omnibase-infra.inference-response.v1",
+        "onex.evt.platform.topic-catalog-response.v1",
+        "onex.evt.platform.topic-catalog-changed.v1",
+        "onex.evt.omniintelligence.llm-call-completed.v1",
+    }
+)
+
+
+def _registry_spec_by_suffix() -> dict[str, pts.ModelTopicSpec]:
+    """All registry specs across every group (independent of runtime gating)."""
+    all_specs = (
+        pts.ALL_PLATFORM_TOPIC_SPECS
+        + pts.ALL_INTELLIGENCE_TOPIC_SPECS
+        + pts.ALL_OMNIMEMORY_TOPIC_SPECS
+        + pts.ALL_OMNIBASE_INFRA_TOPIC_SPECS
+        + pts.ALL_VALIDATION_TOPIC_SPECS
+        + pts.ALL_OMNINODE_ROUTING_TOPIC_SPECS
+        + pts.ALL_OMNICLAUDE_TOPIC_SPECS
+    )
+    return {spec.suffix: spec for spec in all_specs}
+
+
+def _contract_entries_by_topic() -> dict[str, object]:
+    nodes_root = (
+        Path(__file__).resolve().parents[2] / "src" / "omnibase_infra" / "nodes"
+    )
+    entries = ContractTopicExtractor().extract(nodes_root)
+    return {e.topic: e for e in entries}
+
+
+@pytest.mark.unit
+def test_migrated_topics_resolve_same_config_from_contract() -> None:
+    registry = _registry_spec_by_suffix()
+    contracts = _contract_entries_by_topic()
+
+    mismatches: list[str] = []
+    for topic in sorted(MIGRATED_TOPICS):
+        spec = registry.get(topic)
+        assert spec is not None, f"{topic} missing from registry"
+        entry = contracts.get(topic)
+        assert entry is not None, (
+            f"{topic} not resolvable from any omnibase_infra contract — "
+            f"migration incomplete"
+        )
+
+        exp_partitions = spec.partitions
+        exp_rf = spec.replication_factor
+        exp_cfg = dict(spec.kafka_config) if spec.kafka_config else None
+
+        got_partitions = entry.partitions  # type: ignore[attr-defined]
+        got_rf = entry.replication_factor  # type: ignore[attr-defined]
+        got_cfg = (
+            dict(entry.kafka_config)  # type: ignore[attr-defined]
+            if entry.kafka_config  # type: ignore[attr-defined]
+            else None
+        )
+
+        if (got_partitions, got_rf, got_cfg) != (exp_partitions, exp_rf, exp_cfg):
+            mismatches.append(
+                f"  {topic}: contract={(got_partitions, got_rf, got_cfg)} "
+                f"registry={(exp_partitions, exp_rf, exp_cfg)}"
+            )
+
+    assert not mismatches, "Per-topic config drift between contract and registry:\n" + (
+        "\n".join(mismatches)
+    )
+
+
+@pytest.mark.unit
+def test_migrated_topics_carry_config_in_contract() -> None:
+    """Each migrated topic must declare config in its contract (not just exist)."""
+    contracts = _contract_entries_by_topic()
+    missing_config: list[str] = []
+    for topic in sorted(MIGRATED_TOPICS):
+        entry = contracts.get(topic)
+        if entry is None:
+            missing_config.append(f"{topic} (not in any contract)")
+            continue
+        if entry.partitions is None and entry.replication_factor is None:  # type: ignore[attr-defined]
+            missing_config.append(f"{topic} (no topic_config block)")
+    assert not missing_config, "Migrated topics missing contract topic_config:\n" + (
+        "\n".join(missing_config)
+    )
+
+
+@pytest.mark.unit
+def test_registry_is_transitional_not_load_bearing_for_runtime() -> None:
+    """The registry docstring must mark it transitional (AC-8 no shadow registry).
+
+    A regression that re-promotes the registry to a standing authority (deleting
+    the transitional marker) fails this test.
+    """
+    doc = pts.__dict__.get("ALL_PROVISIONED_TOPIC_SPECS")
+    assert doc is not None
+    module_doc = pts.__doc__ or ""
+    # The symbol docstring is attached to the module via the literal docstring;
+    # assert the transitional banner constant lives in the source.
+    source = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "omnibase_infra"
+        / "topics"
+        / "platform_topic_suffixes.py"
+    ).read_text()
+    assert "TRANSITIONAL" in source
+    assert "OMN-13238" in source
+    assert "DO NOT add new entries here" in source
+    # The misleading "single source of truth for topic creation" claim is gone.
+    assert "single source of truth for topic creation" not in source
+    assert module_doc is not None

--- a/tests/unit/tools/test_contract_topic_config.py
+++ b/tests/unit/tools/test_contract_topic_config.py
@@ -1,0 +1,230 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""W3 (OMN-13238): contract-declared per-topic config schema + extractor carry.
+
+Verifies that a contract declaring a ``topic_config`` block produces a
+``ModelContractTopicEntry`` (and, through the provisioner, a ``ModelTopicSpec`` /
+``NewTopic``) carrying those values, while a contract with no ``topic_config``
+falls back to the canonical ``ModelTopicSpec`` defaults.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from omnibase_infra.tools.contract_topic_extractor import ContractTopicExtractor
+from omnibase_infra.topics.model_topic_spec import (
+    DEFAULT_EVENT_TOPIC_PARTITIONS,
+    DEFAULT_EVENT_TOPIC_REPLICATION_FACTOR,
+)
+
+
+def _write_contract(tmp_path: Path, body: str) -> Path:
+    root = tmp_path / "node_x"
+    root.mkdir()
+    (root / "contract.yaml").write_text(textwrap.dedent(body))
+    return tmp_path
+
+
+@pytest.mark.unit
+def test_topic_config_in_published_events_is_carried(tmp_path: Path) -> None:
+    """A ``published_events[].topic_config`` block flows onto the entry."""
+    root = _write_contract(
+        tmp_path,
+        """
+        name: node_x
+        published_events:
+          - topic: "onex.evt.platform.foo.v1"
+            event_type: "Foo"
+            topic_config:
+              partitions: 1
+              replication_factor: 1
+              kafka_config:
+                retention.ms: "604800000"
+                cleanup.policy: "delete"
+        """,
+    )
+    entries = {e.topic: e for e in ContractTopicExtractor().extract(root)}
+    foo = entries["onex.evt.platform.foo.v1"]
+    assert foo.partitions == 1
+    assert foo.replication_factor == 1
+    assert foo.kafka_config is not None
+    assert dict(foo.kafka_config) == {
+        "retention.ms": "604800000",
+        "cleanup.policy": "delete",
+    }
+
+
+@pytest.mark.unit
+def test_topic_config_in_event_bus_publish_dict_is_carried(tmp_path: Path) -> None:
+    """A structured ``event_bus.publish_topics`` item may carry topic_config."""
+    root = _write_contract(
+        tmp_path,
+        """
+        name: node_x
+        event_bus:
+          publish_topics:
+            - topic: "onex.evt.platform.bar.v1"
+              topic_config:
+                partitions: 12
+                replication_factor: 3
+        """,
+    )
+    entries = {e.topic: e for e in ContractTopicExtractor().extract(root)}
+    bar = entries["onex.evt.platform.bar.v1"]
+    assert bar.partitions == 12
+    assert bar.replication_factor == 3
+    assert bar.kafka_config is None
+
+
+@pytest.mark.unit
+def test_no_topic_config_leaves_fields_none(tmp_path: Path) -> None:
+    """Absent ``topic_config`` leaves config fields None (defaults apply later)."""
+    root = _write_contract(
+        tmp_path,
+        """
+        name: node_x
+        published_events:
+          - topic: "onex.evt.platform.baz.v1"
+            event_type: "Baz"
+        """,
+    )
+    entries = {e.topic: e for e in ContractTopicExtractor().extract(root)}
+    baz = entries["onex.evt.platform.baz.v1"]
+    assert baz.partitions is None
+    assert baz.replication_factor is None
+    assert baz.kafka_config is None
+
+
+@pytest.mark.unit
+def test_spec_builder_maps_topic_config_into_topic_spec(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``TopicProvisioner._build_topic_specs`` maps contract config onto specs.
+
+    A topic with ``topic_config`` produces a ``ModelTopicSpec`` with those
+    values; a topic without it falls back to the ModelTopicSpec defaults.
+    """
+    monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+    root = _write_contract(
+        tmp_path,
+        """
+        name: node_x
+        published_events:
+          - topic: "onex.evt.platform.configured.v1"
+            event_type: "Configured"
+            topic_config:
+              partitions: 1
+              replication_factor: 1
+              kafka_config:
+                retention.ms: "604800000"
+          - topic: "onex.evt.platform.defaulted.v1"
+            event_type: "Defaulted"
+        """,
+    )
+
+    from omnibase_infra.event_bus.service_topic_manager import TopicProvisioner
+
+    provisioner = TopicProvisioner(contracts_root=root)
+    specs = {s.suffix: s for s in provisioner._topic_specs}
+
+    configured = specs["onex.evt.platform.configured.v1"]
+    assert configured.partitions == 1
+    assert configured.replication_factor == 1
+    assert configured.kafka_config is not None
+    assert dict(configured.kafka_config) == {"retention.ms": "604800000"}
+
+    defaulted = specs["onex.evt.platform.defaulted.v1"]
+    assert defaulted.partitions == DEFAULT_EVENT_TOPIC_PARTITIONS
+    assert defaulted.replication_factor == DEFAULT_EVENT_TOPIC_REPLICATION_FACTOR
+    assert defaulted.kafka_config is None
+
+
+@pytest.mark.unit
+def test_topic_config_produces_matching_new_topic(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The created NewTopic reflects the contract-declared topic_config.
+
+    Mirrors the ``NewTopic(...)`` construction in
+    ``ensure_provisioned_topics_exist`` without requiring a live broker.
+    """
+    pytest.importorskip("aiokafka")
+    from aiokafka.admin import NewTopic
+
+    monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+    root = _write_contract(
+        tmp_path,
+        """
+        name: node_x
+        published_events:
+          - topic: "onex.evt.platform.created.v1"
+            event_type: "Created"
+            topic_config:
+              partitions: 1
+              replication_factor: 1
+              kafka_config:
+                retention.ms: "604800000"
+                cleanup.policy: "delete"
+        """,
+    )
+
+    from omnibase_infra.event_bus.service_topic_manager import TopicProvisioner
+
+    provisioner = TopicProvisioner(contracts_root=root)
+    spec = next(
+        s
+        for s in provisioner._topic_specs
+        if s.suffix == "onex.evt.platform.created.v1"
+    )
+    new_topic = NewTopic(
+        name=spec.suffix,
+        num_partitions=spec.partitions,
+        replication_factor=spec.replication_factor,
+        topic_configs=dict(spec.kafka_config) if spec.kafka_config else {},
+    )
+    assert new_topic.num_partitions == 1
+    assert new_topic.replication_factor == 1
+    assert new_topic.topic_configs == {
+        "retention.ms": "604800000",
+        "cleanup.policy": "delete",
+    }
+
+
+@pytest.mark.unit
+def test_merge_sources_keeps_declared_config(tmp_path: Path) -> None:
+    """A topic declared in two contracts (one with config) keeps the config."""
+    (tmp_path / "a").mkdir()
+    (tmp_path / "a" / "contract.yaml").write_text(
+        textwrap.dedent(
+            """
+            name: node_a
+            event_bus:
+              subscribe_topics:
+                - "onex.evt.platform.shared.v1"
+            """
+        )
+    )
+    (tmp_path / "b").mkdir()
+    (tmp_path / "b" / "contract.yaml").write_text(
+        textwrap.dedent(
+            """
+            name: node_b
+            published_events:
+              - topic: "onex.evt.platform.shared.v1"
+                event_type: "Shared"
+                topic_config:
+                  partitions: 1
+                  replication_factor: 1
+            """
+        )
+    )
+    entries = {e.topic: e for e in ContractTopicExtractor().extract(tmp_path)}
+    shared = entries["onex.evt.platform.shared.v1"]
+    assert shared.partitions == 1
+    assert shared.replication_factor == 1
+    assert len(shared.source_contracts) == 2


### PR DESCRIPTION
## OMN-13238 — Contract-declared per-topic config + migrate ALL_PROVISIONED_TOPIC_SPECS (Ticket 2 of 2)

Epic **OMN-12651**. Work items **W3 + W4** of the per-contract topic-provisioning canonical plan
(`docs/tracking/2026-06-18-topic-provisioning-per-contract-canonical-plan.md`). Independent of Ticket 1
(**OMN-13237**, boot interleave, already merged to dev @ 909214cd).

### W3 — contract-declared per-topic config schema + extractor carry (omnibase_infra, self-contained)
- Extended the **existing** `ModelContractTopicEntry` (`tools/contract_topic_extractor.py`) with
  `partitions | None`, `replication_factor | None`, `kafka_config | None` (PEP 604, frozen, MappingProxy).
  No new parallel model; no topic machinery added to omnibase_core.
- `_extract_raw_topics_from_contract` now parses an optional `topic_config` block on any structured topic
  item (`published_events[].topic_config`, `produced_events`/`consumed_events`, and `event_bus` dict-form
  items) and threads it onto the entry; `merge_sources` keeps declared config across duplicate declarations.
- `service_topic_manager._build_topic_specs` maps the entry config onto `ModelTopicSpec`
  (which already supports all four fields), falling back to `ModelTopicSpec` defaults
  (partitions=6, replication_factor=1, kafka_config=None) when `topic_config` is absent.

### W4 — migrate config into owning contracts; reconcile the registry (no shadow registry)
- Migrated the **9** config-bearing topics whose owning omnibase_infra contract already declared a
  `published_events` entry into those contracts' `published_events[].topic_config` (5 contracts).
  Config attached to **pre-existing** entries only — no new published events synthesized — so
  orchestrator/effect **event-purity** invariants stay green (a `.cmd.`/`.intent.` topic in
  `published_events` is forbidden; published_events counts are fixed-asserted).
- A parity test asserts every migrated topic resolves the **same** partitions/replication/kafka_config
  from its owning contract as the legacy registry (lossless, drift-guarded).
- `ALL_PROVISIONED_TOPIC_SPECS` is **not deleted**: 118 of the 141 source entries are owned by contracts in
  other repos (omnimemory / omniintelligence / omnimarket build-loop+delegation / omninode routing),
  emitted directly by the runtime kernel (no owning node contract), or are cmd/intent topics that must not
  appear in `published_events`. Forcing those needs cross-repo PRs + an omnibase_core `event_bus` schema
  extension and would compound the active omnimarket↔core pin-drift (**OMN-13224**).
- Per **AC-8 / §3.5**, the registry is explicitly annotated **TRANSITIONAL** (a warm source pending per-repo
  migration, NOT a standing provisioning authority), the misleading "single source of truth for topic
  creation" docstring is corrected, and the per-repo follow-ups + deletion are documented in-source under
  OMN-12651. `registry_outcome = transitional`.

### Acceptance-criteria mapping
- **AC-2** (topic-spec fidelity) → `tests/unit/tools/test_contract_topic_config.py` (entry + ModelTopicSpec
  + NewTopic carry; defaults when absent).
- **AC-7** (no topic literals) → no new `onex.*.v*` Python literals; `topic_literal_baseline.txt` unchanged
  (new config is contract YAML only).
- **AC-8** (no shadow registry) → registry annotated transitional + deletion ticket;
  `tests/ci/test_topic_config_contract_parity.py::test_registry_is_transitional_not_load_bearing_for_runtime`.

### Verification (local, green, no broker)
- `uv run mypy src/ --strict` → Success, 2452 files.
- `uv run ruff format` / `ruff check` → clean.
- New W3/W4 suites + existing extractor/topic-parity/orchestrator-purity suites green; no regressions.
  (Pre-existing, environment-dependent failures on clean origin/dev — entry-point/namespace discovery,
  vendored-migration sync, `test_cli.py::test_registration_only` — are unrelated to this change.)

### dod_evidence
See `contracts/OMN-13238.yaml` (W3 config-carry, W4 parity, no-shadow-registry, no-new-topic-literals,
mypy-strict).

Refs OMN-13238 (epic OMN-12651). Supersedes-link only: OMN-12448, OMN-13220.

Evidence-Source: OCC#2762
Evidence-Ticket: OMN-13238
