### PR TITLE
fix(OMN-13364): tolerate prefixed redpanda broker + preserve vendored migration tree on deploy-runtime restore

### DIFF
--- a/scripts/deploy-runtime.sh
+++ b/scripts/deploy-runtime.sh
@@ -155,6 +155,18 @@ fi
 # moved here as a backup. On success the backup is removed; on failure
 # cleanup_on_exit() restores it.
 FORCE_BACKUP_DIR=""
+# OMN-13364: path (relative to the deploy target) of the vendored forward-migration
+# tree. The backup-restore path in cleanup_on_exit() reverts the WHOLE deployment
+# tree, including freshly-built migrations, which silently regressed the deployed
+# migrations to the pre-build snapshot (dropped node_projection_delegation/
+# 0015_generation_corpus_acceptance.sql in the 2026-06-19 stability redeploy).
+# After a restore, the freshly-synced migration tree is re-applied from this
+# snapshot so the deployed migrations always match the build source (origin/dev).
+readonly MIGRATION_TREE_REL_PATH="docker/migrations/forward"
+# Absolute path to a preserved copy of the freshly-synced vendored migration
+# tree, captured after sync_files() (so the restore can re-apply it). Empty until
+# the snapshot is taken; the snapshot dir is removed on exit.
+MIGRATION_TREE_SNAPSHOT_DIR=""
 # Set to true only when ALL deployment phases complete successfully.
 # Used by cleanup_on_exit to determine if the --force backup can be safely removed.
 DEPLOYMENT_COMPLETE=false
