### PR TITLE
fix(OMN-13372): vendor delegation projection migrations

### DIFF
--- a/docker/migrations/forward/nodes/node_projection_delegation/0016_delegation_judge_verdict_events.sql
+++ b/docker/migrations/forward/nodes/node_projection_delegation/0016_delegation_judge_verdict_events.sql
@@ -1,0 +1,42 @@
+-- OMN-13367: persist controlled, reproducible, auditable judge verdict events
+-- for non-verifiable delegation classes.
+--
+-- The event hash is the idempotency key for replay. Judge failures are stored
+-- as typed judge_failed verdicts with actual_score NULL; they are not coerced
+-- into a silent 0.0 score.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS delegation_judge_verdict_events (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    event_hash TEXT NOT NULL UNIQUE,
+    correlation_id TEXT NOT NULL,
+    task_type TEXT NOT NULL,
+    score_source TEXT NOT NULL DEFAULT 'reproducible_judge',
+    judge_model TEXT NOT NULL,
+    judge_model_version TEXT NOT NULL,
+    judge_provider TEXT NOT NULL,
+    rubric_id TEXT NOT NULL,
+    rubric_hash TEXT NOT NULL,
+    prompt_hash TEXT NOT NULL,
+    input_hash TEXT NOT NULL,
+    temperature NUMERIC(5, 3) NOT NULL,
+    judge_node_version TEXT NOT NULL,
+    reasoning_hash TEXT NOT NULL,
+    verdict TEXT NOT NULL,
+    actual_score NUMERIC(5, 3),
+    failure_kind TEXT,
+    failure_message TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CHECK (
+        (verdict = 'judge_failed' AND actual_score IS NULL AND failure_kind IS NOT NULL AND failure_message IS NOT NULL)
+        OR
+        (verdict <> 'judge_failed' AND actual_score IS NOT NULL AND failure_kind IS NULL AND failure_message IS NULL)
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_delegation_judge_verdict_events_correlation_id
+    ON delegation_judge_verdict_events (correlation_id);
+
+CREATE INDEX IF NOT EXISTS idx_delegation_judge_verdict_events_verdict
+    ON delegation_judge_verdict_events (verdict);

--- a/docker/migrations/forward/nodes/node_projection_delegation/0016_delegation_quality_bar_evidence.sql
+++ b/docker/migrations/forward/nodes/node_projection_delegation/0016_delegation_quality_bar_evidence.sql
@@ -1,0 +1,114 @@
+-- OMN-13368: persist score-vs-required-bar authority evidence on delegation rows.
+--
+-- Delegation escalation now routes on actual_score < required_bar. These columns
+-- make the decision materialized and queryable through the contract-declared
+-- projection API instead of hiding it in logs or client state.
+
+ALTER TABLE delegation_events
+    ADD COLUMN IF NOT EXISTS required_bar NUMERIC(5, 3),
+    ADD COLUMN IF NOT EXISTS actual_score NUMERIC(5, 3),
+    ADD COLUMN IF NOT EXISTS escalation_count INT NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS authority_source TEXT,
+    ADD COLUMN IF NOT EXISTS score_source TEXT,
+    ADD COLUMN IF NOT EXISTS request_override_applied BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS override_within_bounds BOOLEAN NOT NULL DEFAULT TRUE;
+
+CREATE INDEX IF NOT EXISTS idx_delegation_events_score_vs_bar
+    ON delegation_events (required_bar, actual_score);
+
+CREATE OR REPLACE VIEW projection_delegation_quality_gate AS
+WITH totals AS (
+    SELECT
+        COUNT(*) FILTER (WHERE quality_gate_passed IS NOT NULL)::int AS total_checks,
+        COUNT(*) FILTER (WHERE quality_gate_passed IS TRUE)::int AS total_passed,
+        COUNT(*) FILTER (WHERE quality_gate_passed IS FALSE)::int AS total_failed,
+        COALESCE(SUM(escalation_count), 0)::int AS total_escalations,
+        COALESCE(AVG(NULLIF(tokens_to_compliance, 0)), 0)::float
+            AS avg_tokens_to_compliance,
+        percentile_cont(0.5) WITHIN GROUP (
+            ORDER BY NULLIF(tokens_to_compliance, 0)
+        ) AS median_tokens_to_compliance,
+        COALESCE(AVG(NULLIF(compliance_attempts, 0)), 1)::float
+            AS avg_compliance_attempts,
+        COALESCE(AVG(actual_score), 0)::float AS avg_actual_score,
+        COALESCE(AVG(required_bar), 0)::float AS avg_required_bar,
+        MAX(created_at) AS latest_projection_updated_at
+    FROM delegation_events
+),
+failure_categories AS (
+    SELECT COALESCE(
+        jsonb_agg(
+            jsonb_build_object(
+                'category', quality_gate_detail,
+                'count', failed_count,
+                'pct_of_failures', CASE WHEN totals.total_failed > 0
+                    THEN failed_count::float / totals.total_failed ELSE 0 END
+            )
+            ORDER BY failed_count DESC
+        ),
+        '[]'::jsonb
+    ) AS rows
+    FROM (
+        SELECT quality_gate_detail, COUNT(*)::int AS failed_count
+        FROM delegation_events
+        WHERE quality_gate_detail IS NOT NULL
+          AND NOT quality_gate_passed
+        GROUP BY quality_gate_detail
+    ) failures
+    CROSS JOIN totals
+),
+tokens_by_model AS (
+    SELECT COALESCE(
+        jsonb_agg(
+            jsonb_build_object(
+                'model_name', model_name,
+                'avg_tokens', avg_tokens,
+                'avg_attempts', avg_attempts,
+                'sample_count', sample_count
+            )
+            ORDER BY avg_tokens DESC
+        ),
+        '[]'::jsonb
+    ) AS rows
+    FROM (
+        SELECT
+            COALESCE(NULLIF(model_name, ''), delegated_to) AS model_name,
+            COALESCE(AVG(NULLIF(tokens_to_compliance, 0)), 0)::float AS avg_tokens,
+            COALESCE(AVG(NULLIF(compliance_attempts, 0)), 1)::float AS avg_attempts,
+            COUNT(*)::int AS sample_count
+        FROM delegation_events
+        GROUP BY COALESCE(NULLIF(model_name, ''), delegated_to)
+    ) by_model
+)
+SELECT
+    CASE WHEN totals.total_checks > 0
+        THEN totals.total_passed::float / totals.total_checks ELSE 0 END
+        AS overall_pass_rate,
+    totals.total_passed,
+    totals.total_failed,
+    totals.total_checks,
+    totals.total_escalations AS escalation_count,
+    CASE WHEN totals.total_checks > 0
+        THEN totals.total_escalations::float / totals.total_checks ELSE 0 END
+        AS escalation_rate,
+    totals.avg_actual_score,
+    totals.avg_required_bar,
+    jsonb_build_array(jsonb_build_object(
+        'check_type', 'score_vs_required_bar',
+        'passed', totals.total_passed,
+        'failed', totals.total_failed,
+        'total', totals.total_checks,
+        'pass_rate', CASE WHEN totals.total_checks > 0
+            THEN totals.total_passed::float / totals.total_checks ELSE 0 END
+    )) AS by_check_type,
+    failure_categories.rows AS failure_categories,
+    totals.avg_tokens_to_compliance,
+    totals.median_tokens_to_compliance,
+    totals.avg_compliance_attempts,
+    tokens_by_model.rows AS tokens_to_compliance_by_model,
+    COALESCE(totals.latest_projection_updated_at, NOW()) AS captured_at,
+    TRUE AS provisioned,
+    totals.latest_projection_updated_at
+FROM totals
+CROSS JOIN failure_categories
+CROSS JOIN tokens_by_model;


### PR DESCRIPTION
## Summary

- Vendors the current omnimarket `node_projection_delegation` migrations into `docker/migrations/forward/nodes/node_projection_delegation/`.
- Adds the missing judge-verdict and quality-bar evidence migrations to the dev deploy bundle so forward migration can create `delegation_judge_verdict_events` and the `delegation_events.required_bar` / `actual_score` / `escalation_count` columns.

## Live dev evidence

Delegation e2e correlation ID `cb2feaf2-d4c0-4345-96f5-a047712a43d7` reached terminal events after OMN-13371:

- `delegation-request` consumed
- routing selected `Qwen3.6-35B-A3B`
- inference succeeded
- quality gate emitted `passed=True score=1.000`
- `onex.evt.omnibase-infra.delegation-completed.v1` published
- no DLQ hit for the correlation ID

Projection then failed because the deployed vendored migration tree stopped at `0015`:

```text
Projection handler error: handler=HandlerProjectionDelegation topic=onex.evt.omnibase-infra.delegation-completed.v1 error_type=UndefinedColumn error=column "required_bar" of relation "delegation_events" does not exist
```

## Verification

- `OMNIMARKET_SRC="$OMNI_HOME/omni_worktrees/OMN-13372/omnimarket" scripts/sync-node-migrations.sh --check` passed.
- `uv run python scripts/validation/validate_migration_sequence.py` passed.
- `uv run pre-commit run --files docker/migrations/forward/nodes/node_projection_delegation/0016_delegation_judge_verdict_events.sql docker/migrations/forward/nodes/node_projection_delegation/0016_delegation_quality_bar_evidence.sql` passed.

Full `pre-commit run --all-files` is currently blocked by unrelated existing repository-wide hook debt (`transport-mock-lint` in `src/omnibase_infra/services/observability/agent_actions/tests/test_consumer.py` and SPDX header mismatches in unrelated files). This PR was restored to only the two vendored SQL files after the all-files auto-fix attempt.

Evidence-Source: OCC#2836
Evidence-Ticket: OMN-13372
