### PR TITLE
ci(OMN-12562): throttle CR thread gate triggers

### DIFF
--- a/.github/workflows/cr-thread-gate-caller.yml
+++ b/.github/workflows/cr-thread-gate-caller.yml
@@ -17,8 +17,17 @@ jobs:
   gate:
     if: >-
       github.event_name == 'merge_group' ||
-      ((github.event_name != 'issue_comment' || github.event.issue.pull_request != null) &&
-      github.actor != 'dependabot[bot]')
+      (github.event_name == 'pull_request' &&
+      github.actor != 'dependabot[bot]') ||
+      (((github.event_name == 'issue_comment' && github.event.issue.pull_request != null) ||
+      github.event_name == 'pull_request_review' ||
+      github.event_name == 'pull_request_review_comment') &&
+      github.actor != 'dependabot[bot]' &&
+      github.actor != 'github-actions[bot]' &&
+      !contains(github.actor, 'coderabbit'))
+    concurrency:
+      group: cr-thread-gate-${{ github.event.pull_request.number || github.event.issue.number || github.event.merge_group.head_sha || github.run_id }}
+      cancel-in-progress: true
     uses: OmniNode-ai/omniclaude/.github/workflows/cr-thread-gate.yml@main
     with:
       pr-number: ${{ format('{0}', github.event.pull_request.number || github.event.issue.number || 0) }}


### PR DESCRIPTION
## Summary
- keep CR Thread Gate running on PR head updates and merge-group requests
- skip bot-originated CodeRabbit/GitHub comment-review events before they allocate the reusable self-hosted gate job
- add per-PR job concurrency so rapid human review/comment bursts collapse to the latest runnable gate job

Evidence-Source: OCC#2840
Evidence-Ticket: OMN-12562

## Verification
- `actionlint .github/workflows/cr-thread-gate-caller.yml`
- `pre-commit run --files .github/workflows/cr-thread-gate-caller.yml`
- `git diff --check`

## Notes
- Auto-merge is not armed.
- Residual risk: skipped CodeRabbit bot events will not refresh a previously failing gate; human review/comment updates, PR head changes, manual reruns, and merge-group checks still run the required gate.