### PR TITLE
fix(OMN-13247): resolve coding-agent subprocess HOME to contract cred-home

### DIFF
--- a/docker/catalog/services/runtime-effects.yaml
+++ b/docker/catalog/services/runtime-effects.yaml
@@ -34,6 +34,15 @@ hardcoded_env:
   KEYCLOAK_ADMIN_URL: http://keycloak:8080
   OTEL_SERVICE_NAME: omninode-runtime-effects
   RUNTIME_PROFILE: effects
+  # OMN-13247 (Phase B dev-verify fix): credential HOME for the spawned
+  # claude/codex subprocess (node_coding_agent_invoke_effect). The dev runtime
+  # container runs as root (HOME=/root) while the OAuth creds are bind-mounted at
+  # /home/omniinfra/.codex and /home/omniinfra/.claude (volumes below). claude and
+  # codex read AMBIENT auth from $HOME, so the effect overrides the child env with
+  # HOME=$CODING_AGENT_CRED_HOME (and CODEX_HOME=$CODING_AGENT_CRED_HOME/.codex)
+  # rather than letting them look in /root and fail auth. Container-internal path
+  # that must match the credential bind-mount target -> hardcoded_env, not a secret.
+  CODING_AGENT_CRED_HOME: /home/omniinfra
   ONEX_RUNTIME_CAPABILITIES: ${DEV_RUNTIME_EFFECTS_CAPABILITIES:?runtime policy contract must set DEV_RUNTIME_EFFECTS_CAPABILITIES}
   OMNIBASE_INFRA_SAVINGS_KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
   POSTGRES_HOST: postgres

