### PR TITLE
fix(OMN-13097): register gap skill->node_gap_compute CLI mapping

### DIFF
--- a/src/omnibase_infra/cli/skill_mapping.yaml
+++ b/src/omnibase_infra/cli/skill_mapping.yaml
@@ -133,6 +133,33 @@ skills:
     args:
       - {name: omni-home, payload_field: omni_home, arg_type: string}
       - {name: checks, payload_field: checks, arg_type: string_list}
+  - skill_name: gap
+    node_name: node_gap_compute
+    result_model: omnimarket.nodes.node_gap_compute.models.model_gap_compute_result.ModelGapComputeResult
+    args:
+      - {name: subcommand, payload_field: subcommand, arg_type: string, positional: true}
+      - {name: scope, payload_field: scope, arg_type: string}
+      - {name: epic, payload_field: epic, arg_type: string}
+      - {name: report, payload_field: report, arg_type: string}
+      - {name: repo, payload_field: repo, arg_type: string}
+      - {name: repo-roots, payload_field: repo_roots, arg_type: string_list}
+      - {name: since-days, payload_field: since_days, arg_type: integer}
+      - {name: severity-threshold, payload_field: severity_threshold, arg_type: string}
+      - {name: max-findings, payload_field: max_findings, arg_type: integer}
+      - {name: max-best-effort, payload_field: max_best_effort, arg_type: integer}
+      - {name: max-iterations, payload_field: max_iterations, arg_type: integer}
+      - {name: output, payload_field: output, arg_type: string}
+      - {name: ticket, payload_field: ticket, arg_type: string}
+      - {name: resume, payload_field: resume, arg_type: string}
+      - {name: lag-threshold, payload_field: lag_threshold, arg_type: integer}
+      - {name: latest, payload_field: latest, arg_type: boolean, default: false}
+      - {name: audit, payload_field: audit, arg_type: boolean, default: false}
+      - {name: no-fix, payload_field: no_fix, arg_type: boolean, default: false}
+      - {name: verify, payload_field: verify, arg_type: boolean, default: false}
+      - {name: auto-only, payload_field: auto_only, arg_type: boolean, default: false}
+      - {name: skip-infra-probes, payload_field: skip_infra_probes, arg_type: boolean, default: false}
+      - {name: include-auth-probes, payload_field: include_auth_probes, arg_type: boolean, default: false}
+      - {name: dry-run, payload_field: dry_run, arg_type: boolean, default: false}
   - skill_name: hostile_reviewer
     node_name: node_hostile_reviewer_orchestrator
     result_model: omnimarket.nodes.node_hostile_reviewer_orchestrator.models.model_hostile_reviewer_completed_event.ModelHostileReviewerCompletedEvent

--- a/tests/unit/cli/test_cli_skill.py
+++ b/tests/unit/cli/test_cli_skill.py
@@ -35,7 +35,9 @@ from omnibase_infra.cli.model_skill_mapping_registry import ModelSkillMappingReg
 
 pytestmark = pytest.mark.unit
 
