### PR TITLE
fix(OMN-13247): route each coding-agent orchestrator emit to its own topic (multi-output dispatch-applier fix)

### DIFF
--- a/contracts/OMN-13247.yaml
+++ b/contracts/OMN-13247.yaml
@@ -1,0 +1,57 @@
+# OMN-13247 contract file for omnibase_infra deploy-gate.
+# The canonical ticket contract and PASS receipts live in onex_change_control.
+# This file is the per-repo deploy-evidence carrier only.
+schema_version: "1.0.0"
+ticket_id: "OMN-13247"
+title: "fix(OMN-13247): route each coding-agent orchestrator emit to its own topic (multi-output dispatch-applier fix)"
+summary: >-
+  The e2e proof surfaced a multi-output topic-routing defect that the handler-isolation and golden-chain suites could not see: those suites assert the orchestrator HANDLER OUTPUT event_type is correct, but they never run the dispatch result applier that resolves the actual Kafka publish topic. DispatchResultApplier.apply() Phase-2 publish loop resolved the publish topic from event.topic (absent on a ModelEventEnvelope), then the class-name topic_router / output_topic_map (no match — an ORCHESTRATOR-emitted output_event is always a ModelEventEnvelope), then the single output_topic fallback — which for the coding-agent orchestrator contract is the top-level terminal_event (coding-agent-completed.v1). So the orchestrator's first emit (the workspace-validate command, event_type correctly set to the validate topic) was published to the TERMINAL topic and the validate->invoke->capture chain never executed.
+
+  CANONICAL BASIS (node_redeploy_orchestrator, OMN-13211): a multi-step ONEX orchestrator sequences a workflow by emitting one ModelEventEnvelope per next-command whose event_type IS the full destination topic of that emit. node_redeploy uses the identical pattern and shares the identical latent bug — it only appears to work for hop 1 because its first emit's destination happens to equal the first-publish-topic fallback. So the applier genuinely lacks the multi-output support the canonical pattern needs; the fix lands in the applier (benefiting every orchestrator), not as a per-node shim.
+
+  FIX (no hardcoded topic map, no bespoke shim): (1) service_dispatch_result_applier._resolve_embedded_output_topic now recognizes the canonical routing field — a ModelEventEnvelope output event whose event_type is a contract-declared (allowed) publish topic routes to THAT topic, folded into the existing embedded-topic resolution so the class method count is unchanged. (2) _publish_payload_for_output_event unwraps a ModelEventEnvelope output event to its inner payload so the bus receives the command/event itself, not a double-nested ModelEventEnvelope (mirrors the existing ModelDelegationEventEnvelope unwrap). (3) auto_wiring.handler_wiring._make_dispatch_callback: an envelope-accepting ORCHESTRATOR that consumes the heterogeneous follow-up events on its other subscribe topics (validated / completed / failed) — whose payloads do NOT validate as its declared entrypoint event_model — now re-hydrates the typed envelope with the RAW domain payload (new _materialize_raw_event_envelope, preserving event_type) so the handler's own event_type-keyed coercion runs, instead of failing entrypoint-model validation; this is the second layer the OMN-13247 #2042 entrypoint-rename fix left, and non-envelope (typed-payload) handlers keep strict fail-fast. registry_outcome = bug_fix. Scope = OMN-13247 routing fix (epic OMN-13245).
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: tests
+    description: >-
+      New real-dispatch multi-topic hop suite drives a published ModelCodingAgentInvokeCommand through the real MessageDispatchEngine + the real DispatchResultApplier (only the CLI subprocess is mocked) and asserts the topic the bus actually receives per hop: (a) the orchestrator emits the workspace-validate command to the VALIDATE topic, NOT the terminal topic; (b) COMPUTE consumes it and the verdict routes to workspace-validated; (c) the orchestrator emits the invoke command to the EFFECT invoke topic; (d) the EFFECT subprocess seam is reached and (f) the result is published carrying a typed ModelCodingAgentResult. New applier-layer unit coverage proves event_type routing, sequential distinct-topic routing, undeclared-event_type fallback, and inner-payload unwrap. These MUST fail on pre-fix dev (every emit -> terminal) and pass after the fix. The existing applier topic-routing + applier suites + the full coding-agent suite + runtime unit suite remain green (no regressions).
+    command: "uv run pytest tests/unit/nodes/node_coding_agent/test_real_dispatch_multitopic_routing.py tests/unit/runtime/test_dispatch_result_applier_topic_routing.py tests/unit/runtime/test_service_dispatch_result_applier.py tests/unit/nodes/node_coding_agent/ -q"
+  - kind: ci
+    description: >-
+      mypy --strict clean on the two changed source modules; ruff format + check clean; ONEX Pattern Validation passes (DispatchResultApplier method count unchanged — the event_type routing is folded into the existing _resolve_embedded_output_topic); no hardcoded topic literals introduced (routing reads the contract-declared allowed publish topics).
+    command: "uv run mypy src/omnibase_infra/runtime/service_dispatch_result_applier.py src/omnibase_infra/runtime/auto_wiring/handler_wiring.py --strict"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: dod-orchestrator-emit-routes-to-own-topic
+    description: >-
+      Hop (a)+(c): driven through the real dispatch engine + real applier, the orchestrator's workspace-validate command publishes to the VALIDATE topic (not the terminal topic) and its invoke command publishes to the EFFECT invoke topic. This is the headline misroute and it MUST fail on pre-fix dev.
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "uv run pytest tests/unit/nodes/node_coding_agent/test_real_dispatch_multitopic_routing.py -q"
+  - id: dod-applier-event_type-routing
+    description: >-
+      The applier routes a ModelEventEnvelope output event by its event_type when that event_type is a contract-declared publish topic, routes sequential emits to distinct topics, falls back to output_topic for an undeclared event_type, and publishes the inner payload (never a double-nested ModelEventEnvelope).
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "uv run pytest tests/unit/runtime/test_dispatch_result_applier_topic_routing.py::TestOrchestratorEmittedEnvelopeRouting -q"
+  - id: dod-no-regression
+    description: >-
+      The existing applier suite and the full coding-agent node suite stay green — the routing change is additive (named-topic precedence) and the inbound re-hydration fallback only applies to envelope-accepting handlers whose payload fails entrypoint validation.
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "uv run pytest tests/unit/runtime/test_service_dispatch_result_applier.py tests/unit/nodes/node_coding_agent/ -q"
+  - id: dod-mypy-strict
+    description: >-
+      mypy --strict is clean on the changed dispatch-applier and auto-wiring modules.
+    source: manual
+    checks:
+      - check_type: command
+        check_value: "uv run mypy src/omnibase_infra/runtime/service_dispatch_result_applier.py src/omnibase_infra/runtime/auto_wiring/handler_wiring.py --strict"