--- a/src/omnibase_infra/models/coding_agent/__init__.py
+++ b/src/omnibase_infra/models/coding_agent/__init__.py
@@ -54,6 +54,9 @@ from omnibase_infra.models.coding_agent.model_coding_agent_result import (
 from omnibase_infra.models.coding_agent.model_coding_agent_trace_projection import (
     ModelCodingAgentTraceProjection,
 )
+from omnibase_infra.models.coding_agent.model_subprocess_invocation import (
+    ModelSubprocessInvocation,
+)
 from omnibase_infra.models.coding_agent.model_subprocess_outcome import (
     ModelSubprocessOutcome,
 )
@@ -80,6 +83,7 @@ __all__: list[str] = [
     "ModelCodingAgentResult",
     "ModelCodingAgentTraceProjection",
     "ModelAgentInvocation",
+    "ModelSubprocessInvocation",
     "ModelSubprocessOutcome",
     "ModelWorkspaceValidateCommand",
     "ModelWorkspaceValidateResult",

--- a/src/omnibase_infra/models/coding_agent/model_subprocess_invocation.py
+++ b/src/omnibase_infra/models/coding_agent/model_subprocess_invocation.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Coding-agent subprocess invocation seam model.
+
+Bundles the inputs of one subprocess run (argv, cwd, timeout, network posture,
+optional piped stdin, and the EXPLICIT child env) into a single seam object so the
+``SubprocessRunner`` seam takes one parameter. The explicit ``env`` carries
+``HOME`` overridden to the contract-resolved credential home so the spawned
+claude/codex subprocess finds its ambient OAuth creds even when the runtime runs
+as root (OMN-13247 Phase B dev-verify fix).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+
+class ModelSubprocessInvocation:
+    """Plain inputs for one subprocess run, accepted by the subprocess seam."""
+
+    __slots__ = ("argv", "cwd", "env", "network", "stdin", "timeout_s")
+
+    def __init__(
+        self,
+        *,
+        argv: list[str],
+        cwd: str,
+        timeout_s: int,
+        network: bool,
+        stdin: str | None,
+        env: Mapping[str, str],
+    ) -> None:
+        self.argv = argv
+        self.cwd = cwd
+        self.timeout_s = timeout_s
+        self.network = network
+        self.stdin = stdin
+        self.env = env
+
+
+__all__ = ["ModelSubprocessInvocation"]

--- a/src/omnibase_infra/nodes/node_coding_agent_invoke_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_coding_agent_invoke_effect/contract.yaml
@@ -63,6 +63,16 @@ descriptor:
   timeout_ms: 1800000
   # The contract distinction the OMN-13219 gate reads. ONLY this node declares it.
   agent_invocation: true
+  # Credential HOME for the spawned claude/codex subprocess (OMN-13247 Phase B
+  # dev-verify fix). The dev runtime container runs as root (HOME=/root) while the
+  # OAuth creds are bind-mounted at /home/omniinfra/.codex and
+  # /home/omniinfra/.claude (runtime-effects.yaml, OMN-13248). claude/codex read
+  # AMBIENT auth from $HOME, so without overriding HOME for the child process the
+  # CLIs look in /root and fail auth. This descriptor is resolved from the
+  # ${env.VAR} overlay convention (no hardcoded /home/omniinfra in source) and the
+  # handler exports it as HOME (and CODEX_HOME) on the subprocess env. Fails closed:
+  # the handler raises if this resolves empty rather than silently inherit /root.
+  agent_credential_home: "${env.CODING_AGENT_CRED_HOME}"
 runtime_profiles:
   - effects
 terminal_event: onex.evt.omnibase-infra.coding-agent-invoke-completed.v1

--- a/src/omnibase_infra/nodes/node_coding_agent_invoke_effect/contract_descriptor.py
+++ b/src/omnibase_infra/nodes/node_coding_agent_invoke_effect/contract_descriptor.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Read contract-declared descriptor values for the coding-agent invoke effect.
+
+The invoke effect's ``descriptor.agent_credential_home`` is the single source of
+truth for the HOME the spawned claude/codex subprocess must use to find its
+ambient OAuth credentials (OMN-13247 Phase B dev-verify fix). It is declared with
+the ``${env.VAR}`` overlay convention so an operator overlay / the service env
+sets the real path per lane — never a hardcoded ``/home/omniinfra`` in source.
+
+The handler resolves it fail-closed: an unset/empty value raises rather than
+letting the child inherit the runtime container's ``HOME`` (``/root`` under the
+dev runtime, which has no bind-mounted creds).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from omnibase_infra.runtime.overlay.contract_env_ref import expand_contract_env_refs
+
+
+def _load_contract(contract_path: Path) -> dict[str, object]:
+    # ONEX_EXCLUDE: io_audit - Module-level contract load keeps handler policy contract-owned
+    with contract_path.open(encoding="utf-8") as contract_file:
+        raw = yaml.safe_load(contract_file)
+    if not isinstance(raw, dict):
+        raise ValueError(f"contract {contract_path} must contain a mapping")
+    return raw
+
+
+def contract_agent_credential_home(contract_path: Path) -> str:
+    """Return the resolved ``descriptor.agent_credential_home`` for the contract.
+
+    The value is contract-declared (overridable by an operator overlay contract)
+    via the ``${env.VAR}`` convention — never hardcoded in source. Fails closed:
+    raises ``ValueError`` when the field is absent or resolves to an empty string,
+    so the spawned subprocess never silently inherits the runtime container's HOME
+    (``/root`` under the dev runtime, where no creds are bind-mounted).
+    """
+    raw = _load_contract(contract_path)
+    descriptor = raw.get("descriptor")
+    if not isinstance(descriptor, dict):
+        raise ValueError(
+            f"contract {contract_path} must declare a descriptor mapping with "
+            "agent_credential_home"
+        )
+    declared = descriptor.get("agent_credential_home")
+    if not isinstance(declared, str):
+        raise ValueError(
+            f"contract {contract_path} must declare a string "
+            "descriptor.agent_credential_home (the ${env.CODING_AGENT_CRED_HOME} "
+            "overlay value the subprocess uses as HOME)"
+        )
+    resolved = expand_contract_env_refs(declared).strip()
+    if not resolved:
+        raise ValueError(
+            "descriptor.agent_credential_home resolved empty — set "
+            "CODING_AGENT_CRED_HOME (the credential-home path the claude/codex "
+            "subprocess uses as HOME). The coding-agent invoke effect fails closed "
+            "rather than let the child inherit the runtime container's HOME (/root "
+            "under the dev runtime has no bind-mounted creds)."
+        )
+    return resolved
+
+
+__all__: list[str] = ["contract_agent_credential_home"]

--- a/src/omnibase_infra/nodes/node_coding_agent_invoke_effect/handlers/handler_coding_agent_invoke.py
+++ b/src/omnibase_infra/nodes/node_coding_agent_invoke_effect/handlers/handler_coding_agent_invoke.py
@@ -31,6 +31,7 @@ import signal
 import subprocess
 import time
 from collections.abc import Callable, Mapping
+from pathlib import Path
 from typing import TypeVar
 from uuid import uuid4
 
@@ -52,13 +53,24 @@ from omnibase_infra.models.coding_agent.model_coding_agent_invoke_command import
 from omnibase_infra.models.coding_agent.model_coding_agent_result import (
     ModelCodingAgentResult,
 )
+from omnibase_infra.models.coding_agent.model_subprocess_invocation import (
+    ModelSubprocessInvocation,
+)
 from omnibase_infra.models.coding_agent.model_subprocess_outcome import (
     ModelSubprocessOutcome,
+)
+from omnibase_infra.nodes.node_coding_agent_invoke_effect.contract_descriptor import (
+    contract_agent_credential_home,
 )
 
 logger = logging.getLogger(__name__)
 
 HANDLER_ID = "coding-agent-invoke-effect"
+
+# The contract that declares descriptor.agent_credential_home (the ${env.…}
+# overlay value the spawned subprocess uses as HOME). The descriptor is the single
+# source of truth; the handler never hardcodes a credential-home path.
+_CONTRACT = Path(__file__).resolve().parent.parent / "contract.yaml"
 
 # Dispatch payloads are coerced at runtime; the protocol entry is generic over the
 # envelope payload type (ProtocolMessageHandler.handle(ModelEventEnvelope[T])).
@@ -72,12 +84,12 @@ _CLI_BINARY_BY_AGENT: dict[EnumCodingAgent, str] = {
 }
 
 
-# Seam types: the EFFECT's I/O is injected so tests mock it. The signature carries
-# the optional stdin so the live runner pipes the prompt to claude --add-dir
-# correctly (OMN-13246) while remaining trivial to mock.
-SubprocessRunner = Callable[
-    [list[str], str, int, bool, str | None], ModelSubprocessOutcome
-]
+# Seam types: the EFFECT's I/O is injected so tests mock it. The runner takes a
+# single ModelSubprocessInvocation bundling argv, cwd, timeout, network posture,
+# the optional piped stdin (claude --add-dir pipes the prompt via stdin —
+# OMN-13246), and the explicit child ``env`` whose HOME is the contract-resolved
+# credential home (OMN-13247 Phase B dev-verify fix) — trivial to mock.
+SubprocessRunner = Callable[[ModelSubprocessInvocation], ModelSubprocessOutcome]
 GitProbe = Callable[[str], str | None]
 GitDiffCapture = Callable[[str], tuple[tuple[str, ...], str]]
 
@@ -178,6 +190,7 @@ class HandlerCodingAgentInvoke:
         probe_head_sha: GitProbe | None = None,
         capture_diff: GitDiffCapture | None = None,
         which: Callable[[str], str | None] | None = None,
+        agent_credential_home: str | None = None,
     ) -> None:
         # Live process-group runner + git probes are the defaults (the argv
         # mapping is finalized from Phase 0 / OMN-13246). Tests inject mocks for
