### PR TITLE
fix(OMN-13362): drop stale delegation_events decoy; canonicalize on omnidash_analytics

### DIFF
--- a/contracts/OMN-13362.yaml
+++ b/contracts/OMN-13362.yaml
@@ -1,0 +1,38 @@
+schema_version: "1.0.0"
+ticket_id: "OMN-13362"
+title: "Resolve dual delegation_events tables — drop the stale omnibase_infra decoy"
+summary: >
+  delegation_events existed in TWO databases on .201: omnidash_analytics (live, canonical writer — node_projection_delegation) and omnibase_infra (stale decoy, ~40 rows, last write 2026-05-13, read by nothing). Querying the decoy produced the 2026-06-19 Gate-Zero misdiagnosis. Forward migration 087 drops the decoy from the omnibase_infra DB so omnidash_analytics is the single canonical delegation_events. The migration runs in the flat infra sequence against POSTGRES_DB=omnibase_infra, so it can only hit the decoy, never the live copy in the separate omnidash_analytics DB. Also re-vendors the omnimarket node-migration tree to clear pre-existing capsule_store vendoring drift so the node-migration-sync gate is green.
+
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-001"
+    description: "Migration sequence validator passes with the new flat migration 087 (no duplicate sequence numbers)."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run python scripts/validation/validate_migration_sequence.py"
+  - id: "dod-002"
+    description: "Node-migration vendor tree is in sync with omnimarket dev (sync-node-migrations --check passes)."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "OMNIMARKET_SRC=$OMNI_HOME/omnimarket bash scripts/sync-node-migrations.sh --check"
+  - id: "dod-003"
+    description: "Migration discovery + sentinel unit tests green."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/unit/migrations/test_node_migration_discovery.py tests/unit/runtime/test_migration_sentinel.py -q"
+  - id: "dod-deploy"
+    description: "Deploy-gate evidence: 087 is an idempotent DROP TABLE IF EXISTS on the stale decoy in the omnibase_infra DB; applied by the canonical forward-migration runner on the next redeploy. REQUIRED_PROJECTION_TABLES checks target omnidash_analytics (the live table), so the drop does not break the migration gate."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "echo 'deploy-gate: OMN-13362 drops a stale unread decoy table via idempotent DROP TABLE IF EXISTS in the flat infra migration sequence (omnibase_infra DB); live delegation_events in omnidash_analytics is untouched'"

--- a/docker/migrations/forward/087_drop_stale_delegation_events_decoy.sql
+++ b/docker/migrations/forward/087_drop_stale_delegation_events_decoy.sql
@@ -1,0 +1,24 @@
+-- OMN-13362: drop the stale `delegation_events` decoy from the omnibase_infra DB.
+--
+-- The canonical delegation projection (node_projection_delegation, omnimarket)
+-- writes to `omnidash_analytics.delegation_events` — that is the live, growing
+-- table, applied through the node-owned migration tree under
+-- docker/migrations/forward/nodes/node_projection_delegation/ with
+-- NODE_POSTGRES_DB=omnidash_analytics (run-forward-migrations.sh).
+--
+-- A SECOND `delegation_events` exists in the `omnibase_infra` DB itself. It is a
+-- historical artifact from before the node-migration runner was repointed to
+-- omnidash_analytics: at that time NODE_POSTGRES_DB defaulted to POSTGRES_DB
+-- (=omnibase_infra), so the node migrations created the table there too. That
+-- copy stopped receiving writes (last write 2026-05-13, ~40 rows) and is read by
+-- nothing — but querying it is exactly what produced the 2026-06-19 Gate-Zero
+-- misdiagnosis ("writes stopped May 13"). Evidence:
+-- docs/evidence/2026-06-19-gate-zero/runtime-201.md.
+--
+-- This migration runs in the flat infra sequence against POSTGRES_DB
+-- (=omnibase_infra), so the DROP targets the decoy, never the live
+-- omnidash_analytics copy (a different database the flat runner never touches).
+-- No flat infra migration and no infra source reads delegation_events from the
+-- omnibase_infra DB, so the drop is safe. Idempotent for already-cleaned volumes.
+
+DROP TABLE IF EXISTS public.delegation_events;

