### PR TITLE
docs(OMN-13230): two-layer worktree-GC runbook + retain hourly backstop (T6)

### DIFF
--- a/deploy/disk-gc/README.md
+++ b/deploy/disk-gc/README.md
@@ -1,0 +1,26 @@
+<!-- SPDX-FileCopyrightText: 2025 OmniNode.ai Inc. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+# `.201` disk-GC / worktree-reaper units (OMN-13008)
+
+Two coexisting systemd USER timers implement the **two-layer merge-triggered
+worktree GC** model. Neither replaces the other — both are retained.
+
+| Unit pair | Layer | Cadence | Install |
+|-----------|-------|---------|---------|
+| `onex-worktree-reaper.{timer,service}` | 1 — event-first reaper (reap-on-merge) | every 2 min | `bash install-worktree-reaper.sh` |
+| `onex-disk-gc.{timer,service}` | 2 — hourly backstop (worktree GC + docker GC + watermark) | hourly | `bash install-disk-gc.sh` |
+
+- **Layer 1** reaps each newly-merged PR's worktree within ~one poll interval by
+  reading the `onex.evt.github.pr-merged.v1` projection `?since=<cursor>`.
+- **Layer 2** is the cursor-INDEPENDENT backstop that reconciles events missed
+  during downtime / dropped before the cursor advanced. **`onex-disk-gc.timer`
+  must stay installed** (T6 / OMN-13230 retention rule).
+
+Both layers drive the same safety core (`omniclaude/scripts/prune-worktrees.sh`:
+merged + clean + pushed-only; dirty → SKIP). The Mac equivalent of both layers is
+the single `worktree_reaper.py --loop` KeepAlive daemon (Layer 1 fast poll +
+Layer 2 catch-up sweep on start and hourly).
+
+Full model, convergence proof, and verification commands:
+[`docs/runbooks/worktree-reaper-two-layer-gc.md`](../../docs/runbooks/worktree-reaper-two-layer-gc.md).

