### PR TITLE
feat(OMN-13355): vendor premium-counterfactual delegation_events migration (0017)

### DIFF
--- a/docker/migrations/forward/nodes/node_projection_delegation/0017_premium_counterfactual.sql
+++ b/docker/migrations/forward/nodes/node_projection_delegation/0017_premium_counterfactual.sql
@@ -1,0 +1,16 @@
+-- OMN-13355: persist the pinned premium counterfactual on delegation_events rows.
+--
+-- When a cheaper tier serves a delegated task the premium (frontier) model never
+-- runs, so the saving is a modeled counterfactual, not a measurement. The
+-- projection now carries the pinned counterfactual provenance
+-- {model, price_in_per_1k, price_out_per_1k, as_of, tokens_in, tokens_out,
+-- counterfactual_cost_usd, pricing_source, measured} as a single JSONB column so
+-- the saving (cost_savings_usd = counterfactual_cost_usd - cost_usd) is auditable
+-- and recomputable from the persisted provenance. There is no live premium API
+-- call — the price/as_of come from the canonical pricing manifest.
+--
+-- Idempotent ADD COLUMN IF NOT EXISTS so warm dev/stability volumes that already
+-- contain delegation_events reconcile cleanly.
+
+ALTER TABLE delegation_events
+    ADD COLUMN IF NOT EXISTS premium_counterfactual JSONB;

--- a/tests/unit/migrations/test_node_migration_discovery.py
+++ b/tests/unit/migrations/test_node_migration_discovery.py
@@ -113,6 +113,27 @@ class TestVendoredViewMigrations:
         assert "0012_generation_output_columns.sql" in files
         assert "0013_generation_proof_fields.sql" in files
 
+    def test_premium_counterfactual_migration_vendored(self) -> None:
+        """OMN-13355: the pinned premium-counterfactual column migration is vendored.
+
+        The auditable saving (counterfactual - actual) is persisted as a JSONB
+        column on delegation_events. The node-owned migration must be vendored so
+        a clean clone materializes the column under the forward-migration runner.
+        """
+        migration = (
+            NODES_DIR / "node_projection_delegation" / "0017_premium_counterfactual.sql"
+        )
+        assert migration.is_file(), (
+            "0017_premium_counterfactual.sql must be vendored under "
+            "docker/migrations/forward/nodes/node_projection_delegation/ "
+            "(run scripts/sync-node-migrations.sh)"
+        )
+        sql = migration.read_text(encoding="utf-8")
+        assert (
+            "ALTER TABLE delegation_events" in sql
+            and "ADD COLUMN IF NOT EXISTS premium_counterfactual JSONB" in sql
+        )
+
     def test_delegation_base_migration_repairs_warm_table_shape(self) -> None:
         """Base migration must be safe when delegation_events already exists."""
         migration = (


### PR DESCRIPTION
## OMN-13355 — Auditable premium counterfactual (deploy migration)

Evidence-Source: OCC#2845
Evidence-Ticket: OMN-13355

Part 3 of 4 (omnibase_infra). Vendors the node-owned migration that adds the
auditable premium-counterfactual column to `delegation_events`.

### What

`docker/migrations/forward/nodes/node_projection_delegation/0017_premium_counterfactual.sql`:

```sql
ALTER TABLE delegation_events
    ADD COLUMN IF NOT EXISTS premium_counterfactual JSONB;
```

Vendored via the canonical `scripts/sync-node-migrations.sh` path (no hand-copy, no
renumber). The forward-migration runner applies it under the namespaced id
`node:node_projection_delegation:0017_premium_counterfactual.sql`.

The column stores the pinned counterfactual `{model, price_in_per_1k, price_out_per_1k,
as_of, tokens_in, tokens_out, counterfactual_cost_usd, pricing_source, measured}` so the
delegation saving (counterfactual - actual) is auditable from the projection row.

### Cross-repo sequencing

The migration source-of-truth is the omnimarket node (sibling PR adds
`0017_premium_counterfactual.sql` under `src/omnimarket/nodes/node_projection_delegation/
migrations/`). The `ONEX Node Migration Vendor Sync Check` resolves omnimarket via
`$OMNIMARKET_SRC`/`$OMNI_HOME/omnimarket`; it passes once the omnimarket migration is
present in the resolved source tree. Land the omnimarket PR (or have its source resolvable)
so the sync check is green here.

### Tests

`tests/unit/migrations/test_node_migration_discovery.py::test_premium_counterfactual_migration_vendored`
asserts the migration is vendored and declares the JSONB column. All 17 migration
discovery tests pass locally (with omnimarket source resolvable).

PRs no-merge — left green for the merge sweep.

