### PR TITLE
fix(OMN-13247): rename per-handler input_model->event_model so coding-agent nodes auto-wire

### DIFF
--- a/docker/catalog/services/runtime-effects.yaml
+++ b/docker/catalog/services/runtime-effects.yaml
@@ -43,6 +43,15 @@ hardcoded_env:
   # rather than letting them look in /root and fail auth. Container-internal path
   # that must match the credential bind-mount target -> hardcoded_env, not a secret.
   CODING_AGENT_CRED_HOME: /home/omniinfra
+  # OMN-13247 (epic OMN-13245): the coding-agent ORCHESTRATOR resolves its
+  # contract descriptor.allowed_workspace_roots from
+  # ${env.ONEX_CODING_AGENT_WORKSPACE_ROOT} and FAILS CLOSED if it resolves empty
+  # (no unscoped workspace is ever permitted). The agent EFFECT confines every
+  # workspace_path under this root. Container-internal path that must match the
+  # agent-workspaces dir the runtime writes into -> hardcoded_env, not a secret.
+  # Patched live on dev for the e2e proof; committed here so the lane is
+  # reproducible from the catalog.
+  ONEX_CODING_AGENT_WORKSPACE_ROOT: /home/omniinfra/agent-workspaces
   ONEX_RUNTIME_CAPABILITIES: ${DEV_RUNTIME_EFFECTS_CAPABILITIES:?runtime policy contract must set DEV_RUNTIME_EFFECTS_CAPABILITIES}
   OMNIBASE_INFRA_SAVINGS_KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
   POSTGRES_HOST: postgres

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -826,6 +826,21 @@ services:
       ONEX_SECRET_RESOLVER_CONFIG_JSON: ${DEV_RUNTIME_EFFECTS_SECRET_RESOLVER_CONFIG_JSON:?runtime policy contract must set DEV_RUNTIME_EFFECTS_SECRET_RESOLVER_CONFIG_JSON}
       ONEX_GROUP_ID: ${ONEX_EFFECTS_GROUP_ID:-onex-runtime-effects}
       KAFKA_INSTANCE_ID: runtime-effects
+      # OMN-13247 (epic OMN-13245): coding-agent runtime env. These are
+      # effects-only (the four coding-agent nodes run in runtime_profiles:
+      # [effects]) so they live on this service, not the shared x-runtime-env
+      # anchor. Both are container-internal paths (never secrets); they were
+      # patched live on dev for the e2e proof and are committed here so the lane
+      # is reproducible.
+      #   - CODING_AGENT_CRED_HOME: claude/codex read AMBIENT OAuth from $HOME, but
+      #     the runtime container runs as root (HOME=/root) while the creds are
+      #     bind-mounted under /home/omniinfra; the invoke EFFECT overrides the
+      #     child env with HOME=$CODING_AGENT_CRED_HOME (CODEX_HOME=$.../.codex).
+      #   - ONEX_CODING_AGENT_WORKSPACE_ROOT: the orchestrator resolves its
+      #     contract descriptor.allowed_workspace_roots from ${env.…} and FAILS
+      #     CLOSED if unset (no unscoped workspace is ever permitted).
+      CODING_AGENT_CRED_HOME: /home/omniinfra
+      ONEX_CODING_AGENT_WORKSPACE_ROOT: /home/omniinfra/agent-workspaces
       # OMN-7569: Savings estimation consumer config (env_prefix=OMNIBASE_INFRA_SAVINGS_)
       OMNIBASE_INFRA_SAVINGS_KAFKA_BOOTSTRAP_SERVERS: "redpanda:9092"
       # OMN-7569: HandlerRegistrationStoragePostgres reads POSTGRES_HOST directly from env

--- a/src/omnibase_infra/nodes/node_coding_agent_fsm_reducer/contract.yaml
+++ b/src/omnibase_infra/nodes/node_coding_agent_fsm_reducer/contract.yaml
@@ -23,7 +23,7 @@ handler_routing:
         name: HandlerCodingAgentFsm
         module: omnibase_infra.nodes.node_coding_agent_fsm_reducer.handlers.handler_coding_agent_fsm
       description: "Fold one workflow event into the FSM state + trace projection."
-      input_model:
+      event_model:
         name: ModelCodingAgentFsmAdvance
         module: omnibase_infra.nodes.node_coding_agent_fsm_reducer.models.model_coding_agent_fsm_advance
         description: "Prior FSM state + event to fold."