@@ -991,6 +1003,13 @@ cleanup_on_exit() {
                 log_error "Manual recovery required: mv '${FORCE_BACKUP_DIR}' '${original_dir}'"
                 log_error "================================================================="
             else
+                # OMN-13364: the restored tree carries the PRE-BUILD vendored
+                # migration tree. Re-apply the freshly-synced migration tree
+                # (snapshot taken after sync_files) so the deployed migrations
+                # match the build source instead of silently regressing to the
+                # backup's stale snapshot (which dropped a forward migration in
+                # the 2026-06-19 stability redeploy).
+                restore_migration_tree_after_revert "${original_dir}"
                 log_warn "NOTE: registry.json may contain stale metadata (git_sha, deployed_at)"
                 log_warn "from the failed deployment. Verify or re-deploy to restore consistency."
             fi
@@ -1002,8 +1021,66 @@ cleanup_on_exit() {
         FORCE_BACKUP_DIR=""
     fi
 
+    # OMN-13364: remove the migration-tree snapshot taken after sync_files.
+    if [[ -n "${MIGRATION_TREE_SNAPSHOT_DIR}" && -d "${MIGRATION_TREE_SNAPSHOT_DIR}" ]]; then
+        rm -rf "${MIGRATION_TREE_SNAPSHOT_DIR}" 2>/dev/null || true
+    fi
+    MIGRATION_TREE_SNAPSHOT_DIR=""
+
     # Release concurrency lock
     rm -rf "${LOCK_DIR}" 2>/dev/null || true
+}
+
+snapshot_migration_tree() {
+    # Preserve a copy of the freshly-synced vendored forward-migration tree so a
+    # later backup-restore (cleanup_on_exit) can re-apply it instead of leaving
+    # the restored tree on the backup's stale, pre-build migrations (OMN-13364).
+    local deploy_target="$1"
+    local src_tree="${deploy_target}/${MIGRATION_TREE_REL_PATH}"
+
+    if [[ ! -d "${src_tree}" ]]; then
+        # No vendored migration tree to protect (e.g. a deployment layout that
+        # does not bind-mount forward migrations). Nothing to snapshot.
+        log_warn "No vendored migration tree at ${src_tree}; skipping snapshot."
+        return 0
+    fi
+
+    local snapshot_dir="${deploy_target}.migrations.snapshot"
+    rm -rf "${snapshot_dir}" 2>/dev/null || true
+    mkdir -p "${snapshot_dir}"
+    # Mirror the tree exactly so re-apply is a faithful copy of the build source.
+    rsync -a --delete "${src_tree}/" "${snapshot_dir}/"
+    MIGRATION_TREE_SNAPSHOT_DIR="${snapshot_dir}"
+    log_info "Snapshotted vendored migration tree for restore safety: ${snapshot_dir}"
+}
+
+restore_migration_tree_after_revert() {
+    # Re-apply the freshly-synced vendored migration tree onto a restored
+    # deployment tree so a backup-restore never silently regresses migrations to
+    # the backup's pre-build snapshot (OMN-13364).
+    local restored_dir="$1"
+
+    if [[ -z "${MIGRATION_TREE_SNAPSHOT_DIR}" || ! -d "${MIGRATION_TREE_SNAPSHOT_DIR}" ]]; then
+        # The failure happened before sync_files snapshotted the tree (e.g. an
+        # rsync/sanity failure). In that case nothing newer than the backup was
+        # produced, so the backup's migration tree is already the correct one.
+        log_warn "No migration-tree snapshot to re-apply; restored tree keeps the backup migrations."
+        return 0
+    fi
+
+    local dst_tree="${restored_dir}/${MIGRATION_TREE_REL_PATH}"
+    log_warn "Re-applying freshly-built vendored migration tree onto restored deployment:"
+    log_warn "  ${MIGRATION_TREE_SNAPSHOT_DIR}/ -> ${dst_tree}/"
+    mkdir -p "${dst_tree}"
+    if rsync -a --delete "${MIGRATION_TREE_SNAPSHOT_DIR}/" "${dst_tree}/"; then
+        log_warn "Migration tree re-applied: deployed migrations match the build source, not the backup."
+    else
+        log_error "================================================================="
+        log_error "CRITICAL: Failed to re-apply the vendored migration tree after restore!"
+        log_error "The restored deployment may carry STALE migrations (silent loss risk)."
+        log_error "Manual recovery: rsync -a --delete '${MIGRATION_TREE_SNAPSHOT_DIR}/' '${dst_tree}/'"
+        log_error "================================================================="
+    fi
 }
 
 # =============================================================================
@@ -1633,6 +1710,63 @@ build_images() {
 # Restart -- bring up runtime services only
 # =============================================================================
 
+resolve_broker_container() {
+    # Resolve the running broker container id/name for the given compose project.
+    #
+    # OMN-13364: the broker's fixed container_name (e.g. omnibase-infra-redpanda)
+    # is NOT a reliable handle — when it collides with another project's broker,
+    # Docker prefixes it with a random hash (3ed1fdb8d50b_omnibase-infra-redpanda).
+    # The compose service label (com.docker.compose.service=redpanda) survives
+    # the prefix, so resolve by compose project + service label instead of by an
+    # exact container-name string match.
+    local compose_project="$1"
+    docker ps -q \
+        --filter "label=com.docker.compose.project=${compose_project}" \
+        --filter "label=com.docker.compose.service=${BROKER_READINESS_SERVICE}" \
+        2>/dev/null \
+        | head -1
+}
+
+assert_broker_reachable() {
+    # Return 0 when the broker is actually reachable on the lane network.
+    #
+    # Keys readiness off `rpk cluster health` executed INSIDE the broker
+    # container (talking to the broker on TCP/9092 over the lane network), not
+    # off an exact container-name match or the compose-wait exit status. This is
+    # what lets the warmup tolerate a Docker-prefixed broker name and an
+    # already-present healthy broker without false-failing (OMN-13364).
+    local compose_project="$1"
+    local attempts="${BROKER_REACHABLE_RETRIES:-15}"
+    local interval="${BROKER_REACHABLE_INTERVAL:-4}"
+
+    local broker_container
+    broker_container="$(resolve_broker_container "${compose_project}")"
+    if [[ -z "${broker_container}" ]]; then
+        log_error "No running broker container found for project '${compose_project}'"
+        log_error "  (label com.docker.compose.service=${BROKER_READINESS_SERVICE})."
+        return 1
+    fi
+    log_info "Resolved broker container: ${broker_container} (probing reachability)"
+
+    local attempt=0
+    while (( attempt < attempts )); do
+        attempt=$((attempt + 1))
+        # rpk talks to the broker on the internal listener (redpanda:9092 / TCP).
+        # `cluster health` succeeding means the broker is reachable AND serving;
+        # that is the readiness signal the partition-cap rpk calls below need.
+        if docker exec "${broker_container}" \
+            rpk cluster health -X brokers=redpanda:9092 >/dev/null 2>&1; then
+            log_info "Broker reachable: rpk cluster health OK (attempt ${attempt})."
+            return 0
+        fi
+        log_info "  Broker not ready yet (attempt ${attempt}/${attempts}) -- waiting ${interval}s..."
+        sleep "${interval}"
+    done
+
+    log_error "Broker ${broker_container} did not become reachable after ${attempts} attempts."
+    return 1
+}
+
 warm_broker_topic_provisioning() {
     # Bring the broker + partition cap to readiness before the --no-deps runtime
     # restart so the cold-start topic-provisioning burst does not crash-loop the
@@ -1648,6 +1782,17 @@ warm_broker_topic_provisioning() {
     # 1. Ensure the broker itself is up and healthy. `up -d` is a no-op when it
     # is already running; the --wait flag blocks until the healthcheck passes so
     # the partition-cap rpk calls below do not race a still-starting broker.
+    #
+    # OMN-13364: the compose `up --wait` is best-effort, not the source of truth
+    # for broker readiness. When the broker container_name collides with another
+    # project's broker, Docker assigns a random prefix (e.g.
+    # 3ed1fdb8d50b_omnibase-infra-redpanda) and/or leaves the recreate in
+    # 'Created'; `up -d --wait` then errors or never reaches healthy even though
+    # a healthy broker is already reachable on the lane network. Do NOT treat
+    # that as a deploy failure (it would trigger the backup-restore path, which
+    # reverts the freshly-built vendored migration tree). Key broker readiness
+    # off ACTUAL reachability (`rpk cluster health` on TCP/9092 inside the lane)
+    # via assert_broker_reachable below, not off the compose-wait exit status.
     local broker_up_cmd=(
         docker compose
         -p "${compose_project}"
@@ -1658,7 +1803,19 @@ warm_broker_topic_provisioning() {
     )
     log_info "Ensuring broker is healthy: ${BROKER_READINESS_SERVICE}"
     log_cmd "${broker_up_cmd[*]}"
-    "${broker_up_cmd[@]}"
+    if ! "${broker_up_cmd[@]}"; then
+        log_warn "Broker compose up --wait did not report healthy (possible"
+        log_warn "name-prefix collision or already-present broker). Falling back"
+        log_warn "to a direct broker-reachability probe before deciding."
+    fi
+
+    # Source of truth: probe the broker directly. Tolerates a Docker-prefixed
+    # container name and an already-present healthy broker (OMN-13364).
+    if ! assert_broker_reachable "${compose_project}"; then
+        log_error "Broker is not reachable on the lane network after warmup."
+        log_error "Cold-start topic provisioning cannot proceed; aborting."
+        return 1
+    fi
 
     # 2. Apply the partition cap (run-to-completion). force-recreate re-runs the
     # one-shot even if a prior run left an exited container behind.
@@ -2116,6 +2273,11 @@ main() {
 
     # Phase 6: Sync
     sync_files "${repo_root}" "${deploy_target}"
+
+    # OMN-13364: snapshot the freshly-synced vendored migration tree so a later
+    # backup-restore (cleanup_on_exit) re-applies it instead of reverting the
+    # deployed migrations to the backup's stale, pre-build snapshot.
+    snapshot_migration_tree "${deploy_target}"
 
     # Mark deployment directory for cleanup on failure. If registry write or
     # build fails after rsync, cleanup_on_exit() will remove this orphaned

--- a/tests/scripts/test_deploy_runtime_warmup_restore.py
+++ b/tests/scripts/test_deploy_runtime_warmup_restore.py
@@ -1,0 +1,234 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Regression coverage for the OMN-13364 stability-redeploy fragility fixes.
+
+Two coupled deploy-runtime.sh defects, observed on the 2026-06-19 stability-test
+redeploy, are guarded here:
+
+1. Redpanda warmup false-fails on a prefixed-container-name conflict.
+   ``warm_broker_topic_provisioning()`` ran ``docker compose up -d --no-deps
+   --wait redpanda`` and treated the compose-wait exit status as the source of
+   truth for broker readiness. When the broker container_name collides with
+   another project's broker, Docker assigns a random prefix (e.g.
+   ``3ed1fdb8d50b_omnibase-infra-redpanda``) and/or leaves the recreate in
+   'Created'; ``up -d --wait`` then errors / never reaches healthy even though a
+   healthy broker is already reachable on the lane network. The warmup must key
+   readiness off ACTUAL broker reachability (``rpk cluster health`` against the
+   broker resolved by compose label, not by an exact container-name string), and
+   must tolerate a prefixed name and an already-present healthy broker.
+
+2. Backup-restore reverts the vendored forward-migration tree. On that false-fail
+   (with ``--force``), ``cleanup_on_exit()`` restores the WHOLE pre-build
+   deployment tree, including ``docker/migrations/forward/``, silently regressing
+   the deployed migrations to the backup's stale snapshot (it dropped
+   ``node_projection_delegation/0015_generation_corpus_acceptance.sql``). The
+   restore must re-apply the freshly-synced vendored migration tree so the
+   deployed migrations always match the build source (origin/dev), never silently
+   losing a forward migration.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEPLOY_SCRIPT = REPO_ROOT / "scripts" / "deploy-runtime.sh"
+MIGRATION_TREE = REPO_ROOT / "docker" / "migrations" / "forward"
+
+
+def _deploy_script_text() -> str:
+    return DEPLOY_SCRIPT.read_text(encoding="utf-8")
+
+
+def _deploy_script_noncomment() -> str:
+    """deploy-runtime.sh with comment-only lines stripped.
+
+    Assertions about *active* behavior must not be satisfied by a comment that
+    merely mentions the token, so the active-code checks run against this view.
+    """
+    lines = [
+        line
+        for line in _deploy_script_text().splitlines()
+        if not line.lstrip().startswith("#")
+    ]
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Fix 1: warmup tolerates a prefixed / already-healthy broker
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_broker_resolved_by_compose_label_not_exact_name() -> None:
+    """The broker must be resolved by compose label, surviving a Docker prefix.
+
+    A Docker name-prefix collision (3ed1fdb8d50b_omnibase-infra-redpanda) breaks
+    any exact container-name handle, but the compose service label survives. The
+    resolver must filter on com.docker.compose.service=<broker>, not match an
+    exact container_name string.
+    """
+    text = _deploy_script_noncomment()
+    assert "resolve_broker_container()" in text, (
+        "resolve_broker_container helper missing; the warmup would still key off "
+        "an exact container-name string that breaks under Docker's prefix-on-"
+        "collision behavior (OMN-13364)."
+    )
+    assert "label=com.docker.compose.service=${BROKER_READINESS_SERVICE}" in text, (
+        "Broker must be resolved by compose service label, not exact name."
+    )
+    assert "label=com.docker.compose.project=${compose_project}" in text, (
+        "Broker resolution must be scoped to the lane's compose project."
+    )
+
+
+@pytest.mark.unit
+def test_broker_readiness_keyed_off_rpk_cluster_health() -> None:
+    """Broker readiness must be probed via rpk cluster health, not compose-wait."""
+    text = _deploy_script_noncomment()
+    assert "assert_broker_reachable()" in text, (
+        "assert_broker_reachable helper missing; readiness would still depend on "
+        "the compose --wait exit status, which false-fails on a name collision."
+    )
+    assert "rpk cluster health" in text, (
+        "Broker readiness must be keyed off actual reachability (rpk cluster "
+        "health on TCP/9092 inside the lane), not an exact container-name match."
+    )
+
+
+@pytest.mark.unit
+def test_compose_wait_failure_is_tolerated_not_fatal() -> None:
+    """A failing compose `up --wait` must NOT abort the warmup by itself.
+
+    Under ``set -e`` an unguarded ``"${broker_up_cmd[@]}"`` aborts the script on
+    a name-prefix collision, which triggers the destructive backup-restore. The
+    call must be guarded so the reachability probe gets the final say.
+    """
+    text = _deploy_script_text()
+    match = re.search(
+        r"warm_broker_topic_provisioning\(\)\s*\{(?P<body>.*?)\n\}",
+        text,
+        re.DOTALL,
+    )
+    assert match is not None, "warm_broker_topic_provisioning function not found"
+    body = match.group("body")
+    # The broker compose-up must be guarded (if ! ...; then) rather than called
+    # bare, so its failure does not bubble up under set -e.
+    assert 'if ! "${broker_up_cmd[@]}"; then' in body, (
+        "The broker compose up --wait must be guarded so a name-prefix-collision "
+        "failure is tolerated and the rpk reachability probe decides readiness "
+        "(OMN-13364)."
+    )
+    # And the warmup must still hard-fail when the broker is genuinely unreachable.
+    assert "assert_broker_reachable" in body
+    assert "Broker is not reachable on the lane network after warmup." in body
+
+
+# ---------------------------------------------------------------------------
+# Fix 2: backup-restore preserves the vendored forward-migration tree
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_migration_tree_snapshotted_after_sync() -> None:
+    """The freshly-synced vendored migration tree must be snapshotted post-sync."""
+    text = _deploy_script_noncomment()
+    assert "snapshot_migration_tree()" in text, (
+        "snapshot_migration_tree helper missing; without a snapshot the restore "
+        "path cannot re-apply the freshly-built migrations (OMN-13364)."
+    )
+    # The snapshot must be taken right after sync_files in main().
+    sync_idx = text.find('sync_files "${repo_root}" "${deploy_target}"')
+    snap_idx = text.find('snapshot_migration_tree "${deploy_target}"')
+    assert sync_idx != -1, "sync_files is not called in main()"
+    assert snap_idx != -1, "snapshot_migration_tree is not called in main()"
+    assert sync_idx < snap_idx, (
+        "snapshot_migration_tree must run AFTER sync_files so it captures the "
+        "freshly-synced (build-source) migration tree, not the backup's."
+    )
+
+
+@pytest.mark.unit
+def test_restore_reapplies_migration_tree() -> None:
+    """cleanup_on_exit must re-apply the migration tree after a backup-restore."""
+    text = _deploy_script_text()
+    assert "restore_migration_tree_after_revert()" in text, (
+        "restore_migration_tree_after_revert helper missing; a backup-restore "
+        "would silently regress the deployed migrations to the pre-build "
+        "snapshot (OMN-13364)."
+    )
+    # The restore must be wired into the successful-restore branch of cleanup.
+    match = re.search(
+        r"cleanup_on_exit\(\)\s*\{(?P<body>.*?)\nsnapshot_migration_tree",
+        text,
+        re.DOTALL,
+    )
+    assert match is not None, "cleanup_on_exit function not found"
+    body = match.group("body")
+    # The re-apply call must follow a successful `mv` restore (the else branch).
+    restore_idx = body.find('restore_migration_tree_after_revert "${original_dir}"')
+    assert restore_idx != -1, (
+        "restore_migration_tree_after_revert must be called after a successful "
+        "backup-restore so the deployed migrations match the build source."
+    )
+
+
+@pytest.mark.unit
+def test_restore_uses_delete_to_match_build_source_exactly() -> None:
+    """The re-apply must use rsync --delete so the tree matches the build source.
+
+    A plain copy would leave stale files from the backup tree; --delete makes the
+    re-applied tree a faithful mirror of the freshly-built migration tree.
+    """
+    text = _deploy_script_text()
+    match = re.search(
+        r"restore_migration_tree_after_revert\(\)\s*\{(?P<body>.*?)\n\}",
+        text,
+        re.DOTALL,
+    )
+    assert match is not None, "restore_migration_tree_after_revert function not found"
+    body = match.group("body")
+    assert "rsync -a --delete" in body, (
+        "The migration-tree re-apply must rsync --delete so it mirrors the "
+        "build-source tree exactly (no stale files survive)."
+    )
+
+
+@pytest.mark.unit
+def test_snapshot_cleaned_up_on_exit() -> None:
+    """The migration-tree snapshot must be removed in cleanup_on_exit."""
+    text = _deploy_script_noncomment()
+    assert 'rm -rf "${MIGRATION_TREE_SNAPSHOT_DIR}"' in text, (
+        "The migration-tree snapshot dir must be cleaned up so deploys do not "
+        "accumulate orphaned snapshot trees."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Guard: the migration the revert dropped is actually in the source tree
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_dropped_delegation_migration_present_in_source() -> None:
+    """The forward migration the 2026-06-19 revert dropped must exist in source.
+
+    This is the file a backup-restore silently regressed away. If the vendored
+    migration tree ever stops carrying it, the snapshot/re-apply fix protects an
+    empty target — fail loudly so the regression is visible.
+    """
+    dropped = (
+        MIGRATION_TREE
+        / "nodes"
+        / "node_projection_delegation"
+        / "0015_generation_corpus_acceptance.sql"
+    )
+    assert dropped.is_file(), (
+        f"Expected vendored forward migration missing: {dropped}. The "
+        "snapshot/re-apply fix (OMN-13364) protects this tree; if it is gone the "
+        "deploy would have nothing to preserve."
+    )


### PR DESCRIPTION
## OMN-13364 — deploy-runtime.sh redpanda warmup false-fail + backup-restore reverts vendored migration tree

Fixes two coupled `deploy-runtime.sh` defects observed on the 2026-06-19 stability-test redeploy (bit two of the day's redeploys). Together they made every recent stability-test redeploy require manual broker surgery + manual migration rsync, and risked **silent migration loss**.

### Root cause

**1. Redpanda warmup false-fails on a prefixed-container-name conflict.**
`warm_broker_topic_provisioning()` ran `docker compose up -d --no-deps --wait redpanda` and keyed broker readiness off the compose-wait exit status. When the broker `container_name` collides with another project's broker, Docker assigns a random prefix (e.g. `3ed1fdb8d50b_omnibase-infra-redpanda`) and/or leaves the recreate in `Created`; `up -d --wait` then errors / never reaches healthy even though a healthy broker is already reachable on the lane network. The bare call aborted under `set -e`, triggering the destructive backup-restore.

**2. Backup-restore reverts the vendored forward-migration tree.**
On that failure (with `--force`), `cleanup_on_exit()` restored the WHOLE pre-build deployment tree — including `docker/migrations/forward/` (rsynced under `docker/` with `--delete`) — silently regressing deployed migrations to the backup's stale snapshot. It dropped `node_projection_delegation/0015_generation_corpus_acceptance.sql`, forcing a manual rsync of origin/dev vendored migrations + a manual force-recreate of the 4 runtime containers. A reverted migration tree means missing columns + a wedged fail-loud projection — the worse failure mode.

### Fix (root-cause, no band-aids)

- **Warmup tolerates prefixed / already-healthy broker.** The compose `up --wait` is now best-effort (guarded — its failure no longer aborts). Readiness is keyed off ACTUAL reachability via new `assert_broker_reachable()`, which resolves the broker by compose **service label** (`com.docker.compose.service=redpanda`, surviving a Docker name prefix) via `resolve_broker_container()` and probes `rpk cluster health` on TCP/9092 inside the lane. A prefixed name and an already-present healthy broker no longer false-fail; only a genuinely unreachable broker aborts.
- **Restore preserves the vendored migration tree.** `snapshot_migration_tree()` captures the freshly-synced vendored migration tree right after `sync_files`; `restore_migration_tree_after_revert()` re-applies it (`rsync -a --delete`) onto the restored tree so deployed migrations always match the build source (origin/dev), never silently losing a forward migration. The snapshot is cleaned up on exit.
- **Container-name collision root.** The dev `docker-compose.infra.yml` broker is `omnibase-infra-redpanda`; the stability-test overlay already scopes it (`omnibase-infra-stability-test-redpanda`). The real defect was keying off the name; resolving by compose label is collision-proof, so no `container_name` change is needed (and changing it would break tooling that references the broker by exact name).

### Tests / guards

`tests/scripts/test_deploy_runtime_warmup_restore.py` — 8 shell-asserting regression tests:
- broker resolved by compose label (not exact name); readiness keyed off `rpk cluster health`; compose-wait failure tolerated (guarded `if ! ...`) but a truly-unreachable broker still aborts.
- migration tree snapshotted after `sync_files`; re-applied after a backup-restore with `rsync --delete`; snapshot cleaned up on exit; the dropped `0015_…` migration is present in source.

### Verification

- `shellcheck scripts/deploy-runtime.sh` — clean (gate is wired for this surface).
- `uv run pytest tests/scripts/test_deploy_runtime_warmup_restore.py tests/scripts/test_deploy_runtime_coldstart.py tests/scripts/test_deploy_runtime_build_context.py tests/scripts/test_deploy_runtime_no_env_file.py tests/scripts/test_deploy_runtime_prod_lineage.py` — 35 passed.
- `pre-commit run --files scripts/deploy-runtime.sh tests/scripts/test_deploy_runtime_warmup_restore.py` — all hooks pass.

### Scope / safety

CODE-ONLY PR. A separate live broker-recovery run is in flight on .201 — this PR does **not** mutate .201. Worktree off dev; PR targets dev.

### dod_evidence

- Code: `scripts/deploy-runtime.sh` (new `resolve_broker_container`, `assert_broker_reachable`, `snapshot_migration_tree`, `restore_migration_tree_after_revert`; guarded compose-wait; wired into `main()` + `cleanup_on_exit()`).
- Regression test: `tests/scripts/test_deploy_runtime_warmup_restore.py` (8 tests, all passing).
- Lint/format/shellcheck/pre-commit green locally.

Parent epic: OMN-12651 (Runtime Deployment & Topic/Consumer-Group Provisioning).

Closes OMN-13364.



Evidence-Source: OCC#2825
Evidence-Ticket: OMN-13364
