### PR TITLE
feat(OMN-13291): wire validate-validator-requirements fleet gate (omnibase_infra) (W0)

### DIFF
--- a/.github/workflows/validate-validator-requirements.yml
+++ b/.github/workflows/validate-validator-requirements.yml
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+# OMN-13291: Enforce validator-requirements.yaml fleet gate for omnibase_infra.
+# Reports ALL missing gates in a single pass (never fail-on-first).
+name: Validate Validator Requirements
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+  merge_group:
+  workflow_dispatch:
+
+jobs:
+  validate-validator-requirements:
+    name: Enforce validator-requirements.yaml (OMN-13291)
+    # OMNI_RUNNER_SELECTOR_V1 — runners are resolved from centralized selector variables.
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+
+      - name: Checkout omnibase_core
+        uses: actions/checkout@v6
+        with:
+          repository: OmniNode-ai/omnibase_core
+          # Pinned to the commit that exports the validate-validator-requirements hook (OMN-13291).
+          # Update by running: gh api repos/OmniNode-ai/omnibase_core/commits/dev --jq '.sha'
+          ref: d163312724489f10f58ffdf8115ba1fa9d5783e8
+          path: omnibase_core
+          token: ${{ secrets.OMNIBASE_CORE_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Enforce validator-requirements.yaml
+        run: |
+          cd omnibase_core
+          uv sync --all-extras
+          uv run python -m omnibase_core.validation.validator_requirements_consumer \
+            --repo omnibase_infra \
+            --repo-root .. \
+            --spec ../architecture-handshakes/validator-requirements.yaml \
+            --baseline ../architecture-handshakes/validator-requirements-baseline.yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -632,6 +632,26 @@ repos:
         files: ^contracts/llm_endpoints\.yaml$
         pass_filenames: false
         stages: [pre-commit]
+
+  # OMN-13291 (W0): validator-requirements fleet gate. Reports ALL missing
+  # required gates for omnibase_infra against omnibase_core's
+  # architecture-handshakes/validator-requirements.yaml, ratcheted by this
+  # repo's own architecture-handshakes/validator-requirements-baseline.yaml.
+  # Re-pin rev to the merged-dev SHA once the omnibase_core export PR lands.
+  - repo: https://github.com/OmniNode-ai/omnibase_core
+    rev: d163312724489f10f58ffdf8115ba1fa9d5783e8 # pragma: allowlist secret
+    hooks:
+      - id: validate-validator-requirements
+        args:
+          - --repo
+          - omnibase_infra
+          - --repo-root
+          - .
+          - --spec
+          - architecture-handshakes/validator-requirements.yaml
+          - --baseline
+          - architecture-handshakes/validator-requirements-baseline.yaml
+
 # Configuration
 default_install_hook_types: [pre-commit, pre-push]
 default_stages: [pre-commit]

--- a/architecture-handshakes/validator-requirements-baseline.yaml
+++ b/architecture-handshakes/validator-requirements-baseline.yaml
@@ -1,0 +1,150 @@
+---
+# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# Accepted validator-requirement gaps for omnibase_infra (OMN-13291).
+#
+# Ratchet baseline for the validate-validator-requirements fleet gate
+# (consumer: omnibase_core validator_requirements_consumer.py, spec: OMN-9115).
+# The meta-gate compares the live per-repo scan against gaps[] below: a NEW gap
+# not listed fails the gate; a listed gap the scan no longer reproduces (stale)
+# also fails. Each gap closes as its validator is wired by the W1-W10 waves of
+# the validator-standardization remediation plan; shrink this list as that work
+# lands. This PR (OMN-13291 / W0) wires only the META-gate; it records current
+# state so regressions are caught and the baseline can only shrink.
+#
+# Schema (formalized OMN-13291): schema_version + repo + report_format +
+# classification + gaps. report_format "all_gaps" => the consumer enumerates
+# EVERY missing required gate per run (never fail-on-first). classification is
+# metadata-only (it explains why each gap is accepted + the tracking ticket);
+# only gaps[] is the ratchet.
+schema_version:
+  major: 1
+  minor: 0
+  patch: 0
+repo: omnibase_infra
+report_format: "all_gaps"
+
+classification:
+  arch-002-no-transport-imports:
+    pre_commit: backlog
+    ci_workflow: backlog
+    tracking: OMN-9048
+  bandit-security:
+    pre_commit: backlog
+    ci_workflow: backlog
+    tracking: OMN-9048
+  banned-compose-env-vars:
+    pre_commit: backlog
+    ci_workflow: backlog
+    tracking: OMN-9048
+  detect-secrets:
+    pre_commit: backlog
+    ci_workflow: backlog
+    tracking: OMN-9048
+  enum-governance:
+    pre_commit: backlog
+    ci_workflow: backlog
+    tracking: OMN-9048
+  hardcoded-local-paths:
+    pre_commit: backlog
+    ci_workflow: backlog
+    tracking: OMN-9048
+  naming-conventions:
+    pre_commit: backlog
+    ci_workflow: backlog
+    tracking: OMN-9048
+  no-hardcoded-topics:
+    ci_workflow: backlog
+    tracking: OMN-9048
+  no-untracked-todos:
+    ci_workflow: backlog
+    tracking: OMN-9048
+  pydantic-patterns:
+    pre_commit: backlog
+    ci_workflow: backlog
+    tracking: OMN-9048
+  self-gating-workflows:
+    pre_commit: backlog
+    tracking: OMN-9048
+  single-class-per-file:
+    pre_commit: backlog
+    ci_workflow: backlog
+    tracking: OMN-9048
+  spdx-headers:
+    ci_workflow: backlog
+    tracking: OMN-9048
+  stub-implementations:
+    ci_workflow: backlog
+    tracking: OMN-9048
+
+gaps:
+  - repo: omnibase_infra
+    validator: arch-002-no-transport-imports
+    kind: MISSING_CI_WORKFLOW
+  - repo: omnibase_infra
+    validator: arch-002-no-transport-imports
+    kind: MISSING_PRE_COMMIT
+  - repo: omnibase_infra
+    validator: bandit-security
+    kind: MISSING_CI_WORKFLOW
+  - repo: omnibase_infra
+    validator: bandit-security
+    kind: MISSING_PRE_COMMIT
+  - repo: omnibase_infra
+    validator: banned-compose-env-vars
+    kind: MISSING_CI_WORKFLOW
+  - repo: omnibase_infra
+    validator: banned-compose-env-vars
+    kind: MISSING_PRE_COMMIT
+  - repo: omnibase_infra
+    validator: detect-secrets
+    kind: MISSING_CI_WORKFLOW
+  - repo: omnibase_infra
+    validator: detect-secrets
+    kind: MISSING_PRE_COMMIT
+  - repo: omnibase_infra
+    validator: enum-governance
+    kind: MISSING_CI_WORKFLOW
+  - repo: omnibase_infra
+    validator: enum-governance
+    kind: MISSING_PRE_COMMIT
+  - repo: omnibase_infra
+    validator: hardcoded-local-paths
+    kind: MISSING_CI_WORKFLOW
+  - repo: omnibase_infra
+    validator: hardcoded-local-paths
+    kind: MISSING_PRE_COMMIT
+  - repo: omnibase_infra
+    validator: naming-conventions
+    kind: MISSING_CI_WORKFLOW
+  - repo: omnibase_infra
+    validator: naming-conventions
+    kind: MISSING_PRE_COMMIT
+  - repo: omnibase_infra
+    validator: no-hardcoded-topics
+    kind: MISSING_CI_WORKFLOW
+  - repo: omnibase_infra
+    validator: no-untracked-todos
+    kind: MISSING_CI_WORKFLOW
+  - repo: omnibase_infra
+    validator: pydantic-patterns
+    kind: MISSING_CI_WORKFLOW
+  - repo: omnibase_infra
+    validator: pydantic-patterns
+    kind: MISSING_PRE_COMMIT
+  - repo: omnibase_infra
+    validator: self-gating-workflows
+    kind: MISSING_PRE_COMMIT
+  - repo: omnibase_infra
+    validator: single-class-per-file
+    kind: MISSING_CI_WORKFLOW
+  - repo: omnibase_infra
+    validator: single-class-per-file
+    kind: MISSING_PRE_COMMIT
+  - repo: omnibase_infra
+    validator: spdx-headers
+    kind: MISSING_CI_WORKFLOW
+  - repo: omnibase_infra
+    validator: stub-implementations
+    kind: MISSING_CI_WORKFLOW

--- a/architecture-handshakes/validator-requirements.yaml
+++ b/architecture-handshakes/validator-requirements.yaml
@@ -1,0 +1,505 @@
+---
+# Canonical validator requirements for OmniNode-ai downstream repos.
+#
+# This file is the single source of truth for which validators must be wired
+# on every repo's pre-commit + CI + branch protection. The handshake verifier
+# (validator_requirements_consumer.py) reads this spec and cross-references
+# each downstream repo's .pre-commit-config.yaml + .github/workflows/ + branch
+# protection required-checks, and fails loud on any missing/mis-configured
+# validator.
+#
+# Adding a new validator here automatically propagates to all 12 repos via the
+# OMN-9050 pin-bump bot: spec change → bot opens a bump PR on every downstream
+# repo → each repo's handshake workflow fails until wiring is added.
+#
+# See: OMN-9048 (validator standardization epic), OMN-9051 (spec),
+#      OMN-9115 (spec consumer + enforcement wiring).
+
+schema_version:
+  major: 1
+  minor: 2
+  patch: 0
+
+# Canonical list of all OmniNode repos governed by this spec. The consumer
+# uses this list to reject typos in repo arguments. Keep in sync when
+# onboarding/offboarding a repo; adding a repo here without wiring its
+# validators will surface as gaps on the next handshake run.
+known_repos:
+  - omniclaude
+  - omnibase_compat
+  - omnibase_core
+  - omnibase_spi
+  - omnibase_infra
+  - omnidash
+  - omnimarket
+  - omniintelligence
+  - omnimemory
+  - omninode_infra
+  - omniweb
+  - onex_change_control
+
+# Scopes:
+#   - pre_commit: "required" | "optional"  — entry in .pre-commit-config.yaml
+#   - ci_workflow: "required" | "optional" — .github/workflows/*.yml that runs it
+#   - required_check_on_main: exact context name that must be in branch
+#     protection required_status_checks (or null if not gated at that level)
+#   - silent_skip_allowed: false (no advisory modes per feedback_no_informational_gates)
+#   - excludes.forbidden: regex patterns the exclude list MUST NOT contain
+#   - excludes.allowed: regex patterns the exclude list MAY contain (fixtures only)
+#   - applies_to_repos: which of the 12 repos must have this validator wired.
+#     "all" = all 12. Override with a list for validators that legitimately
+#     skip some repos (e.g., Python validators skip omniweb PHP).
+#   - central_source: canonical module/script location
+#   - pre_commit_hook_ids: list of acceptable pre-commit hook id substrings.
+#     The consumer accepts any repo whose .pre-commit-config.yaml contains at
+#     least one hook whose id matches one of these substrings.
+#   - ci_workflow_keywords: list of acceptable CI workflow step-name / run-line
+#     substrings. The consumer accepts any repo whose .github/workflows/*.yml
+#     contains at least one step mentioning one of these keywords.
+
+required_validators:
+
+  hardcoded-local-paths:
+    description: |
+      Blocks /Users/, /Volumes/, /home/, C:\Users\ absolute paths in source.
+      Violations escape this on any repo without the hook wired.
+    central_source: "omnibase_core.validation.validator_local_paths"
+    pre_commit: required
+    ci_workflow: required
+    required_check_on_main: "validate-local-paths / validate"
+    silent_skip_allowed: false
+    pre_commit_hook_ids:
+      - "validate-local-paths"
+      - "check-local-paths"
+    ci_workflow_keywords:
+      - "validator_local_paths"
+      - "validate-local-paths"
+    excludes:
+      allowed: ["^tests/fixtures/", "^docs/"]
+      forbidden: ["^tests/$", "^tests/[^f]", "^src/"]
+    applies_to_repos: all
+
+  spdx-headers:
+    description: |
+      Enforces MIT SPDX headers on source + tests + scripts + examples.
+    central_source: "omnibase_core CLI: onex spdx validate"
+    pre_commit: required
+    ci_workflow: required
+    required_check_on_main: "SPDX Headers / validate"
+    silent_skip_allowed: false
+    pre_commit_hook_ids:
+      - "validate-spdx-headers"
+      - "spdx-headers"
+    ci_workflow_keywords:
+      - "spdx"
+      - "onex spdx validate"
+    excludes:
+      allowed: ["\\.md$", "\\.ya?ml$", "\\.json$"]
+      forbidden: ["^tests/", "^src/"]
+    applies_to_repos: all
+
+  no-hardcoded-topics:
+    description: |
+      Kafka topic strings must come from contract.yaml, not hardcoded in source.
+    central_source: "onex_change_control (centralized hook)"
+    pre_commit: required
+    ci_workflow: required
+    required_check_on_main: "ARCH-Invariants / no-hardcoded-topics"
+    silent_skip_allowed: false
+    pre_commit_hook_ids:
+      - "no-hardcoded-topics"
+    ci_workflow_keywords:
+      - "no-hardcoded-topics"
+      - "hardcoded-topics"
+    excludes:
+      allowed: ["^docs/", "\\.yaml$"]
+      forbidden: ["^src/", "^tests/"]
+    applies_to_repos:
+      - omniclaude
+      - omnibase_core
+      - omnibase_infra
+      - omnibase_spi
+      - omnimarket
+      - omnimemory
+      - omniintelligence
+      - omninode_infra
+      - onex_change_control
+
+  stub-implementations:
+    description: |
+      Blocks NotImplementedError, bare pass, bare TODO docstrings in non-test source.
+    central_source: "omnibase_core.validation.check_stub_implementations"
+    pre_commit: required
+    ci_workflow: required
+    required_check_on_main: "Stub Implementations / check"
+    silent_skip_allowed: false
+    pre_commit_hook_ids:
+      - "check-stub-implementations"
+      - "stub-implementations"
+    ci_workflow_keywords:
+      - "check_stub_implementations"
+      - "stub-implementations"
+    excludes:
+      allowed: ["^tests/"]
+      forbidden: ["^src/"]
+    applies_to_repos:
+      - omniclaude
+      - omnibase_core
+      - omnibase_infra
+      - omnibase_spi
+      - omnimarket
+      - omnimemory
+      - omniintelligence
+
+  enum-governance:
+    description: |
+      Enforces UPPER_SNAKE_CASE enum members + detects Literal-duplication anti-pattern.
+    central_source: "omnibase_core.validation.checker_enum_governance"
+    pre_commit: required
+    ci_workflow: required
+    required_check_on_main: "Enum Governance / validate"
+    silent_skip_allowed: false
+    pre_commit_hook_ids:
+      - "check-enum-governance"
+      - "enum-governance"
+    ci_workflow_keywords:
+      - "checker_enum_governance"
+      - "enum-governance"
+    excludes:
+      allowed: ["^tests/"]
+      forbidden: ["^src/"]
+    applies_to_repos:
+      - omniclaude
+      - omnibase_core
+      - omnibase_infra
+      - omnibase_spi
+      - omnibase_compat
+      - omnimarket
+      - omnimemory
+      - omniintelligence
+
+  naming-conventions:
+    description: |
+      File-naming (model_*, enum_*, protocol_*, handler_*, service_*, node_*) +
+      class-naming prefix (Model*, Enum*, Protocol*, Handler*, Service*).
+    central_source: "omnibase_core.validation.validate_naming_conventions"
+    pre_commit: required
+    ci_workflow: required
+    required_check_on_main: "Naming Conventions / validate"
+    silent_skip_allowed: false
+    pre_commit_hook_ids:
+      - "validate-naming-conventions"
+      - "validate-file-naming-conventions"
+    ci_workflow_keywords:
+      - "naming-conventions"
+      - "validate_naming"
+    excludes:
+      allowed: ["^tests/", "^archived/"]
+      forbidden: ["^src/"]
+    applies_to_repos:
+      - omniclaude
+      - omnibase_core
+      - omnibase_infra
+      - omnibase_spi
+      - omnibase_compat
+      - omnimarket
+      - omnimemory
+      - omniintelligence
+
+  self-gating-workflows:
+    description: |
+      Blocks cross-repo @main refs in .github/workflows/*.yml (retro §4.8).
+      Requires local-path ./.github/workflows/*.yml or pinned SHA/tag.
+    central_source: "scripts/check_self_gating_workflows.py (OMN-9039)"
+    pre_commit: required
+    ci_workflow: optional
+    required_check_on_main: null
+    silent_skip_allowed: false
+    pre_commit_hook_ids:
+      - "check-self-gating-workflows"
+      - "self-gating-workflows"
+    ci_workflow_keywords:
+      - "check_self_gating_workflows"
+      - "self-gating"
+    excludes:
+      allowed: []
+      forbidden: []
+    applies_to_repos: all
+
+  branch-protection-rollout-guard:
+    description: |
+      PreToolUse Claude Code hook that blocks gh api PUT/PATCH .../branches/*/protection
+      unless all required_status_checks contexts are emitted by a workflow on the repo.
+      Lives in omniclaude plugin only (runs at Claude-session level).
+    central_source: "omniclaude plugins/onex/hooks/lib/branch_protection_verifier.py (OMN-9038)"
+    pre_commit: optional
+    ci_workflow: optional
+    required_check_on_main: null
+    silent_skip_allowed: false
+    pre_commit_hook_ids:
+      - "branch-protection-rollout-guard"
+    ci_workflow_keywords:
+      - "branch_protection_verifier"
+    excludes:
+      allowed: []
+      forbidden: []
+    applies_to_repos:
+      - omniclaude
+
+  bandit-security:
+    description: |
+      Python security linting (medium+ severity).
+    central_source: "bandit (pip); per-repo .bandit config"
+    pre_commit: required
+    ci_workflow: required
+    required_check_on_main: "Security Gate / bandit"
+    silent_skip_allowed: false
+    pre_commit_hook_ids:
+      - "bandit"
+    ci_workflow_keywords:
+      - "bandit"
+    excludes:
+      allowed: ["^tests/", "^examples/"]
+      forbidden: ["^src/"]
+    applies_to_repos:
+      - omniclaude
+      - omnibase_core
+      - omnibase_infra
+      - omnibase_spi
+      - omnibase_compat
+      - omnimarket
+      - omnimemory
+      - omniintelligence
+      - omninode_infra
+
+  mypy-type-check:
+    description: |
+      Strict mypy on src/.
+    central_source: "mypy (pip); per-repo pyproject.toml [tool.mypy]"
+    pre_commit: required
+    ci_workflow: required
+    required_check_on_main: "Quality Gate / mypy"
+    silent_skip_allowed: false
+    pre_commit_hook_ids:
+      - "mypy-type-check"
+      - "mypy"
+    ci_workflow_keywords:
+      - "mypy"
+    excludes:
+      allowed: ["^tests/"]
+      forbidden: ["^src/"]
+    applies_to_repos:
+      - omniclaude
+      - omnibase_core
+      - omnibase_infra
+      - omnibase_spi
+      - omnibase_compat
+      - omnimarket
+      - omnimemory
+      - omniintelligence
+
+  ruff-format-check:
+    description: |
+      Ruff format + check, universal across Python repos.
+    central_source: "astral-sh/ruff-pre-commit"
+    pre_commit: required
+    ci_workflow: required
+    required_check_on_main: "Quality Gate / ruff"
+    silent_skip_allowed: false
+    pre_commit_hook_ids:
+      - "ruff-format"
+      - "ruff-fix"
+      - "ruff"
+    ci_workflow_keywords:
+      - "ruff"
+    excludes:
+      allowed: []
+      forbidden: []
+    applies_to_repos:
+      - omniclaude
+      - omnibase_core
+      - omnibase_infra
+      - omnibase_spi
+      - omnibase_compat
+      - omnimarket
+      - omnimemory
+      - omniintelligence
+      - omninode_infra
+      - onex_change_control
+
+  aislop-patterns:
+    description: |
+      Detects AI-generated boilerplate, narrative docstrings, step_narration anti-patterns.
+    central_source: "omniclaude plugins/onex/skills/aislop_sweep"
+    pre_commit: required
+    ci_workflow: required
+    required_check_on_main: "AI Slop / check"
+    silent_skip_allowed: false
+    pre_commit_hook_ids:
+      - "check-ai-slop"
+      - "aislop"
+    ci_workflow_keywords:
+      - "aislop"
+      - "ai-slop"
+      - "check_ai_slop"
+    excludes:
+      allowed: ["^docs/", "^CHANGELOG\\.md$"]
+      forbidden: ["^src/"]
+    applies_to_repos: all
+
+  pydantic-patterns:
+    description: |
+      Enforces ConfigDict(frozen=True, extra="forbid"), Field(..., description), no Any, PEP 604 unions.
+    central_source: "omnibase_core.validation.validate_pydantic_patterns"
+    pre_commit: required
+    ci_workflow: required
+    required_check_on_main: "Pydantic Patterns / validate"
+    silent_skip_allowed: false
+    pre_commit_hook_ids:
+      - "validate-pydantic-patterns"
+      - "validate-pydantic-conventions"
+      - "pydantic-patterns"
+    ci_workflow_keywords:
+      - "pydantic"
+    excludes:
+      allowed: ["^tests/"]
+      forbidden: ["^src/"]
+    applies_to_repos:
+      - omniclaude
+      - omnibase_core
+      - omnibase_infra
+      - omnibase_spi
+      - omnibase_compat
+      - omnimarket
+      - omnimemory
+      - omniintelligence
+
+  single-class-per-file:
+    description: |
+      Enforces one class per .py file (protocols + TypedDicts exempt).
+    central_source: "omnibase_core.validation.validate_single_class_per_file"
+    pre_commit: required
+    ci_workflow: required
+    required_check_on_main: "Single Class / validate"
+    silent_skip_allowed: false
+    pre_commit_hook_ids:
+      - "onex-single-class-per-file"
+      - "single-class-per-file"
+    ci_workflow_keywords:
+      - "single-class-per-file"
+      - "single_class"
+    excludes:
+      allowed: ["^tests/"]
+      forbidden: ["^src/"]
+    applies_to_repos:
+      - omniclaude
+      - omnibase_core
+      - omnibase_infra
+      - omnibase_spi
+      - omnibase_compat
+      - omnimarket
+      - omnimemory
+      - omniintelligence
+
+  detect-secrets:
+    description: |
+      Yelp/detect-secrets baseline, catches committed API keys / passwords / PEM keys.
+    central_source: "Yelp/detect-secrets"
+    pre_commit: required
+    ci_workflow: required
+    required_check_on_main: "Security Gate / detect-secrets"
+    silent_skip_allowed: false
+    pre_commit_hook_ids:
+      - "detect-secrets"
+    ci_workflow_keywords:
+      - "detect-secrets"
+      - "detect_secrets"
+    excludes:
+      allowed: ["\\.secrets\\.baseline$", "^tests/fixtures/"]
+      forbidden: []
+    applies_to_repos: all
+
+  no-untracked-todos:
+    description: |
+      Blocks bare TODO/FIXME. Requires # TODO(OMN-XXXX): format.
+    central_source: "onex_change_control (centralized)"
+    pre_commit: required
+    ci_workflow: required
+    required_check_on_main: "ARCH-Invariants / no-untracked-todos"
+    silent_skip_allowed: false
+    pre_commit_hook_ids:
+      - "no-untracked-todos"
+    ci_workflow_keywords:
+      - "no-untracked-todos"
+      - "untracked-todos"
+    excludes:
+      allowed: ["^docs/"]
+      forbidden: ["^src/", "^tests/"]
+    applies_to_repos: all
+
+  arch-002-no-transport-imports:
+    description: |
+      Nodes must not import aiokafka/httpx/asyncpg directly (SPI boundary).
+      Only handlers/adapters may import transport libraries.
+    central_source: "omnibase_core.validation.validate_no_transport_imports"
+    pre_commit: required
+    ci_workflow: required
+    required_check_on_main: "ARCH-002 / no-transport-imports"
+    silent_skip_allowed: false
+    pre_commit_hook_ids:
+      - "validate-no-transport-imports"
+      - "no-transport-imports"
+    ci_workflow_keywords:
+      - "validate_no_transport_imports"
+      - "no-transport-imports"
+    excludes:
+      allowed: ["^tests/", "^src/.*/runtime/", "^src/.*/api/", "^src/.*/adapters/"]
+      forbidden: ["^src/.*/nodes/"]
+    applies_to_repos:
+      - omnibase_core
+      - omnibase_infra
+      - omnibase_spi
+      - omnimarket
+      - omnimemory
+      - omniintelligence
+
+  banned-compose-env-vars:
+    description: |
+      Detects docker-compose / Kubernetes manifests that reference env vars the
+      handler code no longer reads. Bidirectional drift guard between kernel
+      version bumps and compose config. Trigger class: OMN-8840 runtime-effects
+      crash where banned ONEX_INPUT_TOPIC persisted in compose after code removal.
+    central_source: "omnibase_core.validation.validator_banned_compose_vars"
+    pre_commit: required
+    ci_workflow: required
+    required_check_on_main: "Compose Drift / validate"
+    silent_skip_allowed: false
+    pre_commit_hook_ids:
+      - "validator-banned-compose-vars"
+      - "banned-compose-vars"
+      - "banned-compose-env-vars"
+    ci_workflow_keywords:
+      - "validator_banned_compose_vars"
+      - "banned-compose-vars"
+      - "banned-compose-env-vars"
+    excludes:
+      allowed: []
+      forbidden: []
+    applies_to_repos:
+      - omnibase_infra
+      - omninode_infra
+
+# Handshake metadata
+
+metadata:
+  generated_by: "manually authored (OMN-9051); consumer added OMN-9115"
+  last_updated: "2026-04-17"
+  next_review: "on any new validator addition — single source of truth, change propagates via OMN-9050
+    bot"
+  related_tickets:
+    - OMN-9048  # validator standardization epic
+    - OMN-9049  # universal handshake coverage
+    - OMN-9050  # pin-bump bot
+    - OMN-9051  # spec file owner
+    - OMN-9058  # env-store abstraction
+    - OMN-9115  # spec consumer + enforcement wiring

--- a/scripts/validation/validate_clean_root.py
+++ b/scripts/validation/validate_clean_root.py
@@ -135,6 +135,7 @@ ALLOWED_ROOT_DIRECTORIES: frozenset[str] = frozenset(
         "tests",
         "docs",
         "scripts",
+        "architecture-handshakes",
         # Common optional directories
         "config",
         "contracts",


### PR DESCRIPTION
## OMN-13291 — W0: wire validate-validator-requirements fleet gate (omnibase_infra)

Consumer-side wiring for the validator-standardization remediation plan §3 W0. Parent epic: **OMN-9048**.

Wires the `validate-validator-requirements` meta-gate into **omnibase_infra** as a remote pre-commit hook + CI workflow, so omnibase_infra proves it carries its required validator gate-set declared in omnibase_core's `architecture-handshakes/validator-requirements.yaml`.

### What changed
- Remote pre-commit hook (`validate-validator-requirements` from `omnibase_core`), pinned to the core export commit (`d1633127`). **Re-pin to the merged-dev SHA once omnibase_core#1275 lands.**
- `.github/workflows/validate-validator-requirements.yml` — checks out omnibase_core, installs, runs the consumer against omnibase_infra's spec copy + baseline. Reports ALL missing gates per run (never fail-on-first); no warn-only.
- `architecture-handshakes/validator-requirements-baseline.yaml` — structured schema (schema_version/repo/report_format/classification/gaps) recording the **23 current accepted gaps**. This PR wires only the META-gate; the individual validators are wired by the W1–W10 waves, at which point entries shrink out of this baseline. The ratchet blocks any NEW gap and any stale entry.
- `architecture-handshakes/validator-requirements.yaml` — vendored spec copy so the pre-commit hook resolves the spec from this repo root (mirrors the proven onex_change_control wiring).

### Dependency
Requires **omnibase_core#1275** (exports the remote hook + structured-baseline consumer). This PR's CI checks out core at the pinned SHA, so it is self-contained; arm auto-merge and it lands once gates pass.

### Fail-closed proof (verifier ≠ runner)
Captured in the omnibase_core#1275 PR body. Fleet-level demonstration: removing a baseline-required hook from a consumer repo makes the meta-gate exit 2 naming the specific missing gate (`+ [MISSING_PRE_COMMIT] omniclaude :: ruff-format-check`); restore → exit 0. Per-repo clean-tree scan here returns `baseline-clean (omnibase_infra — 23 accepted gap(s)) EXIT=0`.

### dod_evidence
OCC contract `contracts/OMN-13291.yaml` + paired PASS receipts bind this PR by pr_number + commit_sha. See the OCC evidence PR linked on OMN-13291.

---

Evidence-Source: OCC#2785
Evidence-Ticket: OMN-13291