--- a/src/omnibase_infra/nodes/node_coding_agent_invoke_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_coding_agent_invoke_effect/contract.yaml
@@ -44,7 +44,7 @@ handler_routing:
         name: HandlerCodingAgentInvoke
         module: omnibase_infra.nodes.node_coding_agent_invoke_effect.handlers.handler_coding_agent_invoke
       description: "Run the coding-agent CLI subprocess + capture git diff."
-      input_model:
+      event_model:
         name: ModelCodingAgentInvokeCommand
         module: omnibase_infra.models.coding_agent
         description: "One coding-agent invocation request."

--- a/src/omnibase_infra/nodes/node_coding_agent_orchestrator/contract.yaml
+++ b/src/omnibase_infra/nodes/node_coding_agent_orchestrator/contract.yaml
@@ -21,7 +21,7 @@ handler_routing:
         name: HandlerCodingAgentOrchestrator
         module: omnibase_infra.nodes.node_coding_agent_orchestrator.handlers.handler_coding_agent_orchestrator
       description: "Route a coding-agent lifecycle event to the next bus command."
-      input_model:
+      event_model:
         name: ModelCodingAgentInvokeCommand
         module: omnibase_infra.models.coding_agent
         description: "The invoke-requested command (workflow entrypoint)."

--- a/src/omnibase_infra/nodes/node_coding_agent_workspace_compute/contract.yaml
+++ b/src/omnibase_infra/nodes/node_coding_agent_workspace_compute/contract.yaml
@@ -21,7 +21,7 @@ handler_routing:
         name: HandlerWorkspaceValidate
         module: omnibase_infra.nodes.node_coding_agent_workspace_compute.handlers.handler_workspace_validate
       description: "Pure workspace pre-flight validation."
-      input_model:
+      event_model:
         name: ModelWorkspaceValidateCommand
         module: omnibase_infra.models.coding_agent
         description: "Workspace policy inputs to validate."

