### PR TITLE
feat(OMN-13249): wire canonical-inference gate (pre-commit + CI) — omnibase_infra

### DIFF
--- a/.github/workflows/canonical-inference-gate.yml
+++ b/.github/workflows/canonical-inference-gate.yml
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# OMN-13249 (fleet rollout of OMN-13219): canonical-inference ratchet gate —
+# BLOCKING MODE.
+#
+# Inference must go through the contract-driven routing authority (bus /
+# inference-effect / Bifrost), never a shelled model CLI and never a
+# hardcoded/env-resolved model or provider. This gate fails on:
+#   - model-cli-shellout: codex/claude/gemini/opencode passed to subprocess/exec
+#     or resolved via shutil.which
+#   - model-id-env-read:  os.environ[*_MODEL] / os.environ.get(*_PROVIDER) reads
+#
+# Structural carve-out (OMN-13249): a model-CLI shell-out is permitted iff the
+# enclosing node contract.yaml declares descriptor.agent_invocation: true — a
+# contract fact the gate verifies, never a free-text comment.
+#
+# Endpoint URLs and *_URL / *_ENDPOINT env reads are owned by the URL Authority
+# Gate (OMN-12818). This gate is the missing shell-out-for-inference layer.
+#
+# This is a RATCHET: existing violations are grandfathered by the sha256 baseline
+# at src/omnibase_core/validation/baselines/canonical_inference_baseline.json
+# inside the omnibase_core package. Any NEW violation (fingerprint absent from
+# the baseline) fails the job and blocks merge. The baseline is burn-down only.
+#
+# To permit a legitimate exception, annotate the line:
+#   # canonical-inference-ok: <concrete reason>
+#
+# This job is a REQUIRED STATUS CHECK. The job name "Canonical Inference Gate"
+# must match branch protection rules.
+
+name: Canonical Inference Gate
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [main, dev]
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+  canonical-inference-gate:
+    name: Canonical Inference Gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Run canonical-inference gate (full-repo, against frozen baseline)
+        run: |
+          uv run --with "omnibase-core @ git+https://github.com/OmniNode-ai/omnibase_core.git@940d2f2ab44d2f455a607926674b90ecbc9b74ba" \
+            python -m omnibase_core.validation.validator_canonical_inference \
+            --all --repo omnibase_infra --repo-root .
+
+      - name: Assert baseline did not grow (anti-gaming)
+        run: |
+          uv run --with "omnibase-core @ git+https://github.com/OmniNode-ai/omnibase_core.git@940d2f2ab44d2f455a607926674b90ecbc9b74ba" python - <<'PY'
+          import json
+          import subprocess
+          import sys
+          from pathlib import Path
+
+          # Locate the baseline inside the installed omnibase_core package.
+          import omnibase_core.validation.validator_canonical_inference as _m
+
+          baseline = Path(_m.__file__).parent / "baselines" / "canonical_inference_baseline.json"
+          head = json.loads(baseline.read_text())
+          head_repo = {
+              e["fingerprint"]
+              for e in head["violations"]
+              if e["repo"] == "omnibase_infra"
+          }
+          # Compare against the baseline on the PR base branch.
+          base_ref = "origin/${{ github.base_ref || 'dev' }}"
+          try:
+              prior_text = subprocess.check_output(
+                  ["git", "show", f"{base_ref}:{baseline.relative_to(Path.cwd())}"],
+                  text=True,
+              )
+              prior = json.loads(prior_text)
+              prior_repo = {
+                  e["fingerprint"]
+                  for e in prior["violations"]
+                  if e["repo"] == "omnibase_infra"
+              }
+          except (subprocess.CalledProcessError, ValueError):
+              # Baseline file is not present in this consumer repo working tree —
+              # the baseline is owned by omnibase_core, not this repo. There is no
+              # local prior to compare against; the anti-growth assertion is
+              # enforced in omnibase_core's own CI. Nothing grew here by
+              # definition.
+              print(
+                  "CANONICAL-INFERENCE BASELINE OK (consumer): baseline owned by "
+                  f"omnibase_core; omnibase_infra subset has {len(head_repo)} "
+                  "grandfathered fingerprints."
+              )
+              sys.exit(0)
+          grew = head_repo - prior_repo
+          if grew:
+              sys.stderr.write(
+                  "CANONICAL-INFERENCE BASELINE GREW: "
+                  f"{len(grew)} new fingerprint(s) added to the baseline. The "
+                  "baseline is burn-down only — fix the violation or annotate with "
+                  "# canonical-inference-ok:, never grow the baseline.\n"
+              )
+              sys.exit(1)
+          print(
+              "CANONICAL-INFERENCE BASELINE OK: "
+              f"omnibase_infra subset {len(head_repo)} (<= prior {len(prior_repo)})."
+          )
+          PY

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,21 @@ repos:
       # New violations blocked. Drain tracked by OMN-13026 per-site tickets.
       - id: transport-mock-lint
         args: [--baseline, config/validation/transport_mock_baseline.yaml]