-# The 24 dispatch shims this ticket migrates (ticket deliverable 1).
+# The dispatch shims migrated to the declarative skill->node mapping.
+# OMN-13097 seeded the first 24; `gap` was added once node_gap_compute landed
+# in omnimarket but the CLI still rejected `onex skill gap` (this fix).
 _EXPECTED_SKILLS = frozenset(
     {
         "aislop_sweep",
@@ -51,6 +53,7 @@ _EXPECTED_SKILLS = frozenset(
         "doc_freshness_sweep",
         "dod_verify",
         "duplication_sweep",
+        "gap",
         "hostile_reviewer",
         "linear_housekeeping",
         "merge_sweep",
@@ -363,6 +366,76 @@ def test_command_dispatches_via_receipt_mode(
     assert payload["repos"] == ["omnibase_core", "omnibase_infra"]
     assert payload["dry_run"] is True
     assert captured["backend_overrides"] == {"event_bus": "inmemory"}
+
+
+def test_gap_mapping_routes_positional_subcommand_to_node(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`onex skill gap detect --scope local` dispatches node_gap_compute.
+
+    Guards the regression this fix addresses: the gap SKILL.md and the
+    omnimarket node_gap_compute both existed, but the CLI rejected
+    ``onex skill gap`` because it was absent from skill_mapping.yaml.
+    """
+    captured: dict[str, object] = {}
+
+    def _fake_receipt_mode(**kwargs: object) -> int:
+        captured.update(kwargs)
+        input_path = kwargs["input_path"]
+        assert isinstance(input_path, Path)
+        captured["payload"] = json.loads(input_path.read_text(encoding="utf-8"))
+        return 0
+
+    monkeypatch.setattr(cli_skill, "run_receipt_mode", _fake_receipt_mode)
+    monkeypatch.setattr(
+        cli_skill,
+        "_resolve_packaged_contract",
+        lambda n: tmp_path / f"{n}-contract.yaml",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        run_skill_by_name,
+        [
+            "gap",
+            "detect",
+            "--state-root",
+            str(tmp_path / "state"),
+            "--scope",
+            "local",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["node_name"] == "node_gap_compute"
+    payload = captured["payload"]
+    assert isinstance(payload, dict)
+    assert payload["subcommand"] == "detect"
+    assert payload["scope"] == "local"
+
+
+def test_gap_payload_validates_against_request_model() -> None:
+    """The gap mapping builds a payload the node's request model accepts.
+
+    omnimarket is the backing-node package and is not a hard test dependency
+    of omnibase_infra; skip when it is not installed (CI parity with the other
+    omnimarket-optional tests in this suite).
+    """
+    request_module = pytest.importorskip(
+        "omnimarket.nodes.node_gap_compute.models.model_gap_compute_request"
+    )
+    ModelGapComputeRequest = request_module.ModelGapComputeRequest
+
+    registry = load_skill_registry()
+    gap = registry.get("gap")
+    assert gap is not None
+    assert gap.node_name == "node_gap_compute"
+    payload = _parse_skill_args(
+        gap, ("detect", "--scope", "local", "--severity-threshold", "CRITICAL")
+    )
+    request = ModelGapComputeRequest.model_validate(payload)
+    assert request.subcommand.value == "detect"
+    assert request.scope == "local"
+    assert request.severity_threshold.value == "CRITICAL"
 
 
 def test_command_writes_payload_under_state_root_not_tmp(


### PR DESCRIPTION
## Summary

Registers the `gap` skill in the declarative `skill_mapping.yaml` so
`onex skill gap ...` dispatches `node_gap_compute` via receipt mode. The gap
SKILL.md and the omnimarket `node_gap_compute` both already existed, but the
CLI rejected `onex skill gap` with `UnknownSkillError` because the skill was
absent from the declarative mapping.

This is a follow-up fix to OMN-13097 (Phase 4a dispatch-shim migration): the
`gap` skill was not among the original 24 migrated shims. The paired omnimarket
PR fixes the `node_gap_compute` contract operation field that the bus-dispatch
path requires.

## Changes

- `src/omnibase_infra/cli/skill_mapping.yaml`: add the `gap` mapping
  (positional `subcommand` + full flag surface) routed to `node_gap_compute`.
- `tests/unit/cli/test_cli_skill.py`: add `gap` to the expected-skills set, a
  routing test (`onex skill gap detect --scope local` -> `node_gap_compute`),
  and an omnimarket-optional payload-validation test (skipped when omnimarket
  is not installed, matching the existing omnimarket-optional tests in the
  suite).

## dod_evidence

- Pre-fix: the CLI raised `UnknownSkillError` for `gap`.
- Post-fix: `onex skill gap detect --scope local` routes to `node_gap_compute`.
- `tests/unit/cli/test_cli_skill.py`: 21 passed, 1 skipped.
- Branch rebased onto origin/dev which carries
  `0015_generation_corpus_acceptance.sql` (via #2044); the
  `ONEX Node Migration Vendor Sync Check` pre-commit hook now passes
  (`check: in sync`).

Evidence-Source: OCC#2823
Evidence-Ticket: OMN-13097

Paired OCC evidence: onex_change_control PR #2823 (carries the OMN-13097 contract + 6 dod receipts incl. deploy-gate evidence, re-bound to this PR).
