### PR TITLE
chore(OMN-13131): bump omnibase_core pin to v0.45.0 for renderer-capability runtime

### DIFF
--- a/docker/runners/runner-image.lock.json
+++ b/docker/runners/runner-image.lock.json
@@ -1,12 +1,12 @@
 {
   "base_image_digest": "sha256:3ba65aa20f86a0fad9df2b2c259c613df006b2e6d0bfcc8a146afb8c525a9751",
   "gh_version": "2.67.0",
-  "identity_digest": "a9b134c16ae5a2b6a322fba4a6e219e4",
+  "identity_digest": "99e2542d6724e0c67e67de865c700972",
   "image_version": 5,
   "kubectl_version": "1.32.1",
   "python_version": "3.12",
   "runner_version": "2.334.0",
-  "shared_env_digest": "bcc8bacedd620800c62b693c",
+  "shared_env_digest": "b20344134388330365ca735a",
   "shared_env_install_args": "--frozen --all-extras --all-groups --no-install-project",
   "uv_version": "0.6.14"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     #   omnibase-core = { git = "https://github.com/org/omnibase_core.git", rev = "SHA" }
     # Remember to switch back to PyPI versions before merging to main.
     #
-    "omnibase-core>=0.44.0,<0.45.0",
+    "omnibase-core>=0.45.0,<0.46.0",
     "omnibase-spi>=0.22.0,<0.23.0",
     # ============================================================================
     # External Dependency Security Guidance
@@ -166,15 +166,16 @@ dev = [
 
 [tool.uv]
 override-dependencies = [
-    "omnibase-core>=0.44.0,<0.45.0",
+    "omnibase-core>=0.45.0,<0.46.0",
     "omnibase-spi>=0.22.0,<0.23.0",
 ]
 
 [tool.uv.sources]
-# OMN-13094: pin core to the merged ArtifactStore (OMN-13093) +
-# ModelArtifactRef/ModelSkillResult (OMN-13091) so `onex node --output receipt`
-# consumes the canonical content-addressed capture surface.
-omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", rev = "ae8793bdad96c12a0b47e2f4d1d0f179618553b8" }
+# OMN-13131: bump core source pin to the released v0.45.0 tag so the dev runtime
+# image vendors the renderer-capability contract (model_renderer_capability_contract),
+# runtime_deployment models, enums/ui/*, and contract_graph IR (all additive over 0.44.2).
+# v0.45.0 = dc69b726248fd0212a3abc0a5a587bd974278739.
+omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", rev = "dc69b726248fd0212a3abc0a5a587bd974278739" }
 omnibase-spi = { git = "https://github.com/OmniNode-ai/omnibase_spi.git", branch = "main" }
 onex-change-control = { git = "https://github.com/OmniNode-ai/onex_change_control.git", branch = "main" }
 [tool.ruff]

--- a/src/omnibase_infra/runtime/version_compatibility.py
+++ b/src/omnibase_infra/runtime/version_compatibility.py
@@ -175,8 +175,8 @@ def _build_matrix_from_pyproject(
 _FALLBACK_MATRIX: list[VersionConstraint] = [
     VersionConstraint(
         package="omnibase_core",
-        min_version="0.44.0",
-        max_version="0.45.0",
+        min_version="0.45.0",
+        max_version="0.46.0",
     ),
     VersionConstraint(
         package="omnibase_spi",

--- a/tests/integration/infra/test_omn_12765_release_backmerge_identity.py
+++ b/tests/integration/infra/test_omn_12765_release_backmerge_identity.py
@@ -15,9 +15,9 @@ def test_release_backmerge_preserves_proven_runtime_core_pin() -> None:
 
     pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
     uv_lock = (ROOT / "uv.lock").read_text(encoding="utf-8")
-    # OMN-13094: pin advanced to the merged ArtifactStore slice (OMN-13093) —
-    # receipt mode consumes omnibase_core.artifacts + ModelSkillResult.
-    expected_core = "ae8793bdad96c12a0b47e2f4d1d0f179618553b8"
+    # OMN-13131: pin advanced to the renderer-capability runtime core release
+    # consumed by the W5 runtime image.
+    expected_core = "dc69b726248fd0212a3abc0a5a587bd974278739"
 
     assert expected_core in pyproject
     assert expected_core in uv_lock
@@ -30,7 +30,7 @@ def test_release_backmerge_preserves_runner_identity_lock() -> None:
         (ROOT / "docker/runners/runner-image.lock.json").read_text(encoding="utf-8")
     )
 
-    # OMN-13187: identity regenerated after the dependency refresh changed the
+    # OMN-13131: identity regenerated after the core pin refresh changed the
     # runner image lock binding inputs.
-    assert lock["identity_digest"] == "a9b134c16ae5a2b6a322fba4a6e219e4"
-    assert lock["shared_env_digest"] == "bcc8bacedd620800c62b693c"
+    assert lock["identity_digest"] == "99e2542d6724e0c67e67de865c700972"
+    assert lock["shared_env_digest"] == "b20344134388330365ca735a"

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [manifest]
 overrides = [
-    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=ae8793bdad96c12a0b47e2f4d1d0f179618553b8" },
+    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=dc69b726248fd0212a3abc0a5a587bd974278739" },
     { name = "omnibase-spi", git = "https://github.com/OmniNode-ai/omnibase_spi.git?branch=main" },
 ]
 
@@ -2075,8 +2075,8 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.44.2"
-source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=ae8793bdad96c12a0b47e2f4d1d0f179618553b8#ae8793bdad96c12a0b47e2f4d1d0f179618553b8" }
+version = "0.45.0"
+source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=dc69b726248fd0212a3abc0a5a587bd974278739#dc69b726248fd0212a3abc0a5a587bd974278739" }
 dependencies = [
     { name = "blake3" },
     { name = "click" },
@@ -2189,7 +2189,7 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.20.0,<5.0.0" },
     { name = "mcp", specifier = ">=1.25.0,<2.0.0" },
     { name = "neo4j", specifier = ">=5.15.0,<7.0.0" },
-    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=ae8793bdad96c12a0b47e2f4d1d0f179618553b8" },
+    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=dc69b726248fd0212a3abc0a5a587bd974278739" },
     { name = "omnibase-spi", git = "https://github.com/OmniNode-ai/omnibase_spi.git?branch=main" },
     { name = "opentelemetry-api", specifier = ">=1.27.0,<2.0.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.27.0,<2.0.0" },


### PR DESCRIPTION
Evidence-Source: OCC#2771
Evidence-Ticket: OMN-13131

## Summary

Aligns omnibase_infra's `omnibase_core` pin to the released **v0.45.0** so the dev runtime image vendors the renderer-capability contract surface.

The dev runtime image vendored `omnibase_core` 0.44.2 because omnibase_infra capped `omnibase-core>=0.44.0,<0.45.0` (PyPI constraint + `[tool.uv]` override + `[tool.uv.sources]` git rev `ae8793bd` = 0.44.2) while omnimarket pins `>=0.45.0,<0.46.0`. The incompatible upper bound forced the resolver to 0.44.2 in the combined image, which is missing `models/dashboard/model_renderer_capability_contract.py` — `ModuleNotFoundError` broke W5 reducer auto-wiring.

v0.45.0 is **additive over 0.44.2** (dashboard renderer-capability contract, `models/runtime_deployment`, `enums/ui/*`, `contract_graph` IR), so no source changes are needed.

## Changes

- `[project.dependencies]`: `omnibase-core>=0.44.0,<0.45.0` -> `>=0.45.0,<0.46.0`
- `[tool.uv] override-dependencies`: same bump
- `[tool.uv.sources]`: git `rev` `ae8793bd` (0.44.2) -> `dc69b726248fd0212a3abc0a5a587bd974278739` (the **v0.45.0** tag)
- `uv.lock` re-resolved: `omnibase-core 0.44.2 (ae8793bd) -> 0.45.0 (dc69b726)`
- `src/omnibase_infra/runtime/version_compatibility.py` `_FALLBACK_MATRIX` regenerated via `scripts/update_version_matrix.py` (the `VERSION_MATRIX` derives from pyproject.toml automatically; the fallback is kept in sync per the repo's release checklist)

## Verification (local, against 0.45.0)

- `tests/unit/runtime/test_version_compatibility.py` — 25 passed (incl. `test_matrix_matches_pyproject`, the drift gate)
- `tests/unit/runtime/` — 4913 passed, 5 pre-existing skips, 0 failures (85s)
- `mypy src/omnibase_infra/runtime/version_compatibility.py --strict` — clean
- `uv.lock` shows `omnibase-core version = "0.45.0"`; `python -c "import omnibase_core.models.dashboard.model_renderer_capability_contract"` succeeds (the module whose absence broke W5)

## OCC pairing

The binding PASS `ModelDodReceipt` for this PR (`dod-omnibase-infra-pinfix`) lands under `onex_change_control/drift/dod_receipts/OMN-13131/` via the paired OCC PR; this PR body cites `Evidence-Ticket: OMN-13131` for the Receipt-Gate (dev-preflight mode). No live prod mutation, deploy, or restart.