@@ -192,6 +205,12 @@ class HandlerCodingAgentInvoke:
             capture_diff if capture_diff is not None else _git_capture_diff
         )
         self._which = which if which is not None else _default_which
+        # The credential HOME for the spawned subprocess. Resolved from the
+        # contract descriptor (${env.CODING_AGENT_CRED_HOME}) by default; an
+        # explicit override lets tests pin it without touching the environment.
+        # Resolution is deferred to invoke-time (fail-closed there) so constructing
+        # the handler never requires CODING_AGENT_CRED_HOME to be set.
+        self._agent_credential_home = agent_credential_home
 
     def invoke(self, command: ModelCodingAgentInvokeCommand) -> ModelCodingAgentResult:
         """Run one coding-agent invocation; return the system-derived result."""
@@ -210,6 +229,19 @@ class HandlerCodingAgentInvoke:
                 f"{binary} not found on PATH",
             )
 
+        # Resolve the credential HOME and build the explicit child env BEFORE
+        # spawning. Fail-closed: an unset CODING_AGENT_CRED_HOME raises (surfaced
+        # as UNAVAILABLE) rather than letting the child inherit the runtime
+        # container's HOME (/root under the dev runtime — no creds there).
+        try:
+            child_env = self._build_subprocess_env(command.agent)
+        except ValueError as exc:
+            return self._failed(
+                command,
+                EnumCliBackendStatus.UNAVAILABLE,
+                str(exc),
+            )
+
         starting_head_sha = self._probe_head_sha(command.workspace_path)
 
         invocation = build_agent_invocation(command)
@@ -219,12 +251,17 @@ class HandlerCodingAgentInvoke:
         # The runner spawns in its own process group; on timeout it kills the
         # whole group and returns timed_out=True (no orphaned subprocess). The
         # prompt is piped via stdin for claude write mode (--add-dir is greedy).
+        # The explicit child env carries HOME=<contract cred home> so claude/codex
+        # find their ambient OAuth creds even when the runtime runs as root.
         outcome = self._run_subprocess(
-            invocation.argv,
-            command.workspace_path,
-            timeout_s,
-            command.network,
-            invocation.stdin,
+            ModelSubprocessInvocation(
+                argv=invocation.argv,
+                cwd=command.workspace_path,
+                timeout_s=timeout_s,
+                network=command.network,
+                stdin=invocation.stdin,
+                env=child_env,
+            )
         )
         duration_ms = (time.monotonic() - start) * 1000
 
@@ -279,6 +316,35 @@ class HandlerCodingAgentInvoke:
             output=content,
         )
 