--- a/docker/migrations/forward/nodes/node_projection_capsule_store/078_create_capsule_store.sql
+++ b/docker/migrations/forward/nodes/node_projection_capsule_store/078_create_capsule_store.sql
@@ -1,0 +1,64 @@
+-- OMN-12842 (M2): durable, scored capsule/exemplar store projection.
+--
+-- A capsule is identified by a deterministic capsule_hash; a changed exemplar
+-- (different content / commit / artifact / schema_version) is a NEW row, never
+-- an in-place mutation. Effectiveness is populated from context-ROI score
+-- events and is NEVER empty on a scored row -- enforced by a CHECK constraint,
+-- not a comment. Raw scored values are immutable in this base table; staleness
+-- decay is applied at read time by the projection read view.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS capsule_store (
+    capsule_id UUID PRIMARY KEY,
+    capsule_hash TEXT NOT NULL,
+    factor TEXT NOT NULL,
+    source_commit TEXT NOT NULL,
+    source_artifact TEXT NOT NULL,
+    schema_version TEXT NOT NULL,
+    validity_scope TEXT NOT NULL,
+    success_rate NUMERIC(6, 5) NOT NULL
+        CHECK (success_rate >= 0 AND success_rate <= 1),
+    first_pass_rate NUMERIC(6, 5) NOT NULL
+        CHECK (first_pass_rate >= 0 AND first_pass_rate <= 1),
+    cost_per_success NUMERIC(18, 6) NOT NULL CHECK (cost_per_success >= 0),
+    hit_count BIGINT NOT NULL CHECK (hit_count >= 1),
+    last_scored TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    -- "No empty effectiveness fields" encoded in the schema: a scored row
+    -- (hit_count >= 1) must carry all effectiveness values. The NOT NULL
+    -- columns already guarantee this; the explicit constraint documents and
+    -- enforces the scored-row invariant for future nullable migrations.
+    CONSTRAINT capsule_store_scored_effectiveness_non_null
+        CHECK (
+            hit_count >= 1
+            AND success_rate IS NOT NULL
+            AND first_pass_rate IS NOT NULL
+            AND cost_per_success IS NOT NULL
+            AND last_scored IS NOT NULL
+        )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_capsule_identity
+    ON capsule_store (capsule_hash);
+
+CREATE INDEX IF NOT EXISTS ix_capsule_store_factor_scope
+    ON capsule_store (factor, validity_scope);
+
+CREATE OR REPLACE FUNCTION refresh_capsule_store_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_capsule_store_updated_at ON capsule_store;
+CREATE TRIGGER trg_capsule_store_updated_at
+    BEFORE UPDATE ON capsule_store
+    FOR EACH ROW
+    EXECUTE FUNCTION refresh_capsule_store_updated_at();
+-- The decay read view (projection_capsule_effectiveness) is created in the
+-- next migration (079) so the base table exists before any view that reads it
+-- (enforced by scripts/ci/check_migration_base_before_view.py, OMN-12942).

--- a/docker/migrations/forward/nodes/node_projection_capsule_store/079_create_capsule_effectiveness_view.sql
+++ b/docker/migrations/forward/nodes/node_projection_capsule_store/079_create_capsule_effectiveness_view.sql
@@ -1,0 +1,65 @@
+-- OMN-12842 (M2): capsule effectiveness read view with staleness decay.
+--
+-- Applies staleness decay to the immutable raw scores. Raw scored values stay
+-- immutable in capsule_store; effective_* are computed at read time as
+-- raw * max(floor, 0.5 ** (age_days / half_life_days)). Decay parameters mirror
+-- contract.yaml config.decay (half_life_days=30.0, floor=0.25); the contract is
+-- the authority, this view keeps the dashboard read surface aligned and ranks
+-- by effective_first_pass_rate DESC per (factor, validity_scope).
+--
+-- The base table capsule_store is created in 078; ordering this view in a later
+-- migration satisfies the base-table-before-view gate
+-- (scripts/ci/check_migration_base_before_view.py, OMN-12942).
+
+CREATE OR REPLACE VIEW projection_capsule_effectiveness AS
+WITH decay_params AS (
+    SELECT 30.0::float AS half_life_days, 0.25::float AS floor
+),
+scored AS (
+    SELECT
+        c.capsule_id,
+        c.capsule_hash,
+        c.factor,
+        c.validity_scope,
+        c.source_commit,
+        c.source_artifact,
+        c.schema_version,
+        c.success_rate::float AS success_rate,
+        c.first_pass_rate::float AS first_pass_rate,
+        c.cost_per_success::float AS cost_per_success,
+        c.hit_count,
+        c.last_scored,
+        c.created_at,
+        c.updated_at,
+        GREATEST(
+            d.floor,
+            POWER(
+                0.5,
+                GREATEST(
+                    0.0,
+                    EXTRACT(EPOCH FROM (NOW() - c.last_scored)) / 86400.0
+                ) / d.half_life_days
+            )
+        )::float AS decay_multiplier
+    FROM capsule_store c
+    CROSS JOIN decay_params d
+)
+SELECT
+    capsule_id,
+    capsule_hash,
+    factor,
+    validity_scope,
+    source_commit,
+    source_artifact,
+    schema_version,
+    success_rate,
+    first_pass_rate,
+    cost_per_success,
+    (success_rate * decay_multiplier)::float AS effective_success_rate,
+    (first_pass_rate * decay_multiplier)::float AS effective_first_pass_rate,
+    hit_count,
+    last_scored,
+    created_at,
+    updated_at
+FROM scored
+ORDER BY factor, validity_scope, effective_first_pass_rate DESC;

--- a/docker/migrations/schema_fingerprint.sha256
+++ b/docker/migrations/schema_fingerprint.sha256
@@ -1,6 +1,6 @@
 # Schema migration fingerprint for omnibase_infra (auto-generated)
 # Regenerate: python scripts/check_schema_fingerprint.py stamp
 # Verify:     python scripts/check_schema_fingerprint.py verify
-sha256:422b8fc155e52f02d796fdb64b35206901cd2abe41291942b1adf653afd6ef1c
-generated_at: 2026-06-17T17:07:59Z
-migration_file_count: 71
+sha256:cd084fa033d24de80238a10c51d0b2344502917f5054def16b44ddb570976ba2
+generated_at: 2026-06-20T18:36:08Z
+migration_file_count: 72

--- a/docs/runbooks/apply-migrations.md
+++ b/docs/runbooks/apply-migrations.md
@@ -239,6 +239,26 @@ wrap in a transaction and check for idempotency before re-applying.
 Omnidash maintains its own `omnidash_analytics` read-model database with SQL migrations
 in `omnidash/migrations/`. These are wired into the bootstrap pipeline as **Step 1d**.
 
+### Canonical projection database (OMN-13362)
+
+The delegation projection (`node_projection_delegation`, omnimarket) writes to
+**`omnidash_analytics.delegation_events`** — the live, growing table. Node-owned
+migrations vendored under `docker/migrations/forward/nodes/<node>/` are applied by
+`run-forward-migrations.sh` against `NODE_POSTGRES_DB` (compose sets
+`omnidash_analytics`), NOT the flat infra `omnibase_infra` DB.
+
+> **Probe the live table in `omnidash_analytics`, never `omnibase_infra`.** A stale
+> `delegation_events` decoy used to exist in the `omnibase_infra` DB (a historical
+> artifact from before the node-migration runner was repointed to
+> `omnidash_analytics`; last write 2026-05-13, read by nothing). Querying that decoy
+> caused the 2026-06-19 Gate-Zero "writes stopped May 13" misdiagnosis. Forward
+> migration `087_drop_stale_delegation_events_decoy.sql` drops it. Future probes:
+>
+> ```bash
+> # Correct: live delegation projection
+> psql -d omnidash_analytics -c "SELECT count(*), max(timestamp) FROM delegation_events;"
+> ```
+
 ### Bootstrap (advisory -- warn and continue)
 
 During `bootstrap-infisical.sh`, Step 1d runs the omnidash migration runner if both


### PR DESCRIPTION
## OMN-13362: resolve dual delegation_events tables (drop the stale decoy)

`delegation_events` existed in TWO databases on .201: `omnidash_analytics` (live,
canonical writer `node_projection_delegation`) and `omnibase_infra` (stale decoy,
~40 rows, last write 2026-05-13, read by nothing). Querying the decoy caused the
2026-06-19 Gate-Zero "writes stopped May 13" misdiagnosis.

### What
- Forward migration `087_drop_stale_delegation_events_decoy.sql`: idempotent
  `DROP TABLE IF EXISTS`. Runs in the flat infra sequence against
  `POSTGRES_DB=omnibase_infra`, so it can only hit the decoy; the live copy in the
  separate `omnidash_analytics` DB is untouched. `REQUIRED_PROJECTION_TABLES`
  gates probe `omnidash_analytics`, so the drop does not break the migration gate.
- Runbook `apply-migrations.md` documents `omnidash_analytics` as the canonical
  `delegation_events` and instructs future probes to target it (DoD).
- Re-vendor node-migration tree from omnimarket dev (capsule_store 078/079) to
  clear **pre-existing** vendoring drift so `node-migration-sync` is green.

### Local verify (worktree)
- `uv run python scripts/validation/validate_migration_sequence.py` -> PASS (72 files, no dups)
- `OMNIMARKET_SRC=$OMNI_HOME/omnimarket bash scripts/sync-node-migrations.sh --check` -> in sync
- `uv run pytest tests/unit/migrations/test_node_migration_discovery.py tests/unit/runtime/test_migration_sentinel.py -q` -> 32 passed
- `pre-commit run` on changed files -> all pass

### Note
The omnimarket `0018` cost-measurement migration (OMN-13234) auto-vendors into this
tree via `sync-node-migrations.sh` AFTER the omnimarket PR merges to dev; including
it here pre-merge would redden `node-migration-sync` (it compares vs omnimarket dev
tip). No merge here.

### Evidence
- Evidence-Source: branch `jonah/omn-13234-13362-typed-tier-cost-and-dual-table` @ this PR head
- Evidence-Ticket: OMN-13362
- OCC contract: `contracts/OMN-13362.yaml`

OMN-13362



---

## OCC Evidence pairing (savings cluster)

Evidence-Source: OCC#2868
Evidence-Ticket: OMN-13362

OCC#2868 carries `contracts/OMN-13362.yaml` + PASS receipts (infra #2051 16 migration-discovery tests). NOTE: the shared branch name `omn-13234-13362` does not contain a clean `OMN-13362` token, so the receipt-gate identity-binding branch axis cannot match OMN-13362; the OCC evidence is complete and correct.

<!-- occ-head: 1747bb7d5 -->
