### PR TITLE
fix(OMN-13360): gate projection terminal on rows_upserted>=1 (no false-positive terminal)

### DIFF
--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -1239,6 +1239,31 @@ def _is_projection_runner_handler(handler_instance: object) -> bool:
     )
 
 
+def _extract_rows_upserted(result: object) -> int:
+    """Extract the rows-written count from a projection handler's return value.
+
+    OMN-13360: the projection terminal event must be gated on a real write.
+    Projection handlers return either a ModelProjectionResult-shaped mapping
+    (``{"rows_upserted": N, ...}``) or a runner-shim mapping (``{"projected":
+    bool}``). This narrows both to an integer row count:
+
+    - ``rows_upserted`` present -> coerce to int (the authoritative count).
+    - only ``projected`` present (runner shim) -> 1 when truthy, else 0. The
+      standalone runner returns ``{"projected": bool}`` where True already means
+      a row was committed (its DB execute path raises on failure).
+    - anything else -> 0 (no provable write; terminal must NOT be emitted).
+    """
+    if isinstance(result, dict):
+        if "rows_upserted" in result:
+            try:
+                return int(result["rows_upserted"])
+            except (TypeError, ValueError):
+                return 0
+        if "projected" in result:
+            return 1 if bool(result["projected"]) else 0
+    return 0
+
+
 def _make_projection_dispatch_callback(
     handler_instance: object,
     db_tables: list[dict[str, str]],
@@ -1318,13 +1343,36 @@ def _make_projection_dispatch_callback(
             result = await asyncio.to_thread(_invoke_projection_handler)
             if asyncio.iscoroutine(result):
                 result = await cast("Awaitable[object]", result)
-            projected = True
-            logger.debug(
-                "Projection handler completed: topic=%s event_type=%s result=%s",
-                topic,
-                event_type,
-                result,
-            )
+            # OMN-13360 (deterministic-truth gate): the terminal
+            # `projection-delegation-applied.v1` event asserts that a durable row
+            # landed, so it must be gated on the handler's actual write outcome —
+            # not merely on `handle()` not raising. The projection handler returns
+            # ModelProjectionResult.model_dump() carrying rows_upserted (0 or 1+);
+            # a zero-row / internally-swallowed path returns normally and would
+            # otherwise emit a false-positive `projected:true`. Gate on
+            # rows_upserted >= 1 and log loudly when a no-raise handler wrote zero
+            # rows so the failure surfaces instead of being masked.
+            rows_upserted = _extract_rows_upserted(result)
+            projected = rows_upserted >= 1
+            if projected:
+                logger.debug(
+                    "Projection handler completed: topic=%s event_type=%s "
+                    "rows_upserted=%s result=%s",
+                    topic,
+                    event_type,
+                    rows_upserted,
+                    result,
+                )
+            else:
+                logger.error(
+                    "Projection handler wrote zero rows (no terminal emitted): "
+                    "handler=%s topic=%s event_type=%s rows_upserted=%s result=%s",
+                    type(handler_instance).__name__,
+                    topic or "unknown",
+                    event_type,
+                    rows_upserted,
+                    result,
+                )
         except TypeError as exc:
             logger.error(
                 "Projection handler TypeError (likely missing _db or _event_type): "

--- a/tests/unit/runtime/auto_wiring/test_handler_wiring_db_injection.py
+++ b/tests/unit/runtime/auto_wiring/test_handler_wiring_db_injection.py
@@ -527,6 +527,56 @@ def test_projection_callback_emits_terminal_event_on_success() -> None:
 
 
 @pytest.mark.unit
+def test_projection_callback_does_not_emit_terminal_event_on_zero_rows() -> None:
+    """OMN-13360: a handler that returns rows_upserted=0 must NOT emit a terminal.
+
+    The projection terminal asserts a durable row landed. A no-raise handler that
+    upserts zero rows (internal swallow / dedup no-op / failed-but-unraised write)
+    returns normally; the prior gate emitted `projected:true` regardless. Gating
+    on rows_upserted >= 1 makes that zero-row path produce NO terminal event.
+    """
+    import uuid
+
+    published: list[tuple] = []
+
+    class ZeroRowHandler:
+        def handle(self, input_data: dict) -> dict:
+            # No exception, but nothing was written.
+            return {"rows_upserted": 0, "table": "delegation_events"}
+
+    class FakeEventBus:
+        async def publish(self, topic: str, key: object, value: bytes) -> None:
+            published.append((topic, key, value))
+
+    db_tables = [{"name": "delegation_events", "database": "omnidash_analytics"}]
+    terminal_topic = "onex.evt.omnimarket.projection-delegation-applied.v1"
+    callback = _make_projection_dispatch_callback(
+        ZeroRowHandler(),
+        db_tables,
+        ("onex.evt.omniclaude.task-delegated.v1",),
+        event_bus=FakeEventBus(),
+        terminal_event=terminal_topic,
+    )
+
+    envelope = MagicMock()
+    envelope.topic = "onex.evt.omniclaude.task-delegated.v1"
+    envelope.payload = {"task_type": "code-review"}
+    envelope.correlation_id = uuid.uuid4()
+    fake_adapter = MagicMock()
+
+    with patch(
+        _PATCH_ENVIRON_GET,
+        return_value="postgresql://user:pass@host:5432/omnidash_analytics",
+    ):
+        with patch(_PATCH_BUILD_ADAPTER, return_value=fake_adapter):
+            asyncio.run(callback(envelope))
+
+    assert published == [], (
+        "Zero-row projection must not emit a projected:true terminal event"
+    )
+
+
+@pytest.mark.unit
 def test_projection_callback_emits_terminal_event_from_materialized_dict() -> None:
     """Terminal event correlation is extracted from materialized dispatch dicts."""
     import json


### PR DESCRIPTION
## Summary
- Gate projection terminal events on `rows_upserted >= 1` so a no-op projection write cannot produce a false-positive terminal state.
- Preserves the Gate-Zero projection chain behavior while requiring durable row evidence before terminal completion.

## Verification
- CI checks on PR head passed before merge-queue entry.
- Deploy Gate passed after central OCC evidence merged.
- Dispatcher Route Coverage passed after rerun.
- Receipt Gate is backed by central OCC evidence for OMN-13360.

Evidence-Source: OCC#2839
Evidence-Ticket: OMN-13360

Verification notes: docs/evidence/2026-06-19-gate-zero/reducer-wiring.md item 3; dev probe row proof in docs/evidence/2026-06-19-gate-zero/2026-06-20-dev-probe-row-proof.md.

Closes OMN-13360.