### PR TITLE
feat(OMN-13298): wire url-authority gate (pre-commit + CI)

### DIFF
--- a/.github/workflows/url-authority-gate.yml
+++ b/.github/workflows/url-authority-gate.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras
 
+      - name: Install URL authority validator
+        run: uv pip install --reinstall "omnibase-core @ git+https://github.com/OmniNode-ai/omnibase_core.git@c93c98c92bd1a5b335d7aa504a8cf63dc029b3e7"
+
       - name: Run url-authority gate (full-repo, against frozen baseline)
         run: |
           uv run python -m omnibase_core.validation.validator_url_authority \

--- a/.github/workflows/url-authority-gate.yml
+++ b/.github/workflows/url-authority-gate.yml
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# OMN-13298 (child of OMN-12803): url-authority ratchet gate — BLOCKING MODE.
+#
+# Every URL/endpoint must resolve from a contract (the routing authority for
+# model endpoints, the integration catalog for external/infra endpoints) — never
+# from a public-HTTPS source literal or a *_URL / *_ENDPOINT env read. API-key
+# env reads and config-PATH reads stay legal.
+#
+# This is a RATCHET: existing violations are grandfathered by the sha256 baseline
+# at src/omnibase_core/validation/baselines/url_authority_baseline.json in the
+# omnibase_core package. Any NEW violation (fingerprint absent from the baseline)
+# fails the job and blocks merge. The baseline is burn-down only.
+#
+# To permit a legitimate literal, annotate the line:
+#   # url-authority-ok: <concrete reason>
+#
+# Migration debt ticket: OMN-12807
+#
+# This job is a REQUIRED STATUS CHECK. The job name "URL Authority Gate" must
+# match branch protection rules.
+
+name: URL Authority Gate
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [main, dev]
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+  url-authority-gate:
+    name: URL Authority Gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run url-authority gate (full-repo, against frozen baseline)
+        run: |
+          uv run python -m omnibase_core.validation.validator_url_authority \
+            --all --repo omnibase_infra --repo-root .
+
+      - name: Assert baseline did not grow (anti-gaming)
+        run: |
+          uv run python - <<'PY'
+          import json
+          import subprocess
+          import sys
+          from pathlib import Path
+
+          # Locate the baseline inside the installed omnibase_core package.
+          import omnibase_core.validation.validator_url_authority as _m
+          baseline = Path(_m.__file__).parent / "baselines" / "url_authority_baseline.json"
+          head = json.loads(baseline.read_text())
+          head_repo = {
+              e["fingerprint"]
+              for e in head["violations"]
+              if e["repo"] == "omnibase_infra"
+          }
+          # Compare against the baseline on the PR base branch.
+          base_ref = "origin/${{ github.base_ref || 'dev' }}"
+          try:
+              prior_text = subprocess.check_output(
+                  ["git", "show", f"{base_ref}:{baseline.relative_to(Path.cwd())}"],
+                  text=True,
+              )
+              prior = json.loads(prior_text)
+              prior_repo = {
+                  e["fingerprint"]
+                  for e in prior["violations"]
+                  if e["repo"] == "omnibase_infra"
+              }
+          except (subprocess.CalledProcessError, ValueError):
+              print(
+                  "URL-AUTHORITY BASELINE OK (initial): "
+                  f"baseline file is new on this PR ({len(head_repo)} grandfathered "
+                  "fingerprints); no prior to compare against."
+              )
+              sys.exit(0)
+          grew = head_repo - prior_repo
+          if grew:
+              sys.stderr.write(
+                  "URL-AUTHORITY BASELINE GREW: "
+                  f"{len(grew)} new fingerprint(s) added to the baseline. The baseline "
+                  "is burn-down only — fix the violation or annotate with "
+                  "# url-authority-ok:, never grow the baseline.\n"
+              )
+              sys.exit(1)
+          print(
+              "URL-AUTHORITY BASELINE OK: "
+              f"omnibase_infra subset {len(head_repo)} (<= prior {len(prior_repo)})."
+          )
+          PY

--- a/.github/workflows/url-authority-gate.yml
+++ b/.github/workflows/url-authority-gate.yml
@@ -48,17 +48,15 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras
 