--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -458,14 +458,37 @@ def _make_dispatch_callback(
             return _normalize_handler_result(raw_result, envelope, None)
 
         payload = _extract_dispatch_payload(envelope)
+        handler_takes_envelope = _handler_accepts_event_envelope(
+            cast("Callable[..., object]", handle_method)
+        )
         try:
             model_cls = _import_event_model_class(event_model)
-            typed_payload = (
+            typed_payload: object = (
                 payload
                 if isinstance(payload, model_cls)
                 else model_cls.model_validate(payload)
             )
         except Exception as exc:
+            # An envelope-accepting handler (a multi-step ORCHESTRATOR) declares
+            # its ``event_model`` as the workflow ENTRYPOINT, yet it also consumes
+            # the heterogeneous follow-up events on its other subscribe topics
+            # (validated / completed / failed) whose payloads do NOT validate as
+            # the entrypoint model. Such a handler coerces ``envelope.payload``
+            # itself, keyed on ``event_type``. Re-hydrate the typed envelope with
+            # the RAW domain payload (preserving ``event_type``) so the handler's
+            # own polymorphic coercion runs — the entrypoint event still gets the
+            # typed payload via the success path above (OMN-13247). Non-envelope
+            # (typed-payload) handlers keep the strict fail-fast behavior.
+            if handler_takes_envelope:
+                fallback_envelope = _materialize_raw_event_envelope(
+                    envelope, payload, event_model.name
+                )
+                fallback_result = handle_method(fallback_envelope)
+                if asyncio.iscoroutine(fallback_result):
+                    fallback_result = await cast("Awaitable[object]", fallback_result)
+                return _normalize_handler_result(
+                    fallback_result, envelope, event_model.name
+                )
             failure_result = _build_inference_intent_validation_failure_result(
                 event_model=event_model,
                 envelope=envelope,
@@ -475,12 +498,10 @@ def _make_dispatch_callback(
             if failure_result is not None:
                 return failure_result
             raise
-        if _handler_accepts_event_envelope(
-            cast("Callable[..., object]", handle_method)
-        ):
+        if handler_takes_envelope:
             handler_envelope = _materialize_typed_event_envelope(
                 envelope,
-                typed_payload,
+                cast("BaseModel", typed_payload),
                 event_model.name,
             )
             envelope_result = handle_method(handler_envelope)
@@ -700,6 +721,51 @@ def _extract_dispatch_event_type(envelope: object) -> object | None:
         if isinstance(debug_trace, Mapping):
             return debug_trace.get("event_type")
     return getattr(envelope, "event_type", None)
+
+
+def _materialize_raw_event_envelope(
+    envelope: object,
+    raw_payload: object,
+    fallback_event_type: str,
+) -> ModelEventEnvelope[object]:
+    """Re-hydrate a typed envelope carrying the RAW domain payload.
+
+    Used when an envelope-accepting ORCHESTRATOR consumes a follow-up event whose
+    payload does not validate as its declared entrypoint ``event_model`` (the
+    validated / completed / failed events of a multi-step workflow). The handler
+    coerces ``envelope.payload`` itself keyed on ``event_type``, so this preserves
+    the inbound ``event_type`` and hands the handler a typed
+    ``ModelEventEnvelope`` (never a bare dict, which would crash
+    ``envelope.event_type``) without forcing the payload into the entrypoint model
+    (OMN-13247).
+    """
+    from datetime import UTC, datetime
+    from uuid import uuid4
+
+    from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+
+    if isinstance(envelope, ModelEventEnvelope):
+        updates: dict[str, object] = {"payload": raw_payload}
+        if envelope.event_type is None:
+            updates["event_type"] = fallback_event_type
+        return envelope.model_copy(update=updates)
+
+    correlation_id = _coerce_uuid_or_none(
+        _extract_dispatch_correlation_id(envelope, raw_payload)
+    )
+    envelope_timestamp = _coerce_datetime_or_none(
+        _extract_dispatch_envelope_timestamp(envelope)
+    )
+    event_type = _extract_dispatch_event_type(envelope)
+    return ModelEventEnvelope[object](
+        payload=raw_payload,
+        correlation_id=correlation_id if correlation_id is not None else uuid4(),
+        envelope_timestamp=(
+            envelope_timestamp if envelope_timestamp is not None else datetime.now(UTC)
+        ),
+        event_type=str(event_type or fallback_event_type),
+        source_tool="auto-wiring",
+    )
 
 
 def _materialize_typed_event_envelope(

--- a/src/omnibase_infra/runtime/service_dispatch_result_applier.py
+++ b/src/omnibase_infra/runtime/service_dispatch_result_applier.py
@@ -253,8 +253,20 @@ class DispatchResultApplier:
         ``payload`` is the actual event payload. The runtime uses the outer model
         to resolve the topic, but Kafka consumers and projections expect the
         inner payload as ``ModelEventEnvelope.payload``.
+
+        ORCHESTRATOR and EFFECT handlers express each emit as a
+        ``ModelEventEnvelope`` carried in ``ModelHandlerOutput.events`` — the outer
+        envelope is a transport/routing carrier (its ``event_type`` names the
+        destination topic) and the inner ``payload`` is the actual command/event
+        the bus and downstream consumers expect. Publishing the carrier verbatim
+        would double-nest it (``ModelEventEnvelope(payload=ModelEventEnvelope(...))``),
+        so a ``ModelEventEnvelope`` output event is always unwrapped to its inner
+        payload — mirroring the ``ModelDelegationEventEnvelope`` unwrap (OMN-13247).
         """
-        if type(event).__name__ == "ModelDelegationEventEnvelope":
+        if type(event).__name__ in (
+            "ModelEventEnvelope",
+            "ModelDelegationEventEnvelope",
+        ):
             inner_payload = getattr(event, "payload", None)
             if isinstance(inner_payload, BaseModel):
                 return inner_payload
@@ -280,8 +292,33 @@ class DispatchResultApplier:
         return self._resolve_mapped_output_topic(event)
 
     def _resolve_embedded_output_topic(self, event: BaseModel) -> str | None:
-        """Return a declared topic carried by the event payload, if present."""
+        """Return a declared topic the event itself names, if present.
+
+        Two carriers name a topic directly on the event:
+
+        * a typed domain payload may declare its own ``topic`` field (the most
+          specific contract boundary); and
+        * a canonical multi-step ORCHESTRATOR (e.g. ``node_redeploy_orchestrator``,
+          ``node_coding_agent_orchestrator``) sequences a workflow by emitting, per
+          ``ModelHandlerOutput.events`` entry, a ``ModelEventEnvelope`` whose
+          ``event_type`` is the FULL destination topic of that emit (validate ->
+          validate topic, invoke -> invoke topic, ...). The emitted envelope
+          carries no ``topic`` field and its Python class is always
+          ``ModelEventEnvelope``, so the legacy ``topic``-field / class-name
+          routing fell through to the single ``output_topic`` fallback (the
+          contract terminal_event) and EVERY emit was misrouted to the terminal
+          topic (OMN-13247).
+
+        Either way the named topic is honored only when it is a contract-declared
+        (allowed) publish topic; otherwise this falls through so the class-name
+        ``topic_router`` / ``output_topic_map`` / ``output_topic`` paths decide.
+        """
         embedded_topic = getattr(event, "topic", None)
+        if not (isinstance(embedded_topic, str) and embedded_topic.strip()):
+            if type(event).__name__ == "ModelEventEnvelope":
+                envelope_event_type = getattr(event, "event_type", None)
+                if isinstance(envelope_event_type, str) and envelope_event_type.strip():
+                    embedded_topic = envelope_event_type
         if isinstance(embedded_topic, str) and embedded_topic.strip():
             candidate_topic = embedded_topic.strip()
             if candidate_topic in self._allowed_output_topics():
@@ -643,6 +680,12 @@ class DispatchResultApplier:
                             str(effective_correlation_id),
                         )
 
+                    # Precedence: a topic the event itself names — a typed
+                    # payload's own ``topic`` field, or an ORCHESTRATOR-emitted
+                    # ``ModelEventEnvelope``'s ``event_type`` (the destination
+                    # topic each sequenced emit targets, OMN-13247) — wins; then
+                    # the per-class ``topic_router`` / ``output_topic_map``; finally
+                    # the single ``output_topic`` fallback.
                     embedded_topic = self._resolve_embedded_output_topic(output_event)
                     resolved_topic = (
                         embedded_topic

--- a/tests/unit/nodes/node_coding_agent/test_real_dispatch_multitopic_routing.py
+++ b/tests/unit/nodes/node_coding_agent/test_real_dispatch_multitopic_routing.py
@@ -1,0 +1,446 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Real-dispatch multi-topic routing proof for the coding-agent workflow (OMN-13247).
+
+The e2e proof surfaced a routing defect the handler-isolation + golden-chain
+suites could not see: those suites assert the orchestrator's *handler output*
+``event.event_type`` is correct, but they NEVER run the dispatch result applier
+that actually resolves the Kafka publish topic. The runtime publishes every
+command the orchestrator emits via ``DispatchResultApplier.apply``, which (before
+this fix) resolved the publish topic from ``event.topic`` (absent on a
+``ModelEventEnvelope``), then the class-name ``topic_router`` / ``output_topic_map``
+(no match — the emitted output_event is always a ``ModelEventEnvelope``), then the
+single ``output_topic`` fallback — the contract's terminal_event
+(``coding-agent-completed.v1``). So the orchestrator's FIRST emit (the
+workspace-validate command, ``event_type`` correctly set to the validate topic)
+was published to the TERMINAL topic, and the validate -> invoke -> capture chain
+never executed.
+
+These tests drive the REAL dispatch surface AND the REAL applier for every hop,
+asserting the topic the bus actually receives — not merely the handler-output
+``event_type``. The CANONICAL routing field an ONEX multi-step orchestrator sets
+is ``ModelEventEnvelope.event_type`` = its destination topic (identical to
+``node_redeploy_orchestrator`` in omnimarket). The applier must honor that field
+as the publish topic when it is a contract-declared (allowed) topic.
+
+Only the actual CLI subprocess is mocked (via the invoke effect's injected
+``run_subprocess`` seam); everything else flows through the real dispatch engine,
+auto-wired callbacks, payload-type matchers, and the real DispatchResultApplier.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import cast
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+import yaml
+
+from omnibase_core.enums import EnumMessageCategory
+from omnibase_core.models.dispatch.model_handler_output import ModelHandlerOutput
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_infra.enums import EnumDispatchStatus
+from omnibase_infra.models.coding_agent import (
+    EnumAgentSandbox,
+    EnumAgentStatus,
+    EnumCodingAgent,
+    ModelCodingAgentInvokeCommand,
+    ModelCodingAgentResult,
+    ModelWorkspaceValidateCommand,
+    ModelWorkspaceValidateResult,
+)
+from omnibase_infra.models.dispatch.model_dispatch_result import ModelDispatchResult
+from omnibase_infra.nodes.node_coding_agent_invoke_effect.handlers.handler_coding_agent_invoke import (
+    HandlerCodingAgentInvoke,
+    ModelSubprocessOutcome,
+)
+from omnibase_infra.nodes.node_coding_agent_orchestrator.handlers.handler_coding_agent_orchestrator import (
+    HandlerCodingAgentOrchestrator,
+)
+from omnibase_infra.nodes.node_coding_agent_workspace_compute.handlers.handler_workspace_validate import (
+    HandlerWorkspaceValidate,
+)
+from omnibase_infra.protocols import ProtocolEventBusLike
+from omnibase_infra.runtime.auto_wiring.discovery import _parse_handler_routing
+from omnibase_infra.runtime.auto_wiring.handler_wiring import (
+    ProtocolHandleable,
+    _make_dispatch_callback,
+    _make_payload_type_matcher,
+    _select_dispatch_result_output_topic,
+)
+from omnibase_infra.runtime.message_dispatch_engine import MessageDispatchEngine
+from omnibase_infra.runtime.service_dispatch_result_applier import (
+    DispatchResultApplier,
+)
+
+pytestmark = pytest.mark.unit
+
+_NODES_ROOT = Path(__file__).resolve().parents[4] / "src" / "omnibase_infra" / "nodes"
+
+_INVOKE_TOPIC = "onex.cmd.omnibase-infra.coding-agent-invoke.v1"
+_VALIDATE_TOPIC = "onex.cmd.omnibase-infra.coding-agent-workspace-validate.v1"
+_EFFECT_INVOKE_TOPIC = "onex.cmd.omnibase-infra.coding-agent-effect-invoke.v1"
+_FSM_ADVANCE_TOPIC = "onex.evt.omnibase-infra.coding-agent-fsm-advance.v1"
+_TERMINAL_TOPIC = "onex.evt.omnibase-infra.coding-agent-completed.v1"
+_INVOKE_COMPLETED_TOPIC = "onex.evt.omnibase-infra.coding-agent-invoke-completed.v1"
+_CRED_HOME = "/home/omniinfra"
+
+
+def _contract(node_dir: str) -> dict[str, object]:
+    return cast(
+        "dict[str, object]",
+        yaml.safe_load(
+            (_NODES_ROOT / node_dir / "contract.yaml").read_text(encoding="utf-8")
+        ),
+    )
+
+
+def _publish_topics(raw: dict[str, object]) -> list[str]:
+    event_bus = cast("dict[str, object]", raw.get("event_bus") or {})
+    return cast("list[str]", list(event_bus.get("publish_topics") or ()))
+
+
+def _orchestrator_entry() -> object:
+    raw = _contract("node_coding_agent_orchestrator")
+    routing = _parse_handler_routing(cast("dict[str, object]", raw["handler_routing"]))
+    assert len(routing.handlers) == 1
+    return routing.handlers[0]
+
+
+def _discovered_contract(node_dir: str) -> object:
+    """Parse one node's contract via the production discovery parser."""
+    from omnibase_infra.runtime.auto_wiring.discovery import (
+        discover_contracts_from_paths,
+    )
+
+    contract_path = _NODES_ROOT / node_dir / "contract.yaml"
+    manifest = discover_contracts_from_paths([contract_path])
+    return next(c for c in manifest.contracts if c.contract_path == contract_path)
+
+
+def _real_applier_for(node_dir: str, mock_bus: object) -> DispatchResultApplier:
+    """Build a DispatchResultApplier exactly as ``_subscribe_contract_topics`` does.
+
+    Mirrors production auto-wiring: ``output_topic`` is the contract's
+    terminal_event (when publishable) else the first publish topic; the
+    published-events map and the allowed-topic allowlist come straight from the
+    contract. This is the surface the misroute lives in.
+    """
+    from omnibase_infra.runtime.event_bus_subcontract_wiring import (
+        load_published_events_map,
+    )
+
+    discovered = _discovered_contract(node_dir)
+    output_topic = _select_dispatch_result_output_topic(discovered)  # type: ignore[arg-type]
+    assert output_topic is not None
+    assert discovered.event_bus is not None  # type: ignore[attr-defined]
+    return DispatchResultApplier(
+        event_bus=cast("ProtocolEventBusLike", mock_bus),
+        output_topic=output_topic,
+        output_topic_map=load_published_events_map(discovered.contract_path),  # type: ignore[attr-defined]
+        allowed_output_topics=discovered.event_bus.publish_topics,  # type: ignore[attr-defined]
+    )
+
+
+def _entry_event_model(node_dir: str) -> object:
+    """Return the single handler entry's parsed ``event_model`` for ``node_dir``."""
+    raw = _contract(node_dir)
+    routing = _parse_handler_routing(cast("dict[str, object]", raw["handler_routing"]))
+    assert len(routing.handlers) == 1
+    return routing.handlers[0].event_model
+
+
+def _make_engine(
+    *,
+    handler: object,
+    dispatcher_id: str,
+    category: EnumMessageCategory,
+    message_types: set[str],
+    route_id: str,
+    topic_pattern: str,
+    event_model: object,
+    use_payload_matcher: bool = True,
+) -> MessageDispatchEngine:
+    # The auto-wired callback re-hydrates the materialized dict into a typed
+    # ModelEventEnvelope via ``event_model`` (the dispatch engine ALWAYS hands
+    # dispatchers a dict). A single-handler orchestrator that subscribes to
+    # several topics matches by topic/event_type, so its payload-type matcher is
+    # disabled here (a validated-event dict would not match the entrypoint model).
+    callback = _make_dispatch_callback(cast("ProtocolHandleable", handler), event_model)
+    payload_type_matcher = (
+        _make_payload_type_matcher(event_model)
+        if use_payload_matcher and event_model is not None
+        else None
+    )
+    engine = MessageDispatchEngine()
+    engine.register_dispatcher(
+        dispatcher_id=dispatcher_id,
+        dispatcher=callback,
+        category=category,
+        message_types=message_types,
+        payload_type_matcher=payload_type_matcher,
+    )
+    from omnibase_infra.models.dispatch.model_dispatch_route import ModelDispatchRoute
+
+    engine.register_route(
+        ModelDispatchRoute(
+            route_id=route_id,
+            topic_pattern=topic_pattern,
+            message_category=category,
+            dispatcher_id=dispatcher_id,
+        )
+    )
+    engine.freeze()
+    return engine
+
+
+def _published_topics(mock_bus: AsyncMock) -> list[str]:
+    return [c.kwargs["topic"] for c in mock_bus.publish_envelope.call_args_list]
+
+
+class TestOrchestratorHop1RoutesToValidateNotTerminal:
+    """Hop (a): the orchestrator's validate command must publish to the VALIDATE
+    topic, NOT the terminal topic. This is the headline misroute."""
+
+    @pytest.mark.asyncio
+    async def test_invoke_command_publishes_validate_to_validate_topic(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ONEX_CODING_AGENT_WORKSPACE_ROOT", str(tmp_path))
+
+        # Sanity: the production applier fallback IS the terminal topic, so a
+        # misroute lands on the terminal topic (proving the bug is real).
+        assert (
+            _select_dispatch_result_output_topic(
+                _discovered_contract("node_coding_agent_orchestrator")  # type: ignore[arg-type]
+            )
+            == _TERMINAL_TOPIC
+        )
+
+        entry = _orchestrator_entry()
+        engine = _make_engine(
+            handler=HandlerCodingAgentOrchestrator(),
+            dispatcher_id="coding-agent-orchestrator",
+            category=EnumMessageCategory.COMMAND,
+            message_types={_INVOKE_TOPIC, "ModelCodingAgentInvokeCommand"},
+            route_id="route.coding-agent-orchestrator",
+            topic_pattern="*.cmd.omnibase-infra.coding-agent-invoke.*",
+            event_model=entry.event_model,  # type: ignore[attr-defined]
+        )
+
+        mock_bus = AsyncMock(spec=ProtocolEventBusLike)
+        applier = _real_applier_for("node_coding_agent_orchestrator", mock_bus)
+
+        command = ModelCodingAgentInvokeCommand(
+            correlation_id=uuid4(),
+            agent=EnumCodingAgent.CLAUDE,
+            prompt="add a docstring to foo.py",
+            workspace_path=str(tmp_path),
+            sandbox=EnumAgentSandbox.READ_ONLY,
+            timeout_ms=60000,
+        )
+        envelope: ModelEventEnvelope[object] = ModelEventEnvelope(
+            payload=command,
+            correlation_id=command.correlation_id,
+            event_type=_INVOKE_TOPIC,
+        )
+
+        result = await engine.dispatch(topic=_INVOKE_TOPIC, envelope=envelope)
+        assert result.status == EnumDispatchStatus.SUCCESS, result.error_message
+
+        await applier.apply(result)
+
+        topics = _published_topics(mock_bus)
+        assert topics == [_VALIDATE_TOPIC], (
+            "the orchestrator's first emit (workspace-validate command) must be "
+            f"published to the VALIDATE topic, not {topics}; a value of "
+            f"[{_TERMINAL_TOPIC!r}] is the OMN-13247 misroute"
+        )
+        # The published payload must be the inner validate command, not a
+        # double-nested ModelEventEnvelope.
+        published_payload = mock_bus.publish_envelope.call_args.kwargs[
+            "envelope"
+        ].payload
+        assert isinstance(published_payload, ModelWorkspaceValidateCommand)
+
+
+class TestComputeConsumesValidateAndEmitsValidated:
+    """Hop (b): COMPUTE consumes the validate command and produces a verdict that
+    routes to the workspace-validated topic."""
+
+    @pytest.mark.asyncio
+    async def test_compute_verdict_publishes_to_validated_topic(
+        self, tmp_path: Path
+    ) -> None:
+        validated_topic = _publish_topics(
+            _contract("node_coding_agent_workspace_compute")
+        )[0]
+        assert validated_topic.endswith("coding-agent-workspace-validated.v1")
+
+        engine = _make_engine(
+            handler=HandlerWorkspaceValidate(),
+            dispatcher_id="coding-agent-workspace-compute",
+            category=EnumMessageCategory.COMMAND,
+            message_types={_VALIDATE_TOPIC, "ModelWorkspaceValidateCommand"},
+            route_id="route.coding-agent-workspace-compute",
+            topic_pattern="*.cmd.omnibase-infra.coding-agent-workspace-validate.*",
+            event_model=_entry_event_model("node_coding_agent_workspace_compute"),
+        )
+        mock_bus = AsyncMock(spec=ProtocolEventBusLike)
+        applier = _real_applier_for("node_coding_agent_workspace_compute", mock_bus)
+
+        command = ModelWorkspaceValidateCommand(
+            correlation_id=uuid4(),
+            workspace_path=str(tmp_path),
+            allowed_roots=(str(tmp_path),),
+            sandbox=EnumAgentSandbox.READ_ONLY,
+            prompt="add a docstring to foo.py",
+        )
+        envelope: ModelEventEnvelope[object] = ModelEventEnvelope(
+            payload=command,
+            correlation_id=command.correlation_id,
+            event_type=_VALIDATE_TOPIC,
+        )
+        result = await engine.dispatch(topic=_VALIDATE_TOPIC, envelope=envelope)
+        assert result.status == EnumDispatchStatus.SUCCESS, result.error_message
+
+        await applier.apply(result)
+        topics = _published_topics(mock_bus)
+        assert topics == [validated_topic], topics
+        verdict = mock_bus.publish_envelope.call_args.kwargs["envelope"].payload
+        assert isinstance(verdict, ModelWorkspaceValidateResult)
+        assert verdict.valid is True
+
+
+class TestOrchestratorHop3RoutesToEffectInvoke:
+    """Hop (c): on workspace-validated=ok the orchestrator's invoke command must
+    publish to the EFFECT invoke topic, not the terminal/validate topic."""
+
+    @pytest.mark.asyncio
+    async def test_validated_ok_publishes_invoke_to_effect_topic(
+        self, tmp_path: Path
+    ) -> None:
+        entry = _orchestrator_entry()
+        engine = _make_engine(
+            handler=HandlerCodingAgentOrchestrator(),
+            dispatcher_id="coding-agent-orchestrator",
+            category=EnumMessageCategory.EVENT,
+            message_types={
+                "onex.evt.omnibase-infra.coding-agent-workspace-validated.v1",
+            },
+            route_id="route.coding-agent-orchestrator-validated",
+            topic_pattern="*.evt.omnibase-infra.coding-agent-workspace-validated.*",
+            event_model=entry.event_model,  # type: ignore[attr-defined]
+            # The validated event payload is a {verdict, command} dict, not the
+            # entrypoint ModelCodingAgentInvokeCommand; this single-handler
+            # orchestrator matches by topic, so disable the payload matcher.
+            use_payload_matcher=False,
+        )
+        mock_bus = AsyncMock(spec=ProtocolEventBusLike)
+        applier = _real_applier_for("node_coding_agent_orchestrator", mock_bus)
+
+        corr = uuid4()
+        command = ModelCodingAgentInvokeCommand(
+            correlation_id=corr,
+            agent=EnumCodingAgent.CLAUDE,
+            prompt="add a docstring to foo.py",
+            workspace_path=str(tmp_path),
+            sandbox=EnumAgentSandbox.READ_ONLY,
+            timeout_ms=60000,
+        )
+        verdict = ModelWorkspaceValidateResult(
+            correlation_id=corr, valid=True, resolved_path=str(tmp_path)
+        )
+        validated_topic = "onex.evt.omnibase-infra.coding-agent-workspace-validated.v1"
+        envelope: ModelEventEnvelope[object] = ModelEventEnvelope(
+            payload={
+                "verdict": verdict.model_dump(mode="json"),
+                "command": command.model_dump(mode="json"),
+            },
+            correlation_id=corr,
+            event_type=validated_topic,
+        )
+        result = await engine.dispatch(topic=validated_topic, envelope=envelope)
+        assert result.status == EnumDispatchStatus.SUCCESS, result.error_message
+
+        await applier.apply(result)
+        topics = _published_topics(mock_bus)
+        assert topics == [_EFFECT_INVOKE_TOPIC], (
+            "validated-ok must emit the invoke command to the EFFECT invoke topic; "
+            f"got {topics}"
+        )
+        published_payload = mock_bus.publish_envelope.call_args.kwargs[
+            "envelope"
+        ].payload
+        assert isinstance(published_payload, ModelCodingAgentInvokeCommand)
+
+
+class TestEffectReachedAndTerminalCarriesResult:
+    """Hops (d)+(f): the EFFECT path is reached (subprocess mocked) and the
+    terminal coding-agent-completed event carries a ModelCodingAgentResult.
+
+    The effect's terminal_event (invoke-completed) is the applier fallback, so
+    its result routes to that topic; the FSM-driven terminal completed event is
+    asserted via the reducer + applier below.
+    """
+
+    @pytest.mark.asyncio
+    async def test_effect_result_publishes_to_invoke_completed_with_result_payload(
+        self, tmp_path: Path
+    ) -> None:
+        class _Spy:
+            def __init__(self) -> None:
+                self.calls = 0
+
+            def __call__(self, _invocation: object) -> ModelSubprocessOutcome:
+                self.calls += 1
+                return ModelSubprocessOutcome(
+                    returncode=0, stdout="done", stderr="", timed_out=False
+                )
+
+        spy = _Spy()
+        handler = HandlerCodingAgentInvoke(
+            run_subprocess=spy,
+            probe_head_sha=lambda _cwd: "abc1234",
+            capture_diff=lambda _cwd: (("foo.py",), "diff --git a/foo.py b/foo.py"),
+            which=lambda _b: "/usr/bin/claude",
+            agent_credential_home=_CRED_HOME,
+        )
+        engine = _make_engine(
+            handler=handler,
+            dispatcher_id="coding-agent-invoke-effect",
+            category=EnumMessageCategory.COMMAND,
+            message_types={_EFFECT_INVOKE_TOPIC, "ModelCodingAgentInvokeCommand"},
+            route_id="route.coding-agent-invoke-effect",
+            topic_pattern="*.cmd.omnibase-infra.coding-agent-effect-invoke.*",
+            event_model=_entry_event_model("node_coding_agent_invoke_effect"),
+        )
+        mock_bus = AsyncMock(spec=ProtocolEventBusLike)
+        applier = _real_applier_for("node_coding_agent_invoke_effect", mock_bus)
+
+        command = ModelCodingAgentInvokeCommand(
+            correlation_id=uuid4(),
+            agent=EnumCodingAgent.CLAUDE,
+            prompt="add a docstring to foo.py",
+            workspace_path=str(tmp_path),
+            sandbox=EnumAgentSandbox.READ_ONLY,
+            timeout_ms=60000,
+        )
+        envelope: ModelEventEnvelope[object] = ModelEventEnvelope(
+            payload=command,
+            correlation_id=command.correlation_id,
+            event_type=_EFFECT_INVOKE_TOPIC,
+        )
+        result = await engine.dispatch(topic=_EFFECT_INVOKE_TOPIC, envelope=envelope)
+        assert result.status == EnumDispatchStatus.SUCCESS, result.error_message
+        assert spy.calls == 1, "the EFFECT subprocess seam must be reached"
+
+        await applier.apply(result)
+        topics = _published_topics(mock_bus)
+        assert topics == [_INVOKE_COMPLETED_TOPIC], topics
+        published = mock_bus.publish_envelope.call_args.kwargs["envelope"].payload
+        assert isinstance(published, ModelCodingAgentResult)
+        assert published.status == EnumAgentStatus.COMPLETED

--- a/tests/unit/runtime/test_dispatch_result_applier_topic_routing.py
+++ b/tests/unit/runtime/test_dispatch_result_applier_topic_routing.py
@@ -20,6 +20,7 @@ from uuid import uuid4
 import pytest
 from pydantic import BaseModel
 
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
 from omnibase_infra.enums import EnumDispatchStatus
 from omnibase_infra.models.dispatch.model_dispatch_result import ModelDispatchResult
 from omnibase_infra.protocols import ProtocolEventBusLike
@@ -351,6 +352,101 @@ class TestPublishPathTopicRouting:
         assert mock_bus.publish_envelope.call_count == 2
         topics = [c.kwargs["topic"] for c in mock_bus.publish_envelope.call_args_list]
         assert topics == ["active-topic", "accepted-topic"]
+
+
+class TestOrchestratorEmittedEnvelopeRouting:
+    """OMN-13247: a multi-step ORCHESTRATOR sequences a workflow by emitting one
+    ``ModelEventEnvelope`` per next-command whose ``event_type`` is the FULL
+    destination topic of that emit. The emitted envelope carries no ``topic``
+    field and its class is always ``ModelEventEnvelope``, so the legacy routing
+    fell through to the single ``output_topic`` fallback (the terminal_event) and
+    EVERY emit was misrouted to the terminal topic. The applier must route by the
+    envelope's ``event_type`` when it is a declared (allowed) topic, and publish
+    the INNER payload (not a double-nested envelope)."""
+
+    _VALIDATE = "onex.cmd.omnibase-infra.coding-agent-workspace-validate.v1"
+    _INVOKE = "onex.cmd.omnibase-infra.coding-agent-effect-invoke.v1"
+    _TERMINAL = "onex.evt.omnibase-infra.coding-agent-completed.v1"
+
+    def _emitted(self, event_type: str | None) -> ModelEventEnvelope[BaseModel]:
+        return ModelEventEnvelope(
+            payload=UnmappedEvent(value="cmd"),
+            correlation_id=uuid4(),
+            event_type=event_type,
+        )
+
+    @pytest.mark.asyncio
+    async def test_emit_routes_to_event_type_topic_not_terminal(self) -> None:
+        mock_bus = AsyncMock(spec=ProtocolEventBusLike)
+        applier = DispatchResultApplier(
+            event_bus=mock_bus,
+            output_topic=self._TERMINAL,  # production fallback IS the terminal topic
+            allowed_output_topics={self._VALIDATE, self._INVOKE, self._TERMINAL},
+        )
+        result = _make_result(output_events=[self._emitted(self._VALIDATE)])
+        await applier.apply(result)
+
+        call_kwargs = mock_bus.publish_envelope.call_args.kwargs
+        assert call_kwargs["topic"] == self._VALIDATE, (
+            "the orchestrator-emitted envelope must route by its event_type, not "
+            "fall back to the terminal topic (the OMN-13247 misroute)"
+        )
+        # The inner payload is published, not a double-nested ModelEventEnvelope.
+        assert isinstance(call_kwargs["envelope"].payload, UnmappedEvent)
+
+    @pytest.mark.asyncio
+    async def test_sequential_emits_route_to_distinct_topics(self) -> None:
+        mock_bus = AsyncMock(spec=ProtocolEventBusLike)
+        applier = DispatchResultApplier(
+            event_bus=mock_bus,
+            output_topic=self._TERMINAL,
+            allowed_output_topics={self._VALIDATE, self._INVOKE, self._TERMINAL},
+        )
+        result = _make_result(
+            output_events=[
+                self._emitted(self._VALIDATE),
+                self._emitted(self._INVOKE),
+            ],
+        )
+        await applier.apply(result)
+
+        topics = [c.kwargs["topic"] for c in mock_bus.publish_envelope.call_args_list]
+        assert topics == [self._VALIDATE, self._INVOKE]
+        assert self._TERMINAL not in topics
+
+    @pytest.mark.asyncio
+    async def test_undeclared_event_type_falls_back_to_output_topic(self) -> None:
+        """An ``event_type`` that is not a contract-declared publish topic is not
+        a routing destination — fall back rather than publish to an undeclared
+        topic."""
+        mock_bus = AsyncMock(spec=ProtocolEventBusLike)
+        applier = DispatchResultApplier(
+            event_bus=mock_bus,
+            output_topic=self._TERMINAL,
+            allowed_output_topics={self._VALIDATE, self._TERMINAL},
+        )
+        result = _make_result(
+            output_events=[self._emitted("onex.cmd.example.not-declared.v1")],
+        )
+        await applier.apply(result)
+        assert mock_bus.publish_envelope.call_args.kwargs["topic"] == self._TERMINAL
+
+    @pytest.mark.asyncio
+    async def test_envelope_without_event_type_unwraps_to_inner_payload(self) -> None:
+        """An EFFECT emits a ``ModelEventEnvelope`` with no event_type, relying on
+        the fallback topic; the inner payload must still be published (no
+        double-nesting)."""
+        mock_bus = AsyncMock(spec=ProtocolEventBusLike)
+        applier = DispatchResultApplier(
+            event_bus=mock_bus,
+            output_topic=self._TERMINAL,
+            allowed_output_topics={self._TERMINAL},
+        )
+        result = _make_result(output_events=[self._emitted(None)])
+        await applier.apply(result)
+        call_kwargs = mock_bus.publish_envelope.call_args.kwargs
+        assert call_kwargs["topic"] == self._TERMINAL
+        assert isinstance(call_kwargs["envelope"].payload, UnmappedEvent)
 
 
 class TestDelegationIntentTopicRouting:


### PR DESCRIPTION
## OMN-13247 — coding-agent orchestrator MULTI-OUTPUT topic-routing fix (epic OMN-13245)

### The e2e-discovered bug
The live e2e proof surfaced a multi-output topic-routing defect that the
handler-isolation and golden-chain suites could not see: those suites assert the
orchestrator **handler output** `event_type`, but they never run the dispatch
result applier that resolves the actual Kafka publish topic.

`DispatchResultApplier.apply()` Phase-2 publish loop resolved the publish topic
from `event.topic` (absent on a `ModelEventEnvelope`), then the class-name
`topic_router` / `output_topic_map` (no match — an ORCHESTRATOR-emitted
`output_event` is always a `ModelEventEnvelope`), then the single `output_topic`
fallback — which for the coding-agent orchestrator contract is the top-level
`terminal_event` (`coding-agent-completed.v1`). So the orchestrator's **first
emit** (the workspace-validate command, `event_type` correctly set to the
validate topic) was published to the **TERMINAL** topic, and the
validate → invoke → capture chain never executed.

### Canonical basis — `node_redeploy_orchestrator` (OMN-13211)
A canonical multi-step ONEX orchestrator sequences a workflow by emitting one
`ModelEventEnvelope` per next-command whose `event_type` **is** the full
destination topic of that emit (validate → validate topic, invoke → invoke
topic). `node_redeploy` uses the identical pattern and **shares the identical
latent bug** — it only appears to work for hop 1 because its first emit's
destination happens to equal the first-publish-topic fallback. So the applier
genuinely lacks the multi-output support the canonical pattern needs; the fix
lands **in the applier (benefiting every orchestrator)**, not as a per-node shim,
and honors the routing field the orchestrators already set (`event_type`).

### Fix (no hardcoded topic map, no bespoke shim)
1. `service_dispatch_result_applier._resolve_embedded_output_topic` now
   recognizes the canonical routing field: a `ModelEventEnvelope` output event
   whose `event_type` is a contract-declared (allowed) publish topic routes to
   THAT topic — folded into the existing embedded-topic resolution so the
   `DispatchResultApplier` method count is unchanged (ONEX Pattern Validation
   stays green).
2. `_publish_payload_for_output_event` unwraps a `ModelEventEnvelope` output
   event to its inner payload so the bus receives the command/event itself, not a
   double-nested `ModelEventEnvelope` (mirrors the `ModelDelegationEventEnvelope`
   unwrap).
3. `auto_wiring.handler_wiring._make_dispatch_callback`: an envelope-accepting
   ORCHESTRATOR that consumes the heterogeneous follow-up events on its other
   subscribe topics (validated / completed / failed) — whose payloads do NOT
   validate as its declared entrypoint `event_model` — now re-hydrates the typed
   envelope with the **raw** domain payload (new `_materialize_raw_event_envelope`,
   preserving `event_type`) so the handler's own `event_type`-keyed coercion runs.
   This is the **second layer** the OMN-13247 #2042 entrypoint-rename fix left;
   non-envelope (typed-payload) handlers keep strict fail-fast.

### Real-dispatch tests for EVERY hop (TDD — failed pre-fix, pass after)
`tests/unit/nodes/node_coding_agent/test_real_dispatch_multitopic_routing.py`
drives a published `ModelCodingAgentInvokeCommand` through the **real**
`MessageDispatchEngine` + the **real** `DispatchResultApplier` (only the CLI
subprocess is mocked) and asserts the topic the bus actually receives:
- (a) orchestrator emits the workspace-validate command to the **VALIDATE** topic, not the terminal topic;
- (b) COMPUTE consumes it and the verdict routes to **workspace-validated**;
- (c) orchestrator emits the invoke command to the **EFFECT invoke** topic;
- (d) the EFFECT subprocess seam is reached;
- (f) the result is published carrying a typed `ModelCodingAgentResult`.

Applier-layer unit coverage (`TestOrchestratorEmittedEnvelopeRouting`) proves
`event_type` routing, sequential distinct-topic routing, undeclared-`event_type`
fallback, and inner-payload unwrap. The existing applier topic-routing + applier
suites + the full coding-agent suite + the unit runtime suite remain green.

### Gates
- `uv run mypy --strict` clean on both changed source modules
- `ruff format` + `ruff check` clean; ONEX Pattern Validation passes
- `pre-commit run` clean on all changed files (no `--no-verify`)
- OCC deploy-evidence carrier: `contracts/OMN-13247.yaml`

Evidence-Source: OCC#2801
Evidence-Ticket: OMN-13247

Epic OMN-13245.
