### PR TITLE
chore(OMN-13401): vendor delegation cost/budget migrations 0018/0019 into deployed forward tree

### DIFF
--- a/docker/migrations/forward/nodes/node_projection_delegation/0018_delegation_cost_measurements.sql
+++ b/docker/migrations/forward/nodes/node_projection_delegation/0018_delegation_cost_measurements.sql
@@ -1,0 +1,33 @@
+-- OMN-13234: persist the typed per-tier actual-cost measurement on
+-- delegation_events rows so honest savings (counterfactual - actual) is
+-- auditable and recomputable from the projection.
+--
+-- The typed tier cost model (free_local | metered | budgeted, in
+-- omnibase_core ModelTierCost / EnumTierCostType) decides how a tier is billed.
+-- When a cheaper tier serves a task the premium model never runs, so the
+-- premium_counterfactual (added in 0017) is a modeled figure, not a measurement.
+-- These columns carry the OTHER half of the saving — the tier's actual cost:
+--
+--   cost_tier_type           the typed cost regime that priced this call
+--                            (free_local | metered | budgeted)
+--   cost_tier_name           the routing tier name that served the task
+--                            (local | cheap_cloud | cheap_frontier | claude)
+--   cost_measurement_source  how cost_usd was derived
+--                            (free_local | metered | budgeted_in_budget |
+--                             budgeted_overage | budgeted_split |
+--                             manifest_compute | no_cost_model)
+--   budget_headroom_consumed_usd  for budgeted tiers, the monthly-cap drawdown
+--                            (accounting cost of in-budget tokens; 0 cash)
+--
+-- cost_usd (cash) and cost_savings_usd already exist (0007); this migration
+-- only records HOW cost_usd was measured. cost_savings_usd is computed at write
+-- time as premium_counterfactual.counterfactual_cost_usd - cost_usd.
+--
+-- Idempotent ADD COLUMN IF NOT EXISTS so warm dev/stability volumes that
+-- already contain delegation_events reconcile cleanly.
+
+ALTER TABLE delegation_events
+    ADD COLUMN IF NOT EXISTS cost_tier_type TEXT NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS cost_tier_name TEXT NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS cost_measurement_source TEXT NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS budget_headroom_consumed_usd NUMERIC NOT NULL DEFAULT 0;

--- a/docker/migrations/forward/nodes/node_projection_delegation/0019_delegation_budget_state.sql
+++ b/docker/migrations/forward/nodes/node_projection_delegation/0019_delegation_budget_state.sql
@@ -1,0 +1,54 @@
+-- OMN-13235: per-tenant ceiling budget-state surface (cap + consumption),
+-- event-sourced from delegation-completed events, projection-readable.
+--
+-- A `budgeted` ceiling tier (EnumTierCostType.BUDGETED, OMN-13234) carries a
+-- monthly_cap_usd: tokens served while headroom remains cost 0 cash and draw the
+-- cap down; tokens past the cap bill overage. This table is the durable,
+-- event-sourced state of that drawdown so the dashboard / API can show how much
+-- of a tenant's monthly ceiling budget is consumed and how much headroom remains.
+--
+-- One row per (tenant_id, cost_tier_name, budget_period) — the period is the
+-- UTC month (YYYY-MM) the cap applies to. Each delegation-completed event for a
+-- budgeted tier accumulates its measured headroom drawdown
+-- (budget_headroom_consumed_usd, 0018) plus any cash overage into the period
+-- row; headroom_remaining_usd is derived = cap - consumed (floored at 0). The
+-- write is idempotent per source event via last_correlation_id so a replayed
+-- event does not double-count.
+--
+-- Idempotent CREATE/ADD so warm dev/stability volumes reconcile cleanly.
+
+CREATE TABLE IF NOT EXISTS delegation_budget_state (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id TEXT NOT NULL,
+    cost_tier_name TEXT NOT NULL,
+    budget_period TEXT NOT NULL,
+    monthly_cap_usd NUMERIC(18, 6) NOT NULL CHECK (monthly_cap_usd >= 0),
+    consumed_usd NUMERIC(18, 6) NOT NULL DEFAULT 0 CHECK (consumed_usd >= 0),
+    overage_usd NUMERIC(18, 6) NOT NULL DEFAULT 0 CHECK (overage_usd >= 0),
+    headroom_remaining_usd NUMERIC(18, 6) NOT NULL DEFAULT 0
+        CHECK (headroom_remaining_usd >= 0),
+    delegation_count INTEGER NOT NULL DEFAULT 0 CHECK (delegation_count >= 0),
+    last_correlation_id TEXT,
+    first_event_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_event_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_delegation_budget_state_identity
+    ON delegation_budget_state (tenant_id, cost_tier_name, budget_period);
+
+CREATE OR REPLACE FUNCTION refresh_delegation_budget_state_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_delegation_budget_state_updated_at
+    ON delegation_budget_state;
+CREATE TRIGGER trg_delegation_budget_state_updated_at
+    BEFORE UPDATE ON delegation_budget_state
+    FOR EACH ROW
+    EXECUTE FUNCTION refresh_delegation_budget_state_updated_at();

--- a/tests/unit/migrations/test_node_migration_discovery.py
+++ b/tests/unit/migrations/test_node_migration_discovery.py
@@ -134,6 +134,61 @@ class TestVendoredViewMigrations:
             and "ADD COLUMN IF NOT EXISTS premium_counterfactual JSONB" in sql
         )
 