-      - name: Install URL authority validator
-        run: uv pip install --reinstall "omnibase-core @ git+https://github.com/OmniNode-ai/omnibase_core.git@c93c98c92bd1a5b335d7aa504a8cf63dc029b3e7"
-
       - name: Run url-authority gate (full-repo, against frozen baseline)
         run: |
-          uv run python -m omnibase_core.validation.validator_url_authority \
+          uv run --with "omnibase-core @ git+https://github.com/OmniNode-ai/omnibase_core.git@c93c98c92bd1a5b335d7aa504a8cf63dc029b3e7" \
+            python -m omnibase_core.validation.validator_url_authority \
             --all --repo omnibase_infra --repo-root .
 
       - name: Assert baseline did not grow (anti-gaming)
         run: |
-          uv run python - <<'PY'
+          uv run --with "omnibase-core @ git+https://github.com/OmniNode-ai/omnibase_core.git@c93c98c92bd1a5b335d7aa504a8cf63dc029b3e7" python - <<'PY'
           import json
           import subprocess
           import sys

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,16 @@ repos:
       # New violations blocked. Drain tracked by OMN-13026 per-site tickets.
       - id: transport-mock-lint
         args: [--baseline, config/validation/transport_mock_baseline.yaml]
+  # URL Authority Gate (OMN-13298, child of OMN-12803).
+  # Ratchet: NEW fingerprints fail; existing violations grandfathered in the
+  # shared baseline at omnibase_core/src/omnibase_core/validation/baselines/url_authority_baseline.json.
+  # Baseline is burn-down only. Suppress with: # url-authority-ok: <reason>
+  - repo: https://github.com/OmniNode-ai/omnibase_core
+    rev: 72b2208e2dad0246a0189a87f82324faeee2a7b2 # pragma: allowlist secret
+    hooks:
+      - id: check-url-authority
+        args: [--repo, omnibase_infra, --repo-root, .]
+        exclude: ^(tests/|archived/|archive/).*\.py$
   # Hardcoded topic guard — sourced from onex_change_control (OMN-5256/OMN-5259)
   # Pre-existing violations excluded pending migration to canonical constants (OMN-5259)
   # OMN-13195 (phase A4): dropped the redundant `event_bus/topic_constants.py`

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
   # shared baseline at omnibase_core/src/omnibase_core/validation/baselines/url_authority_baseline.json.
   # Baseline is burn-down only. Suppress with: # url-authority-ok: <reason>
   - repo: https://github.com/OmniNode-ai/omnibase_core
-    rev: 72b2208e2dad0246a0189a87f82324faeee2a7b2 # pragma: allowlist secret
+    rev: c93c98c92bd1a5b335d7aa504a8cf63dc029b3e7 # pragma: allowlist secret
     hooks:
       - id: check-url-authority
         args: [--repo, omnibase_infra, --repo-root, .]


### PR DESCRIPTION
## Summary

Wires the existing `check-url-authority` remote pre-commit hook from omnibase_core and adds the companion `url-authority-gate.yml` CI workflow. This is a pure wiring change — the validator already lives in omnibase_core and is remote-hook-exposed.

**What changes:**
- `.pre-commit-config.yaml`: adds new omnibase_core hook block with `check-url-authority` hook, args `[--repo, omnibase_infra, --repo-root, .]`
- `.github/workflows/url-authority-gate.yml`: new CI workflow (REQUIRED STATUS CHECK — "URL Authority Gate")

**Ratchet mode:** all pre-existing violations (49) are grandfathered in the shared baseline seeded in omnibase_core PR #1264. Only NEW hardcoded URL fingerprints fail the gate going forward. Migration debt: OMN-12807 (infra) / OMN-12808 (others).

## Fail-Closed Proof (verifier ≠ runner)

Planted `URL_TEST = "https://api.example.com/v1/endpoint"` in src/, ran validator:

```
URL-AUTHORITY GATE FAILED: 1 NEW violation(s) — every URL must resolve from a contract
  [url-const-assignment] omnibase_infra/src/.../check_url_probe.py:2
    URL_TEST = "https://api.example.com/v1/endpoint"
Exit code: 1

# Reverted:
URL-AUTHORITY GATE PASSED: 0 new violations (49 grandfathered).
Exit code: 0
```

Evidence-Source: OCC#2773
Evidence-Ticket: OMN-13298