+    def _resolve_credential_home(self) -> str:
+        """Resolve the credential HOME (override > contract descriptor).
+
+        Fails closed via ``contract_agent_credential_home`` when the descriptor
+        resolves empty (``CODING_AGENT_CRED_HOME`` unset), so the subprocess never
+        silently inherits ``/root``.
+        """
+        if self._agent_credential_home is not None:
+            return self._agent_credential_home
+        return contract_agent_credential_home(_CONTRACT)
+
+    def _build_subprocess_env(self, agent: EnumCodingAgent) -> dict[str, str]:
+        """Build the explicit child env for the spawned claude/codex subprocess.
+
+        Copies the parent ``os.environ`` and overrides ``HOME`` with the
+        contract-resolved credential home so the CLI reads its ambient OAuth creds
+        from ``<cred_home>/.claude`` / ``<cred_home>/.codex`` instead of the
+        runtime container's ``HOME`` (``/root`` under the dev runtime, where no
+        creds are bind-mounted). For codex, ``CODEX_HOME`` is set to
+        ``<cred_home>/.codex`` so it does not depend on codex's own ``$HOME``
+        derivation. No API-key / endpoint env is added — auth stays ambient.
+        """
+        cred_home = self._resolve_credential_home()
+        env = dict(os.environ)
+        env["HOME"] = cred_home
+        if agent is EnumCodingAgent.CODEX:
+            env["CODEX_HOME"] = str(Path(cred_home) / ".codex")
+        return env
+
     def _failed(
         self,
         command: ModelCodingAgentInvokeCommand,
@@ -332,13 +398,9 @@ def _default_which(binary: str) -> str | None:
 
 
 def _run_subprocess_pgroup(
-    argv: list[str],
-    cwd: str,
-    timeout_s: int,
-    network: bool,
-    stdin: str | None,
+    invocation: ModelSubprocessInvocation,
 ) -> ModelSubprocessOutcome:
-    """Run ``argv`` in ``cwd`` in its OWN process group; timeout kills the group.
+    """Run ``invocation`` in its OWN process group; timeout kills the group.
 
     ``start_new_session=True`` puts the child in a fresh session + process group,
     so a runaway agent that forks children is reaped as a unit: on timeout (or
@@ -346,22 +408,30 @@ def _run_subprocess_pgroup(
     subprocess survives (plan §5.5). The prompt is piped via stdin when provided
     (claude WORKSPACE_WRITE; ``--add-dir`` is greedy on positionals — OMN-13246).
 
-    ``network`` is threaded for parity with the seam contract; network isolation
-    is enforced by the container/namespace boundary (Phase B), not by this
-    in-process runner, so it does not branch on the flag here.
+    ``invocation.env`` is the EXPLICIT child environment (a copy of the parent env
+    with ``HOME`` — and ``CODEX_HOME`` for codex — overridden to the
+    contract-resolved credential home) so claude/codex find their ambient OAuth
+    creds even when the runtime runs as root (OMN-13247 Phase B dev-verify fix).
+    It is passed verbatim to ``Popen(env=...)``; the child never inherits the
+    parent env implicitly.
+
+    ``invocation.network`` is carried for parity with the seam contract; network
+    isolation is enforced by the container/namespace boundary (Phase B), not by
+    this in-process runner, so it does not branch on the flag here.
     """
-    del network  # isolation is a container-boundary concern (Phase B), not here.
+    stdin = invocation.stdin
     process = subprocess.Popen(
-        argv,
-        cwd=cwd,
+        invocation.argv,
+        cwd=invocation.cwd,
         stdin=subprocess.PIPE if stdin is not None else subprocess.DEVNULL,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
         start_new_session=True,
+        env=dict(invocation.env),
     )
     try:
-        stdout, stderr = process.communicate(input=stdin, timeout=timeout_s)
+        stdout, stderr = process.communicate(input=stdin, timeout=invocation.timeout_s)
         return ModelSubprocessOutcome(
             returncode=process.returncode,
             stdout=stdout or "",
@@ -466,6 +536,7 @@ __all__: list[str] = [
     "GitProbe",
     "HandlerCodingAgentInvoke",
     "ModelAgentInvocation",
+    "ModelSubprocessInvocation",
     "ModelSubprocessOutcome",
     "SubprocessRunner",
     "build_agent_invocation",

--- a/src/omnibase_infra/runtime/overlay/contract_env_ref.py
+++ b/src/omnibase_infra/runtime/overlay/contract_env_ref.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Shared ``${env.VAR}`` overlay expansion for contract string values.
+
+This is the sanctioned overlay-resolution surface for the ``${env.VAR}`` /
+``${env.VAR:default}`` convention that contract descriptors use to bind a
+lane-specific value (a workspace root, a credential home, a contracts dir) from
+the operator environment WITHOUT hardcoding the value in source. It lives in the
+overlay package — the one module family allowed to read ``os.environ`` — so node
+contract helpers (e.g. node_coding_agent_invoke_effect's contract_descriptor) call
+through here instead of each duplicating an env read.
+
+An unset var with no default expands to the empty string so the caller's
+fail-closed check rejects it (rather than leaving a literal placeholder).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+# ``${env.VAR}`` / ``${env.VAR:default}`` — the same env-overlay convention
+# node_contract_loader_effect uses for paths.
+_ENV_REF = re.compile(
+    r"\$\{env\.(?P<name>[A-Za-z_][A-Za-z0-9_]*)(?::(?P<default>[^}]*))?\}"
+)
+
+
+def expand_contract_env_refs(value: str) -> str:
+    """Expand ``${env.VAR}`` / ``${env.VAR:default}`` references in ``value``.
+
+    Resolves each reference from the operator environment; an unset var with no
+    inline default expands to the empty string (so the caller fails closed rather
+    than passing a literal ``${env.…}`` placeholder downstream).
+    """
+
+    def _sub(match: re.Match[str]) -> str:
+        name = match.group("name")
+        default = match.group("default")
+        return os.environ.get(name, default if default is not None else "")
+
+    return _ENV_REF.sub(_sub, value)
+
+
+__all__: list[str] = ["expand_contract_env_refs"]

--- a/tests/unit/nodes/node_coding_agent/test_golden_chain_coding_agent.py
+++ b/tests/unit/nodes/node_coding_agent/test_golden_chain_coding_agent.py
@@ -57,6 +57,7 @@ from omnibase_infra.nodes.node_coding_agent_fsm_reducer.models.model_coding_agen
     ModelCodingAgentFsmAdvance,
 )
 from omnibase_infra.nodes.node_coding_agent_invoke_effect.handlers.handler_coding_agent_invoke import (
+    ModelSubprocessInvocation,
     ModelSubprocessOutcome,
 )
 
@@ -134,26 +135,21 @@ def _fsm_state(
 
 
 class _SpySubprocess:
-    """Mock for the invoke effect's run_subprocess seam; records calls.
+    """Mock for the invoke effect's run_subprocess seam; records invocations.
 
-    The seam signature carries the optional stdin (claude WORKSPACE_WRITE pipes
-    the prompt via stdin — OMN-13246), so the spy records it too. No real
-    claude/codex subprocess ever runs under test.
+    The seam takes one ModelSubprocessInvocation bundling argv, cwd, timeout,
+    network posture, the optional stdin (claude WORKSPACE_WRITE pipes the prompt
+    via stdin — OMN-13246), and the explicit child env (HOME overridden to the
+    contract-resolved credential home — OMN-13247 Phase B). No real claude/codex
+    subprocess ever runs under test.
     """
 
     def __init__(self, outcome: ModelSubprocessOutcome) -> None:
         self._outcome = outcome
-        self.calls: list[tuple[list[str], str, int, bool, str | None]] = []
+        self.calls: list[ModelSubprocessInvocation] = []
 
-    def __call__(
-        self,
-        argv: list[str],
-        cwd: str,
-        timeout_s: int,
-        network: bool,
-        stdin: str | None,
-    ) -> ModelSubprocessOutcome:
-        self.calls.append((argv, cwd, timeout_s, network, stdin))
+    def __call__(self, invocation: ModelSubprocessInvocation) -> ModelSubprocessOutcome:
+        self.calls.append(invocation)
         return self._outcome
 
 
@@ -492,6 +488,12 @@ class TestFsmReducerDispatch:
 # ---------------------------------------------------------------------------
 
 
+# A pinned credential home for the effect tests so they never depend on the
+# CODING_AGENT_CRED_HOME env var being set (the contract resolves it via
+# ${env.CODING_AGENT_CRED_HOME}; an explicit override pins it deterministically).
+_CRED_HOME = "/home/omniinfra"
+
+
 @pytest.mark.unit
 class TestInvokeEffectDispatch:
     async def test_invoke_completed_with_git_diff(self, tmp_path: Path) -> None:
@@ -505,6 +507,7 @@ class TestInvokeEffectDispatch:
             probe_head_sha=lambda _cwd: "abc1234",
             capture_diff=lambda _cwd: (("foo.py",), "diff --git a/foo.py b/foo.py"),
             which=lambda _b: "/usr/bin/claude",
+            agent_credential_home=_CRED_HOME,
         )
         command = _invoke_command(workspace_path=str(tmp_path))
         envelope: ModelEventEnvelope[ModelCodingAgentInvokeCommand] = (
@@ -521,11 +524,100 @@ class TestInvokeEffectDispatch:
         assert result.starting_head_sha == "abc1234"
         assert len(spy.calls) == 1
 
+    async def test_subprocess_env_carries_resolved_cred_home(
+        self, tmp_path: Path
+    ) -> None:
+        """The spawned subprocess env sets HOME=<resolved cred home> (OMN-13247).
+
+        The root-HOME cred-resolution fix: claude/codex read ambient OAuth creds
+        from $HOME, and the dev runtime runs as root (HOME=/root) while the creds
+        are bind-mounted under the contract-resolved credential home. The handler
+        must hand the runner an explicit env with HOME overridden to that home —
+        asserted here against the mocked runner so no real CLI runs.
+        """
+        spy = _SpySubprocess(
+            ModelSubprocessOutcome(
+                returncode=0, stdout="done", stderr="", timed_out=False
+            )
+        )
+        handler = HandlerCodingAgentInvoke(
+            run_subprocess=spy,
+            probe_head_sha=lambda _cwd: "abc1234",
+            capture_diff=lambda _cwd: ((), ""),
+            which=lambda _b: "/usr/bin/claude",
+            agent_credential_home=_CRED_HOME,
+        )
+        result = handler.invoke(_invoke_command(workspace_path=str(tmp_path)))
+        assert result.status == EnumAgentStatus.COMPLETED
+        assert len(spy.calls) == 1
+        env = spy.calls[0].env
+        assert env["HOME"] == _CRED_HOME
+
+    async def test_codex_subprocess_env_sets_codex_home(self, tmp_path: Path) -> None:
+        """For codex, the env also sets CODEX_HOME=<cred home>/.codex (OMN-13247).
+
+        codex derives its credential dir from CODEX_HOME; pinning it alongside HOME
+        keeps auth resolution independent of codex's own $HOME derivation.
+        """
+        spy = _SpySubprocess(
+            ModelSubprocessOutcome(
+                returncode=0, stdout="done", stderr="", timed_out=False
+            )
+        )
+        handler = HandlerCodingAgentInvoke(
+            run_subprocess=spy,
+            probe_head_sha=lambda _cwd: "abc1234",
+            capture_diff=lambda _cwd: ((), ""),
+            which=lambda _b: "/usr/bin/codex",
+            agent_credential_home=_CRED_HOME,
+        )
+        command = ModelCodingAgentInvokeCommand(
+            correlation_id=uuid4(),
+            agent=EnumCodingAgent.CODEX,
+            prompt="add a docstring to foo.py",
+            workspace_path=str(tmp_path),
+            sandbox=EnumAgentSandbox.READ_ONLY,
+            timeout_ms=60000,
+        )
+        result = handler.invoke(command)
+        assert result.status == EnumAgentStatus.COMPLETED
+        env = spy.calls[0].env
+        assert env["HOME"] == _CRED_HOME
+        assert env["CODEX_HOME"] == f"{_CRED_HOME}/.codex"
+
+    def test_unavailable_when_cred_home_unset(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Fail-closed: no override + unset CODING_AGENT_CRED_HOME -> UNAVAILABLE.
+
+        The handler refuses to spawn (and never silently inherits the runtime
+        container's /root HOME) when the credential home is unresolvable.
+        """
+        monkeypatch.delenv("CODING_AGENT_CRED_HOME", raising=False)
+        spy = _SpySubprocess(
+            ModelSubprocessOutcome(returncode=0, stdout="x", stderr="", timed_out=False)
+        )
+        # No agent_credential_home override: resolution falls to the contract,
+        # whose ${env.CODING_AGENT_CRED_HOME} now resolves empty -> fail closed.
+        handler = HandlerCodingAgentInvoke(
+            run_subprocess=spy,
+            which=lambda _b: "/usr/bin/claude",
+        )
+        result = handler.invoke(_invoke_command(workspace_path=str(tmp_path)))
+        assert result.status == EnumAgentStatus.FAILED
+        assert result.error_class == EnumCliBackendStatus.UNAVAILABLE
+        # No subprocess attempted when the credential home is unresolvable.
+        assert spy.calls == []
+
     def test_unavailable_when_binary_missing(self, tmp_path: Path) -> None:
         spy = _SpySubprocess(
             ModelSubprocessOutcome(returncode=0, stdout="x", stderr="", timed_out=False)
         )
-        handler = HandlerCodingAgentInvoke(run_subprocess=spy, which=lambda _b: None)
+        handler = HandlerCodingAgentInvoke(
+            run_subprocess=spy,
+            which=lambda _b: None,
+            agent_credential_home=_CRED_HOME,
+        )
         result = handler.invoke(_invoke_command(workspace_path=str(tmp_path)))
         assert result.status == EnumAgentStatus.FAILED
         assert result.error_class == EnumCliBackendStatus.UNAVAILABLE
@@ -541,6 +633,7 @@ class TestInvokeEffectDispatch:
             probe_head_sha=lambda _cwd: None,
             capture_diff=lambda _cwd: ((), ""),
             which=lambda _b: "/usr/bin/claude",
+            agent_credential_home=_CRED_HOME,
         )
         result = handler.invoke(_invoke_command(workspace_path=str(tmp_path)))
         assert result.error_class == EnumCliBackendStatus.TIMEOUT
@@ -557,6 +650,7 @@ class TestInvokeEffectDispatch:
             probe_head_sha=lambda _cwd: None,
             capture_diff=lambda _cwd: ((), ""),
             which=lambda _b: "/usr/bin/claude",
+            agent_credential_home=_CRED_HOME,
         )
         result = handler.invoke(_invoke_command(workspace_path=str(tmp_path)))
         assert result.error_class == EnumCliBackendStatus.SUBPROCESS_ERROR
@@ -573,6 +667,7 @@ class TestInvokeEffectDispatch:
             probe_head_sha=lambda _cwd: None,
             capture_diff=lambda _cwd: ((), ""),
             which=lambda _b: "/usr/bin/claude",
+            agent_credential_home=_CRED_HOME,
         )
         result = handler.invoke(_invoke_command(workspace_path=str(tmp_path)))
         assert result.error_class == EnumCliBackendStatus.EMPTY_RESPONSE

--- a/tests/unit/nodes/node_coding_agent/test_subprocess_runner_and_git_probes.py
+++ b/tests/unit/nodes/node_coding_agent/test_subprocess_runner_and_git_probes.py
@@ -12,12 +12,17 @@ edits + untracked files), never parsed from stdout.
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
+from collections.abc import Mapping
 from pathlib import Path
 
 import pytest
 
+from omnibase_infra.models.coding_agent.model_subprocess_invocation import (
+    ModelSubprocessInvocation,
+)
 from omnibase_infra.nodes.node_coding_agent_invoke_effect.handlers.handler_coding_agent_invoke import (
     _git_capture_diff,
     _git_head_sha,
@@ -28,6 +33,28 @@ pytestmark = pytest.mark.unit
 
 _HAS_GIT = shutil.which("git") is not None
 _HAS_SH = shutil.which("sh") is not None
+
+# The explicit child env the runner now requires (a copy of the parent env). The
+# real handler overrides HOME with the contract-resolved credential home; these
+# runner-level tests pass the inherited env unchanged (no agent binary is run).
+_ENV = dict(os.environ)
+
+
+def _invocation(
+    argv: list[str],
+    cwd: str,
+    timeout_s: int,
+    stdin: str | None = None,
+    env: Mapping[str, str] | None = None,
+) -> ModelSubprocessInvocation:
+    return ModelSubprocessInvocation(
+        argv=argv,
+        cwd=cwd,
+        timeout_s=timeout_s,
+        network=False,
+        stdin=stdin,
+        env=env if env is not None else _ENV,
+    )
 
 
 def _git_init(repo: Path) -> None:
@@ -40,7 +67,7 @@ def _git_init(repo: Path) -> None:
 class TestProcessGroupRunner:
     def test_runner_captures_stdout_and_exit(self, tmp_path: Path) -> None:
         outcome = _run_subprocess_pgroup(
-            ["sh", "-c", "printf done"], str(tmp_path), 10, False, None
+            _invocation(["sh", "-c", "printf done"], str(tmp_path), 10)
         )
         assert outcome.returncode == 0
         assert outcome.stdout == "done"
@@ -49,14 +76,14 @@ class TestProcessGroupRunner:
     def test_runner_pipes_stdin(self, tmp_path: Path) -> None:
         # Proves the prompt-via-stdin path the claude write mode relies on.
         outcome = _run_subprocess_pgroup(
-            ["cat"], str(tmp_path), 10, False, "piped-prompt"
+            _invocation(["cat"], str(tmp_path), 10, stdin="piped-prompt")
         )
         assert outcome.returncode == 0
         assert outcome.stdout == "piped-prompt"
 
     def test_runner_nonzero_exit(self, tmp_path: Path) -> None:
         outcome = _run_subprocess_pgroup(
-            ["sh", "-c", "exit 3"], str(tmp_path), 10, False, None
+            _invocation(["sh", "-c", "exit 3"], str(tmp_path), 10)
         )
         assert outcome.returncode == 3
         assert outcome.timed_out is False
@@ -66,9 +93,24 @@ class TestProcessGroupRunner:
         # whole process group is killed (SIGTERM->SIGKILL). The call returns
         # promptly with timed_out=True rather than hanging the full sleep.
         outcome = _run_subprocess_pgroup(
-            ["sh", "-c", "sleep 30 & sleep 30"], str(tmp_path), 1, False, None
+            _invocation(["sh", "-c", "sleep 30 & sleep 30"], str(tmp_path), 1)
         )
         assert outcome.timed_out is True
+
+    def test_runner_uses_explicit_env_home(self, tmp_path: Path) -> None:
+        # The runner passes the explicit env verbatim to the child: the subprocess
+        # sees HOME=<cred home>, NOT the parent process's HOME. This is the
+        # root-HOME cred-resolution fix (OMN-13247 Phase B): the child reads its
+        # ambient OAuth creds from <cred home> even when the runtime runs as root.
+        cred_home = str(tmp_path / "creds")
+        child_env = {**os.environ, "HOME": cred_home}
+        outcome = _run_subprocess_pgroup(
+            _invocation(
+                ["sh", "-c", 'printf %s "$HOME"'], str(tmp_path), 10, env=child_env
+            )
+        )
+        assert outcome.returncode == 0
+        assert outcome.stdout == cred_home
 
 
 @pytest.mark.skipif(not _HAS_GIT, reason="requires git")


### PR DESCRIPTION
## OMN-13247 — Resolve coding-agent subprocess HOME to the contract credential-home

### Problem (root-HOME cred-resolution gap, found in Phase B dev verify)
Phase A (#2031) is merged to dev. During Phase B dev verify, the coding-agent invoke
effect (`node_coding_agent_invoke_effect`) failed auth when run under the dev runtime.
Cause: the dev runtime container runs as **root** with `HOME=/root`, while the
claude/codex OAuth creds are bind-mounted at `/home/omniinfra/.codex` and
`/home/omniinfra/.claude` (`runtime-effects.yaml`, OMN-13248). The handler's `Popen`
passed **no `env=`**, so the spawned `claude`/`codex` subprocess inherited
`HOME=/root`, found no ambient credentials, and failed authentication.

### Fix
- **Contract descriptor (overlay-resolved, fail-closed):** add
  `descriptor.agent_credential_home: "${env.CODING_AGENT_CRED_HOME}"` to the invoke
  effect `contract.yaml`. No hardcoded `/home/omniinfra` in source — the value is
  resolved from the operator/overlay env. Resolution **fails closed**: an unset
  `CODING_AGENT_CRED_HOME` raises rather than silently inheriting `/root`.
- **Handler:** resolve the cred home (`contract_descriptor.py`, reusing a shared
  `${env.…}` overlay expander at `runtime/overlay/contract_env_ref.py`), build an
  **explicit child env** (copy `os.environ`, override `HOME`, and set `CODEX_HOME`
  for codex), and pass it to the subprocess. Unresolvable cred home →
  `UNAVAILABLE` (no subprocess spawned).
- **Service env default:** `CODING_AGENT_CRED_HOME=/home/omniinfra` added to
  `runtime-effects.yaml` `hardcoded_env` (container-internal path that must match the
  credential bind-mount target — not an operator secret).
- **Seam tidy-up:** the runner args are bundled into `ModelSubprocessInvocation`
  (single seam parameter).

### Tests (runner mocked — no real claude/codex executed)
- `test_subprocess_env_carries_resolved_cred_home` — asserts the spawned subprocess
  env includes `HOME=<resolved cred home>`.
- `test_codex_subprocess_env_sets_codex_home` — asserts codex also gets
  `CODEX_HOME=<cred home>/.codex`.
- `test_unavailable_when_cred_home_unset` — fail-closed: no override + unset
  `CODING_AGENT_CRED_HOME` → `UNAVAILABLE`, no subprocess attempted.
- `test_runner_uses_explicit_env_home` — the live process-group runner passes the
  explicit env verbatim to the child (`$HOME` in the child == the cred home).
- All pre-existing coding-agent tests stay green (43 passed).

### Gates
- `uv run ruff check` / `ruff format` — clean.
- `uv run mypy --strict` on changed source — clean.
- `pre-commit` hooks pass on the staged files (incl. `check-env-reads` — the env read
  routes through the sanctioned overlay module — and `onex-validate-patterns`).

### dod_evidence
- Behavior proof: `test_subprocess_env_carries_resolved_cred_home` asserts the
  subprocess env is `HOME=<resolved cred home>` against the mocked runner; the codex
  variant additionally asserts `CODEX_HOME`. Fail-closed proven by
  `test_unavailable_when_cred_home_unset`.
- No real claude/codex is executed in tests (runner injected/mocked).

Refs OMN-13247 (Phase A #2031 merged; this is the Phase B dev-verify env fix),
OMN-13248 (credential bind-mount).


---
Evidence-Source: OCC#2796
Evidence-Ticket: OMN-13247