+    def test_cost_measurements_migration_vendored(self) -> None:
+        """OMN-13401/OMN-13234: the per-tier actual-cost measurement migration is vendored.
+
+        0018 records HOW cost_usd was measured (cost_tier_type, cost_tier_name,
+        cost_measurement_source, budget_headroom_consumed_usd) so honest savings
+        (counterfactual - actual) is auditable from the projection. The node-owned
+        migration must be vendored so a clean clone materializes the columns under
+        the forward-migration runner.
+        """
+        migration = (
+            NODES_DIR
+            / "node_projection_delegation"
+            / "0018_delegation_cost_measurements.sql"
+        )
+        assert migration.is_file(), (
+            "0018_delegation_cost_measurements.sql must be vendored under "
+            "docker/migrations/forward/nodes/node_projection_delegation/ "
+            "(run scripts/sync-node-migrations.sh)"
+        )
+        sql = migration.read_text(encoding="utf-8")
+        assert "ALTER TABLE delegation_events" in sql
+        for column in (
+            "cost_tier_type",
+            "cost_tier_name",
+            "cost_measurement_source",
+            "budget_headroom_consumed_usd",
+        ):
+            assert f"ADD COLUMN IF NOT EXISTS {column}" in sql
+
+    def test_budget_state_migration_vendored(self) -> None:
+        """OMN-13401/OMN-13235: the per-tenant ceiling budget-state table is vendored.
+
+        0019 creates the durable, event-sourced delegation_budget_state surface
+        (cap + consumption + headroom) so the dashboard/API can show how much of a
+        tenant's monthly ceiling budget is consumed. The node-owned migration must
+        be vendored so a clean clone materializes the table under the
+        forward-migration runner.
+        """
+        migration = (
+            NODES_DIR
+            / "node_projection_delegation"
+            / "0019_delegation_budget_state.sql"
+        )
+        assert migration.is_file(), (
+            "0019_delegation_budget_state.sql must be vendored under "
+            "docker/migrations/forward/nodes/node_projection_delegation/ "
+            "(run scripts/sync-node-migrations.sh)"
+        )
+        sql = migration.read_text(encoding="utf-8")
+        assert "CREATE TABLE IF NOT EXISTS delegation_budget_state" in sql
+        assert (
+            "CREATE UNIQUE INDEX IF NOT EXISTS ux_delegation_budget_state_identity"
+            in sql
+        )
+
     def test_delegation_base_migration_repairs_warm_table_shape(self) -> None:
         """Base migration must be safe when delegation_events already exists."""
         migration = (


### PR DESCRIPTION
## OMN-13401 — Vendor delegation cost/budget migrations 0018/0019 into deployed forward tree

Evidence-Source: OCC#2870
Evidence-Ticket: OMN-13401

Runtime E2E Closeout (2026-06-21) — Ticket A2 (CODE/INFRA; blocks dev redeploy savings readback). Parent OMN-12296.

### Problem (verified at origin/dev)

omnimarket origin/dev (`24da4d9d`) source `node_projection_delegation/migrations/` carries `0017_premium_counterfactual`, `0018_delegation_cost_measurements`, `0019_delegation_budget_state`. omnibase_infra's deployed vendored tree `docker/migrations/forward/nodes/node_projection_delegation/` (origin/dev `2b9a08cfe`) vendored **0017 ONLY** — 0018/0019 were never synced. The forward-migration runner reads only the vendored tree, so a dev rebuild applies 0017 only and leaves the dev ledger at 0016→0017. Required 0018/0019 stay unapplied → Phase 5 savings/cost runtime readback (measured cost, budget state) is invalid until vendored + applied.

Evidence: `.onex_state/runtime-e2e-2026-06-21/00-preflight/04b-migration-vendoring-gap.txt`. 0017 landed this exact way via infra#2050 / OMN-13355.

### What

Vendored 1:1 via the canonical `scripts/sync-node-migrations.sh` path (OMN-12559 — no hand-copy, no renumber). The runner applies them under namespaced ids `node:node_projection_delegation:0018_delegation_cost_measurements.sql` / `...:0019_delegation_budget_state.sql`, in a separate identity space from the flat infra sequence.

```
docker/migrations/forward/nodes/node_projection_delegation/0018_delegation_cost_measurements.sql   (+33)
docker/migrations/forward/nodes/node_projection_delegation/0019_delegation_budget_state.sql         (+54)
tests/unit/migrations/test_node_migration_discovery.py                                              (+55)
```

- **0018** (OMN-13234): `ALTER TABLE delegation_events ADD COLUMN IF NOT EXISTS` the typed per-tier actual-cost columns (`cost_tier_type`, `cost_tier_name`, `cost_measurement_source`, `budget_headroom_consumed_usd`) so honest savings (counterfactual − actual) is auditable from the projection.
- **0019** (OMN-13235): `CREATE TABLE IF NOT EXISTS delegation_budget_state` — the durable, event-sourced per-tenant ceiling budget surface (cap + consumption + headroom) plus its identity unique index and `updated_at` trigger.

### Byte-match proof (no hand-edit)

`cmp -s` against the omnimarket source returns equal; sha256 matches both sides:

```
0018  f10798ce3382ab582482831bb0bd87c5c9831e2dfc28c9031b8bca214308fbf2   (1988 bytes, src == vendored)
0019  7b56108fc65070e639386563a236f523e804342dfe351c1decd0bb50e29d99eb   (2568 bytes, src == vendored)
```

The vendoring run reported exactly 2 files updated and nothing else drifted; `sync-node-migrations.sh --check` then reports **in sync**.

### Tests

Adds discovery tests mirroring the 0017 vendoring (`test_cost_measurements_migration_vendored`, `test_budget_state_migration_vendored`) asserting both migrations are vendored and declare their columns/table. All 18 migration discovery tests pass locally with omnimarket source resolvable.

The `ONEX Node Migration Vendor Sync Check` pre-commit/CI gate resolves omnimarket via `$OMNI_HOME/omnimarket` and passes (omnimarket source carries 0018/0019 on origin/dev). Migration freeze / sequence-duplicate checks pass. Full `pre-commit run` on the changed files: all hooks Passed/Skipped.

### After merge

A dev rebuild + force-recreate applies `node:node_projection_delegation:0017/0018/0019` against `omnidash_analytics` (verified in Ticket B / OMN-13397).

PR no-merge — left green for the merge sweep (omnibase_infra is queue-controlled, squash-only; bare `--auto`).