--- a/tests/unit/nodes/node_coding_agent/test_real_dispatch_event_model_wiring.py
+++ b/tests/unit/nodes/node_coding_agent/test_real_dispatch_event_model_wiring.py
@@ -1,0 +1,226 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Real-dispatch-path regression for the coding-agent event_model wiring (OMN-13247).
+
+The e2e proof surfaced a wiring bug the handler-isolation suite could not see:
+the four coding-agent node contracts declared their PER-HANDLER model under the
+YAML key ``input_model:`` (inside ``handler_routing.handlers[]``), but the
+auto-wiring parser (``discovery.py::_parse_handler_routing``) reads ONLY the
+per-handler key ``event_model:``. With ``event_model`` parsed as ``None`` the
+auto-wired dispatch callback (``handler_wiring._make_dispatch_callback``) hands
+the handler the RAW materialized dispatch dict instead of re-hydrating it into a
+typed ``ModelEventEnvelope`` — and the dispatch engine ALWAYS materializes the
+envelope to a dict before calling the dispatcher
+(``message_dispatch_engine._execute_dispatcher`` -> ``envelope_for_handler:
+dict``). The orchestrator's ``handle`` then does ``envelope.event_type`` on a
+dict and crashes, so the workflow never advances past hop 1.
+
+This test drives the REAL dispatch surface end to end:
+
+  1. the orchestrator contract is parsed by the SAME parser the runtime uses
+     (``_parse_handler_routing``), so a contract carrying the wrong per-handler
+     key yields ``event_model=None`` and this test fails;
+  2. the auto-wired dispatch callback + payload-type matcher are built exactly
+     as ``handler_wiring`` builds them in production
+     (``_make_dispatch_callback`` / ``_make_payload_type_matcher``);
+  3. the callback is registered on a real ``MessageDispatchEngine`` and a
+     ``ModelEventEnvelope`` carrying ``ModelCodingAgentInvokeCommand`` is
+     dispatched through ``engine.dispatch`` — the engine materializes the
+     envelope to a dict and the callback must re-hydrate it via ``event_model``.
+
+It asserts (a) the orchestrator handler receives a typed ``ModelEventEnvelope``
+(NOT a dict) and (b) the workflow advances past hop 1 by emitting the
+workspace-validate command. It MUST fail on the pre-fix contract (per-handler
+``input_model:`` -> ``event_model`` absent -> raw dict -> crash) and pass after
+the rename to ``event_model:``. No real claude/codex subprocess is ever run.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+from uuid import uuid4
+
+import pytest
+import yaml
+
+from omnibase_core.enums import EnumMessageCategory
+from omnibase_core.models.dispatch.model_handler_output import ModelHandlerOutput
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_infra.enums.enum_dispatch_status import EnumDispatchStatus
+from omnibase_infra.models.coding_agent import (
+    EnumAgentSandbox,
+    EnumCodingAgent,
+    ModelCodingAgentInvokeCommand,
+)
+from omnibase_infra.models.dispatch.model_dispatch_route import ModelDispatchRoute
+from omnibase_infra.nodes.node_coding_agent_orchestrator.handlers.handler_coding_agent_orchestrator import (
+    HandlerCodingAgentOrchestrator,
+)
+from omnibase_infra.runtime.auto_wiring.discovery import _parse_handler_routing
+from omnibase_infra.runtime.auto_wiring.handler_wiring import (
+    ProtocolHandleable,
+    _make_dispatch_callback,
+    _make_payload_type_matcher,
+)
+from omnibase_infra.runtime.auto_wiring.models.model_handler_routing_entry import (
+    ModelHandlerRoutingEntry,
+)
+from omnibase_infra.runtime.message_dispatch_engine import MessageDispatchEngine
+
+_NODES_ROOT = Path(__file__).resolve().parents[4] / "src" / "omnibase_infra" / "nodes"
+_ORCH_CONTRACT = _NODES_ROOT / "node_coding_agent_orchestrator" / "contract.yaml"
+
+# The orchestrator's contract-declared workflow entrypoint + hop-1 output topic.
+_INVOKE_TOPIC = "onex.cmd.omnibase-infra.coding-agent-invoke.v1"
+_WORKSPACE_VALIDATE_SUFFIX = "coding-agent-workspace-validate.v1"
+
+
+def _orchestrator_entry() -> ModelHandlerRoutingEntry:
+    """Parse the live orchestrator contract via the production parser.
+
+    Returns the single ``handler_routing.handlers[]`` entry. ``entry.event_model``
+    is the value the runtime feeds into ``_make_dispatch_callback``; it is
+    ``None`` whenever the contract carries the wrong per-handler key.
+    """
+    raw = yaml.safe_load(_ORCH_CONTRACT.read_text(encoding="utf-8"))
+    routing = _parse_handler_routing(raw["handler_routing"])
+    assert len(routing.handlers) == 1, "orchestrator contract has one handler entry"
+    return routing.handlers[0]
+
+
+def _invoke_command(workspace_path: str) -> ModelCodingAgentInvokeCommand:
+    return ModelCodingAgentInvokeCommand(
+        correlation_id=uuid4(),
+        agent=EnumCodingAgent.CLAUDE,
+        prompt="add a docstring to foo.py",
+        workspace_path=workspace_path,
+        sandbox=EnumAgentSandbox.READ_ONLY,
+        timeout_ms=60000,
+    )
+
+
+@pytest.mark.unit
+class TestContractParsesEventModel:
+    """The per-handler model must be visible to the auto-wiring parser."""
+
+    def test_parser_reads_per_handler_event_model(self) -> None:
+        """The orchestrator contract entry exposes a non-None ``event_model``.
+
+        This is the load-bearing assertion: the parser reads ONLY
+        ``handler_routing.handlers[].event_model``, so a contract declaring the
+        model under ``input_model:`` parses to ``event_model=None`` and fails
+        here. (Pre-fix the four coding-agent contracts all used ``input_model:``.)
+        """
+        entry = _orchestrator_entry()
+        assert entry.event_model is not None, (
+            "orchestrator handler entry must declare a per-handler 'event_model:' "
+            "so the dispatch callback re-hydrates the typed envelope; found None "
+            "(contract likely still uses the per-handler 'input_model:' key the "
+            "parser ignores)"
+        )
+        assert entry.event_model.name == "ModelCodingAgentInvokeCommand"
+        assert entry.event_model.module == "omnibase_infra.models.coding_agent"
+
+
+@pytest.mark.unit
+class TestRealDispatchRehydratesTypedEnvelope:
+    """Drive the actual dispatch engine + auto-wired callback, not handler.handle()."""
+
+    @pytest.mark.asyncio
+    async def test_invoke_command_dispatch_advances_to_workspace_validate(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A dispatched invoke command re-hydrates to a typed envelope + emits hop 1.
+
+        The dispatch engine ALWAYS materializes the envelope to a dict before
+        calling the dispatcher, so the callback built from the contract's
+        ``event_model`` is the only thing that turns that dict back into a typed
+        ``ModelEventEnvelope`` the orchestrator can read. Without it the handler
+        receives a dict and crashes on ``envelope.event_type``; with it the
+        workflow advances past hop 1 by emitting the workspace-validate command.
+        """
+        # The orchestrator's allowed roots are contract-declared via ${env.…} and
+        # it fails closed if empty, so the lane env var must resolve to a real root.
+        monkeypatch.setenv("ONEX_CODING_AGENT_WORKSPACE_ROOT", str(tmp_path))
+
+        entry = _orchestrator_entry()
+        seen_envelopes: list[object] = []
+
+        class _RecordingOrchestrator(HandlerCodingAgentOrchestrator):
+            """Records the runtime-supplied envelope to prove re-hydration."""
+
+            async def handle(
+                self, envelope: ModelEventEnvelope[object]
+            ) -> ModelHandlerOutput[None]:
+                seen_envelopes.append(envelope)
+                return await super().handle(envelope)
+
+        # cast: the orchestrator's handle() returns ModelHandlerOutput, which the
+        # dispatch callback normalizes — the same shape the runtime wires in prod.
+        callback = _make_dispatch_callback(
+            cast("ProtocolHandleable", _RecordingOrchestrator()), entry.event_model
+        )
+        payload_type_matcher = (
+            _make_payload_type_matcher(entry.event_model)
+            if entry.event_model is not None
+            else None
+        )
+
+        engine = MessageDispatchEngine()
+        # The engine derives ``message_type`` from the envelope ``event_type``
+        # (the topic alias) and falls back to the payload class name when no
+        # event_type is set, so the dispatcher must accept both the topic alias
+        # and the model name — the same set the contract wiring registers.
+        engine.register_dispatcher(
+            dispatcher_id="coding-agent-orchestrator",
+            dispatcher=callback,
+            category=EnumMessageCategory.COMMAND,
+            message_types={_INVOKE_TOPIC, "ModelCodingAgentInvokeCommand"},
+            payload_type_matcher=payload_type_matcher,
+        )
+        engine.register_route(
+            ModelDispatchRoute(
+                route_id="route.coding-agent-orchestrator",
+                topic_pattern="*.cmd.omnibase-infra.coding-agent-invoke.*",
+                message_category=EnumMessageCategory.COMMAND,
+                dispatcher_id="coding-agent-orchestrator",
+            )
+        )
+        engine.freeze()
+
+        command = _invoke_command(workspace_path=str(tmp_path))
+        envelope: ModelEventEnvelope[object] = ModelEventEnvelope(
+            payload=command,
+            correlation_id=command.correlation_id,
+            event_type=_INVOKE_TOPIC,
+        )
+
+        result = await engine.dispatch(topic=_INVOKE_TOPIC, envelope=envelope)
+
+        # The dispatch must succeed (no AttributeError on a dict 'envelope').
+        assert result.status == EnumDispatchStatus.SUCCESS, result.error_message
+
+        # The handler received a TYPED envelope, not the materialized dict — this
+        # is exactly what the event_model re-hydration restores.
+        assert len(seen_envelopes) == 1
+        received = seen_envelopes[0]
+        assert isinstance(received, ModelEventEnvelope), (
+            "orchestrator handler must receive a typed ModelEventEnvelope; got "
+            f"{type(received).__name__} (a 'dict' means event_model wiring is broken)"
+        )
+        # ...carrying the re-hydrated typed payload and the workflow event_type.
+        assert isinstance(received.payload, ModelCodingAgentInvokeCommand)
+        assert received.event_type == _INVOKE_TOPIC
+
+        # Hop 1: the workflow advanced and emitted the workspace-validate command.
+        emitted_types = [
+            getattr(event, "event_type", None) for event in result.output_events
+        ]
+        assert any(
+            isinstance(t, str) and t.endswith(_WORKSPACE_VALIDATE_SUFFIX)
+            for t in emitted_types
+        ), (
+            "orchestrator must advance past hop 1 by emitting the workspace-validate "
+            f"command; output event types were {emitted_types}"
+        )


### PR DESCRIPTION
## OMN-13247 (epic OMN-13245) — coding-agent bus wiring fix: per-handler event_model

### Problem (e2e-discovered wiring bug)
The live coding-agent e2e proof crashed at hop 1 with `AttributeError: 'dict' object has no attribute 'event_type'`. Root cause: the four coding-agent node contracts declared their PER-HANDLER model under the YAML key `input_model:` (inside `handler_routing.handlers[]`), but the auto-wiring parser (`runtime/auto_wiring/discovery.py::_parse_handler_routing`) reads ONLY the per-handler key `event_model:`.

With `event_model=None`, the auto-wired dispatch callback (`handler_wiring._make_dispatch_callback`) takes the no-event-model branch and hands the handler the **materialized dispatch dict** instead of re-hydrating it into a typed `ModelEventEnvelope`. The dispatch engine ALWAYS materializes the envelope to a dict before calling the dispatcher (`message_dispatch_engine._execute_dispatcher` → `envelope_for_handler: dict`), so the orchestrator's `handle` then does `envelope.event_type` on a dict and crashes — the workflow never advances past hop 1.

Working orchestrators (`node_chain_orchestrator`, `node_routing_orchestrator`) already use per-handler `event_model:`.

### Fix (align contracts to the convention; parser unchanged)
Rename the PER-HANDLER `input_model:` → `event_model:` (same value) in all four contracts:
- `node_coding_agent_orchestrator`
- `node_coding_agent_workspace_compute`
- `node_coding_agent_invoke_effect`
- `node_coding_agent_fsm_reducer`

The node-level top-level `input_model:`/`output_model:` are correct and unchanged. No parser change and no alias was added.

### Regression test (TDD, REAL dispatch path)
`tests/unit/nodes/node_coding_agent/test_real_dispatch_event_model_wiring.py` drives the actual dispatch surface — not `handler.handle()` in isolation:
1. parses the live orchestrator contract via the production parser `_parse_handler_routing`;
2. builds the production callback + matcher via `_make_dispatch_callback` / `_make_payload_type_matcher`;
3. registers it on a real `MessageDispatchEngine` and dispatches a `ModelCodingAgentInvokeCommand` envelope — the engine materializes it to a dict and the callback must re-hydrate it via `event_model`.

It asserts (a) the orchestrator receives a typed `ModelEventEnvelope` (NOT a dict) and (b) the workflow advances past hop 1 by emitting the workspace-validate command. Verified to **FAIL on the pre-fix contracts** (`AttributeError: 'dict' object has no attribute 'event_type'`) and **PASS after**. No real claude/codex subprocess is executed.

### Env durability
Committed both coding-agent env vars to the catalog (`docker/catalog/services/runtime-effects.yaml`) and the committed compose source (`docker/docker-compose.infra.yml`, runtime-effects):
- `CODING_AGENT_CRED_HOME=/home/omniinfra`
- `ONEX_CODING_AGENT_WORKSPACE_ROOT=/home/omniinfra/agent-workspaces`

The orchestrator `descriptor.allowed_workspace_roots` resolves the latter via `${env.…}` and **fails closed if unset**. Both were patched live on dev for the proof but not yet committed; both are container-internal paths (`hardcoded_env`), never secrets.

### Gates
- `uv run ruff format` / `ruff check --fix` — clean.
- `uv run mypy --strict` on the new test — clean.
- coding-agent + auto-wiring suites: 330 passed; dispatch-engine suites: 139 passed.
- catalog `generate runtime` renders both env vars into the runtime-effects service.
- `pre-commit` on staged files — clean.

### dod_evidence
- Behavior proof: `test_real_dispatch_event_model_wiring.py::test_invoke_command_dispatch_advances_to_workspace_validate` drives the real dispatch engine + auto-wired callback and asserts the orchestrator receives a typed `ModelEventEnvelope` and emits the workspace-validate command. Proven to fail pre-fix and pass post-fix.
- No real claude/codex executed (the workflow stops at hop-1 emission; the effect's subprocess seam is never reached in this test).

Refs OMN-13247 (epic OMN-13245). Phase A #2031 + Phase B #2041 merged; this is the e2e-discovered event_model wiring fix.

---
Evidence-Source: OCC#2797
Evidence-Ticket: OMN-13247