--- a/docker/migrations/forward/nodes/node_pr_merged_projection/0001_create_pr_merged_events.sql
+++ b/docker/migrations/forward/nodes/node_pr_merged_projection/0001_create_pr_merged_events.sql
@@ -1,0 +1,32 @@
+-- OMN-13227 / T3: Create the pr_merged_events projection table.
+--
+-- HandlerPrMergedProjection UPSERTs one row per onex.evt.github.pr-merged.v1
+-- event, deduped by event_id (the publisher-minted UUID). The per-machine
+-- worktree reaper (OMN-13228 / T4) polls
+--   GET /projection/onex.evt.github.pr-merged.v1?since=<cursor>
+-- and matches {repo, branch, pr_number, ticket} to a local worktree, then runs
+-- prune-worktrees.sh against it.
+--
+-- projection_cursor is a strictly-monotonic BIGSERIAL: the generic projection
+-- API filters rows with projection_cursor > :since and returns the largest
+-- value as next_cursor, so the reaper never re-processes a merged PR.
+
+CREATE TABLE IF NOT EXISTS pr_merged_events (
+    projection_cursor BIGSERIAL PRIMARY KEY,
+    event_id TEXT NOT NULL UNIQUE,
+    repo TEXT NOT NULL,
+    branch TEXT NOT NULL,
+    pr_number INTEGER NOT NULL,
+    ticket TEXT NOT NULL DEFAULT '',
+    merged_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_pr_merged_events_cursor
+    ON pr_merged_events (projection_cursor);
+
+CREATE INDEX IF NOT EXISTS idx_pr_merged_events_repo_branch
+    ON pr_merged_events (repo, branch);
+
+CREATE INDEX IF NOT EXISTS idx_pr_merged_events_merged_at
+    ON pr_merged_events (merged_at DESC);

--- a/docker/migrations/forward/nodes/node_renderer_capability_projection/0001_create_renderer_capability_projection.sql
+++ b/docker/migrations/forward/nodes/node_renderer_capability_projection/0001_create_renderer_capability_projection.sql
@@ -1,0 +1,35 @@
+-- OMN-13131 / W5: Renderer Capability Registry projection.
+-- Sole writer: node_renderer_capability_projection (NodeReducer). This table IS
+-- the registry — there is no in-memory CapabilityRegistry class. Consumers read
+-- the materialized projection via GET /projection/onex.evt.omnimarket.renderer-capability-projection-snapshot.v1.
+-- One row per renderer_id (UPSERT key); heartbeat-TTL freshness is materialized
+-- as is_degraded + a typed empty_state_reason ('upstream-blocked' when degraded).
+
+CREATE TABLE IF NOT EXISTS renderer_capability_projection (
+    id                          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- Upsert key — one row per renderer.
+    renderer_id                 TEXT NOT NULL,
+
+    -- Declared capability surface (mirrors ModelRendererCapabilityContract).
+    platform                    TEXT NOT NULL,
+    supported_component_kinds   TEXT[] NOT NULL DEFAULT '{}',
+    interaction_model           TEXT NOT NULL,
+    accessibility_tier          TEXT NOT NULL,
+    contract_version            TEXT NOT NULL,
+
+    -- Heartbeat freshness.
+    declared_at                 TIMESTAMPTZ NOT NULL,
+    last_heartbeat              TIMESTAMPTZ NOT NULL,
+    is_degraded                 BOOLEAN NOT NULL DEFAULT FALSE,
+    empty_state_reason          TEXT,                    -- typed EnumEmptyStateReason value; 'upstream-blocked' when degraded
+
+    -- Projection lineage.
+    observed_at                 TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at                  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT uq_renderer_capability_renderer_id UNIQUE (renderer_id)
+);
+
+CREATE INDEX IF NOT EXISTS ix_renderer_capability_last_heartbeat
+    ON renderer_capability_projection (last_heartbeat DESC);

--- a/docs/runbooks/worktree-reaper-two-layer-gc.md
+++ b/docs/runbooks/worktree-reaper-two-layer-gc.md
@@ -1,0 +1,140 @@
+# Merge-Triggered Worktree GC — Two-Layer Model (Event-First + Timer-Backstop)
+
+**Epic:** OMN-13008 (merge-triggered worktree reaper)
+**Tickets:** T4 (OMN-13228, event-first reaper) · T6 (OMN-13230, timer backstop + this runbook)
+**Owners:** `.201` systemd units in `deploy/disk-gc/`; Mac launchd daemon in
+`omniclaude/scripts/worktree-reaper-daemon.sh`.
+
+## Why this exists
+
+Stale worktrees for already-merged PRs accumulate under the worktrees root and —
+alongside docker images — filled `/data` on `.201` on 2026-06-11 (the OMN-13009
+demo-day incident). The fix is to garbage-collect a worktree as soon as its PR
+merges, removing ONLY worktrees whose PR is merged (or whose remote branch is
+gone) AND that are clean AND fully pushed.
+
+A purely periodic sweep is too slow (a worktree can linger up to an hour) and a
+purely event-driven reaper is not durable (events get dropped; the daemon can be
+down during a merge). So GC runs as **two layers that converge on the same end
+state** — every merged-and-clean worktree removed — using the SAME safety core.
+
+## The two layers
+
+| Layer | What | Trigger | Latency | Cursor |
+|-------|------|---------|---------|--------|
+| **1 — event-first** | Reap each newly-merged PR's worktree | `onex.evt.github.pr-merged.v1` projection read `?since=<cursor>` | Reaped within ≤1 poll interval of the merge event materializing (target ≤60s) | Advances a monotonic cursor on a fully-successful execute pass |
+| **2 — timer-backstop** | Cursor-INDEPENDENT full reconciliation: reap ALL already-merged worktrees still present | Periodic timer (hourly) + once on daemon start | Up to one backstop interval | None — it is a reconciliation, not a windowed advance |
+
+Layer 1 is the steady-state fast path. Layer 2 is the safety net for events that
+were **missed during downtime or dropped before the cursor advanced**: it scans
+every worktree directly and lets the prune safety decide, regardless of the
+cursor. Because Layer 2 never touches the cursor, it can never regress or skip
+Layer 1's watermark — the two layers are independent and both converge.
+
+### Shared safety core (both layers)
+
+Neither layer re-implements GC safety. Both drive the canonical
+`omniclaude/scripts/prune-worktrees.sh`, which removes a worktree ONLY when:
+
+- its PR is **MERGED** (or the remote branch is gone), **AND**
+- the working tree is **clean** (no uncommitted changes → otherwise SKIP), **AND**
+- there are **no unpushed commits** (no-upstream defaults to SKIP, never DELETE).
+
+Detached-HEAD and dirty worktrees are SKIPPED, never deleted. Salvage of dirty
+worktrees is out of scope (OMN-13044 owns that). Default-SKIP on any ambiguity:
+a prune failure, a projection fetch error, or a malformed event leaves the cursor
+un-advanced (Layer 1) or the root marked failed for retry (Layer 2).
+
+## `.201` (systemd, user scope — no sudo)
+
+Two coexisting systemd USER units in `deploy/disk-gc/`, installed independently.
+**Both are retained — neither replaces the other.**
+
+| Unit | Role | Cadence | Install |
+|------|------|---------|---------|
+| `onex-worktree-reaper.timer` → `.service` | Layer 1 event-first reaper | every 2 min (`OnCalendar=*:0/2`) | `bash deploy/disk-gc/install-worktree-reaper.sh` |
+| `onex-disk-gc.timer` → `.service` | Layer 2 backstop (worktree GC + docker GC + watermark) | hourly (`OnCalendar=hourly`) | `bash deploy/disk-gc/install-disk-gc.sh` |
+
+`onex-disk-gc.service` runs three conservative passes in order: `worktree-gc.sh`
+(drives `prune-worktrees.sh`), `disk-gc.sh` (docker/builder/image GC honoring the
+keep-list), and `disk-watermark-check.sh` (emits a bus alert if `/data` crosses
+the watermark). The hourly worktree-GC pass IS the Layer 2 backstop on `.201`.
+
+> **Retention rule (T6):** `onex-disk-gc.timer` must stay installed as the
+> hourly backstop. Do NOT remove it when the event-first reaper is running — the
+> reaper handles steady state, the hourly timer reconciles missed events. They
+> coexist by design.
+
+Verify both are armed:
+
+```bash
+systemctl --user list-timers 'onex-*'
+systemctl --user status onex-worktree-reaper.timer   # Layer 1, ~2 min
+systemctl --user status onex-disk-gc.timer           # Layer 2, hourly
+journalctl --user -u onex-disk-gc.service -f          # backstop sweep logs
+```
+
+## Mac (launchd KeepAlive daemon)
+
+launchd **periodic** jobs do not fire reliably on this Mac
+(`feedback_local_durability`). So the Mac packs BOTH layers into a single
+**resident KeepAlive daemon** — `ai.omninode.worktree-reaper.plist` runs
+`omniclaude/scripts/worktree-reaper-daemon.sh`, which execs
+`omniclaude/scripts/worktree_reaper.py --execute --loop`:
+
+- **Layer 1** runs every `ONEX_REAPER_INTERVAL` seconds (default 60) — the fast
+  event poll.
+- **Layer 2** runs once on daemon start (reconciling anything missed while the
+  daemon was down) and then every `ONEX_REAPER_CATCH_UP_INTERVAL` seconds
+  (default 3600 = hourly), the Mac equivalent of `.201`'s `onex-disk-gc.timer`.
+  Set `ONEX_REAPER_CATCH_UP_INTERVAL=0` to disable the periodic backstop.
+
+The catch-up sweep is `run_catch_up_sweep()` in `worktree_reaper.py`: it drives
+`prune-worktrees.sh` directly across every root (cursor-independent) so it reaps
+ALL already-merged worktrees still present, not just the since-cursor window.
+
+Run a one-shot backstop sweep manually (needs no projection URL — it drives prune
+directly):
+
+```bash
+# dry-run reconciliation (default; reports, never deletes)
+python omniclaude/scripts/worktree_reaper.py --catch-up
+# real reconciliation
+python omniclaude/scripts/worktree_reaper.py --catch-up --execute
+```
+
+Install / inspect the daemon:
+
+```bash
+bash omniclaude/scripts/install-worktree-reaper-daemon.sh
+launchctl list | grep ai.omninode.worktree-reaper
+```
+
+## Convergence proof
+
+Both layers are proven to converge on the same end state:
+
+- **Layer 1 (event path)** — proven in T4 (OMN-13228): a throwaway merged PR's
+  worktree is reaped within one poll interval; the cursor advances; dirty /
+  unpushed worktrees SKIP. Tests in `omniclaude/tests/scripts/test_worktree_reaper.py`
+  (`test_merged_clean_row_drives_prune_script`, `test_dirty_or_unpushed_worktree_is_skipped`).
+- **Layer 2 (backstop / catch-up)** — proven in T6 (OMN-13230):
+  `test_catch_up_sweep_converges_on_seeded_stale_merged_worktree_and_skips_dirty`
+  seeds a stale-but-merged worktree and a dirty merged worktree, runs the catch-up
+  sweep through the real prune subprocess path, and asserts the clean one is
+  removed while the dirty one is SKIPPED and left intact. The catch-up sweep never
+  touches the cursor (`test_catch_up_sweep_never_touches_cursor`), so it cannot
+  regress Layer 1.
+
+Convergence: whether a merge is caught by the cursor window (Layer 1) or a full
+scan (Layer 2), the worktree is reaped under the same safety. A missed or dropped
+event is reconciled within one backstop interval; the event path keeps that
+window small in steady state.
+
+## Related docs
+
+- `omniclaude/scripts/worktree_reaper.py` — the Mac reaper (both layers).
+- `omniclaude/scripts/prune-worktrees.sh` — the shared safety core.
+- `scripts/worktree-gc.sh` — the `.201` driver invoked by `onex-disk-gc.service`.
+- `deploy/disk-gc/` — `.201` systemd units (`onex-worktree-reaper.*`,
+  `onex-disk-gc.*`) and installers.


### PR DESCRIPTION
## OMN-13230 (T6 of OMN-13008) — two-layer worktree-GC runbook + retain hourly backstop

Documents the **event-first + timer-backstop** model for the merge-triggered worktree
reaper and confirms/retains the hourly `.201` backstop (no behavior removal).

### What changed
- `docs/runbooks/worktree-reaper-two-layer-gc.md` — full two-layer model:
  - **Layer 1 (event-first, T4):** reaps each merged PR's worktree within one poll
    interval via the `onex.evt.github.pr-merged.v1` projection `?since=<cursor>`.
  - **Layer 2 (timer-backstop, this ticket):** cursor-INDEPENDENT reconciliation
    that reaps ALL already-merged worktrees still present — the hourly
    `onex-disk-gc.timer` on `.201` and the catch-up sweep in the Mac reaper daemon.
  - `.201` systemd units (`onex-worktree-reaper.*` every 2 min + `onex-disk-gc.*`
    hourly) coexist; both retained. Convergence proof cites the T4 and T6 tests.
- `deploy/disk-gc/README.md` — pointer where the timers live + the retention rule
  (`onex-disk-gc.timer` stays installed as the hourly backstop).

### Retention (DoD)
The hourly `.201` `onex-disk-gc.timer` is RETAINED as the Layer 2 backstop — no
unit removed, no behavior changed. The reaper handles steady state; the hourly
timer reconciles missed events. They coexist by design.

### Note: node-migration vendor sync (pre-existing gate)
Also vendors the already-merged omnimarket-dev node migrations
(`node_pr_merged_projection`, `node_renderer_capability_projection`) into the infra
migration tree. The `node-migration-sync` CI gate compares against omnimarket dev
tip and fires this drift on ANY infra PR until vendored; the SQL matches omnimarket
dev exactly (mechanically generated by `scripts/sync-node-migrations.sh`). Pre-existing
local test `tests/unit/verification/test_cli.py::TestCLIMain::test_registration_only`
fails identically on clean `origin/dev` (env-dependent CLI exit-code assert) and is
untouched by this docs+SQL change.

Docs + vendored SQL only — zero Python touched.

Evidence-Source: OCC#2767
Evidence-Ticket: OMN-13230


<!-- receipt-gate-retrigger: t6-occ-bound-1781816340 -->