+
+  # Canonical Inference Gate (OMN-13249, fleet rollout of OMN-13219).
+  # Rejects NEW non-canonical model-inference surfaces: shelled model CLIs
+  # (codex/claude/gemini/opencode) and *_MODEL/*_PROVIDER env reads. Structural
+  # carve-out: a model-CLI shell-out is permitted iff the enclosing node
+  # contract.yaml declares descriptor.agent_invocation: true (a contract fact,
+  # never a free-text comment). Ratchet: existing violations grandfathered in the
+  # shared baseline at omnibase_core/src/omnibase_core/validation/baselines/canonical_inference_baseline.json;
+  # baseline is burn-down only. Suppression: # canonical-inference-ok: <reason>
+  - repo: https://github.com/OmniNode-ai/omnibase_core
+    rev: 940d2f2ab44d2f455a607926674b90ecbc9b74ba # pragma: allowlist secret
+    hooks:
+      - id: check-canonical-inference
+        args: [--repo, omnibase_infra, --repo-root, .]
+        exclude: ^(tests/|archived/|archive/).*\.py$
   # Hardcoded topic guard — sourced from onex_change_control (OMN-5256/OMN-5259)
   # Pre-existing violations excluded pending migration to canonical constants (OMN-5259)
   # OMN-13195 (phase A4): dropped the redundant `event_bus/topic_constants.py`


### PR DESCRIPTION
## OMN-13249 — canonical-inference fleet wiring (omnibase_infra)

Fleet rollout of the canonical-inference gate (OMN-13219) to **omnibase_infra**, reconciled with the In-Progress **OMN-13249** (Phase C carve-out + fleet rollout). No duplicate ticket created.

### What
- Add the remotely-exposed `check-canonical-inference` pre-commit hook from omnibase_core, pinned to the export commit `940d2f2a` (the hook is exported by core PR #1265, queued to merge to dev).
- Add the required `Canonical Inference Gate` CI workflow (`--repo omnibase_infra`, runs against the frozen shared baseline via `uv run --with omnibase-core@940d2f2a`).


The gate rejects NEW non-canonical model-inference surfaces (shelled codex/claude/gemini/opencode CLIs, `*_MODEL`/`*_PROVIDER` env reads). Existing omnibase_infra violations are grandfathered in the shared baseline (seeded by core#1265); baseline is burn-down only.

### Fail-closed proof (verifier = core@940d2f2a validator; runner ≠ verifier)
```
# clean full-repo scan
$ python -m omnibase_core.validation.validator_canonical_inference --all --repo omnibase_infra --repo-root .
EXIT 0 — CANONICAL-INFERENCE GATE PASSED: 0 new violations (1 grandfathered).
# (cross-repo plant proof captured on omnimarket; same validator + shared baseline.)
```

### Reconciliation (OMN-13249)
Repos now covered by the canonical-inference fleet gate: **omnimarket, omniclaude, omniintelligence, omnibase_infra** (this wave). Remaining toward "all 11 repos": omnibase_core (origin, already enforced), omnibase_spi/omnibase_compat (layer-constrained, no model-CLI surface), omnimemory, onex_change_control, omnidash, omniweb — to be wired as a follow-up wave.

Evidence-Source: OCC#2782
Evidence-Ticket: OMN-13249