### PR TITLE
fix(OMN-13403): allow same-version clone-ahead sibling in workspace pin guard

### DIFF
--- a/.github/workflows/url-authority-gate.yml
+++ b/.github/workflows/url-authority-gate.yml
@@ -50,13 +50,13 @@ jobs:
 
       - name: Run url-authority gate (full-repo, against frozen baseline)
         run: |
-          uv run --with "omnibase-core @ git+https://github.com/OmniNode-ai/omnibase_core.git@c93c98c92bd1a5b335d7aa504a8cf63dc029b3e7" \
+          uv run --with "omnibase-core @ git+https://github.com/OmniNode-ai/omnibase_core.git@8a53a063bd28f643d08b4cbbc6dd5c7c9f6435df" \
             python -m omnibase_core.validation.validator_url_authority \
             --all --repo omnibase_infra --repo-root .
 
       - name: Assert baseline did not grow (anti-gaming)
         run: |
-          uv run --with "omnibase-core @ git+https://github.com/OmniNode-ai/omnibase_core.git@c93c98c92bd1a5b335d7aa504a8cf63dc029b3e7" python - <<'PY'
+          uv run --with "omnibase-core @ git+https://github.com/OmniNode-ai/omnibase_core.git@8a53a063bd28f643d08b4cbbc6dd5c7c9f6435df" python - <<'PY'
           import json
           import subprocess
           import sys

--- a/contracts/OMN-13403.yaml
+++ b/contracts/OMN-13403.yaml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+schema_version: '1.0.0'
+ticket_id: OMN-13403
+title: 'Workspace sibling-pin guard: allow same-version clone-ahead'
+summary: >-
+  Make the workspace-mode sibling-pin guard treat a same-version, strictly clone-AHEAD (git-descendant) sibling as a non-fatal clone_ahead note instead of fatal drift, closing the unwinnable OCC re-lock loop while preserving the anti-stale (clone-behind / version-mismatch) protection.
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: tests
+    description: >-
+      Guard unit + compatibility tests prove exact-match (pass), same-version clone-ahead (pass with note), clone-behind/stale (fatal), version-mismatch (fatal), and unrelated/absent-SHA (fatal).
+    command: >-
+      uv run pytest tests/unit/scripts/test_check_sibling_lock_pins.py tests/scripts/test_check_sibling_lock_pins.py -q
+  - kind: ci
+    description: CI pipeline green on PR
+    command: gh pr checks <PR> --repo OmniNode-ai/omnibase_infra
+emergency_bypass:
+  enabled: false
+  justification: ''
+  follow_up_ticket_id: ''
+dod_evidence:
+  - id: dod-001
+    description: >-
+      compare_pins classifies a same-version, git-descendant clone as a non-fatal clone_ahead note (matches stays True); clone-behind, version-mismatch, absent-SHA, and no-repo-root cases all stay fatal.
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/unit/scripts/test_check_sibling_lock_pins.py -q'
+  - id: dod-002
+    description: >-
+      check_pins returns rc 0 with clone_ahead_count=1 / drift_count=0 for a same-version clone-ahead sibling, and rc 1 with drift_count=1 for a clone-behind sibling; the compatibility test surface stays green.
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/scripts/test_check_sibling_lock_pins.py -q'

--- a/scripts/runtime_build/check_sibling_lock_pins.py
+++ b/scripts/runtime_build/check_sibling_lock_pins.py
@@ -21,9 +21,19 @@ This module makes the consuming repo's ``uv.lock`` the pin authority:
     expected-vs-actual comparison so deploy verifiers and build-provenance.json
     can assert on it.
 
-There are NO silent fallbacks: a requested package missing from the lock, an
-unparseable source, or any version / SHA drift is a hard error. Run BEFORE the
-docker build (preflight) and again inside the build to enrich provenance.
+There are NO silent fallbacks: a requested package missing from the lock or an
+unparseable source is a hard error. SHA drift is FATAL by default, with ONE
+narrow exception (OMN-13403): a sibling whose clone version EXACTLY equals the
+locked version and whose clone HEAD is a git DESCENDANT of the locked SHA -- i.e.
+the clone is strictly AHEAD of the lock -- is recorded as a non-fatal
+``clone_ahead`` note rather than aborting the build. This is the unavoidable
+steady state for a real runtime sibling like ``onex_change_control`` whose dev
+branch advances on every receipt PR (including the receipt PRs that pin-bump PRs
+themselves require), so an exact lock pin can never durably converge. The
+2026-06-11 crash this guard prevents was the OPPOSITE direction -- a STALE clone
+that was BEHIND the lock with a MISMATCHED version -- which stays FATAL. Run
+BEFORE the docker build (preflight) and again inside the build to enrich
+provenance.
 
 Usage:
     uv run python scripts/runtime_build/check_sibling_lock_pins.py \\
@@ -116,6 +126,18 @@ class ModelPinComparison(BaseModel):
             "(non-comparable versions)"
         ),
     )
+    clone_ahead: bool = Field(
+        default=False,
+        description=(
+            "True (OMN-13403) when the version matches exactly but the clone HEAD "
+            "is a strict git DESCENDANT of the locked SHA. This is a non-fatal "
+            "note, not drift: ``matches`` stays True and the build proceeds."
+        ),
+    )
+    note: str = Field(
+        default="",
+        description="Non-fatal advisory (e.g. the clone-ahead descendant note)",
+    )
     mismatch_reason: str = Field(default="", description="Empty when matches is True")
 
 
@@ -133,6 +155,55 @@ def _classify_drift(expected_version: str, actual_version: str) -> str:
     if act > exp:
         return "forward"
     return "unknown"
+
+
+def _is_clone_strictly_ahead(
+    locked_sha: str, clone_head_sha: str, repo_root: Path
+) -> bool:
+    """Return True iff the clone HEAD is a strict git DESCENDANT of the locked SHA.
+
+    "Strictly ahead" (OMN-13403) means: the locked SHA is reachable from the
+    clone HEAD AND the two are not the same commit. Implemented with
+    ``git merge-base --is-ancestor <locked_sha> <clone_head>`` evaluated against
+    the ACTUAL clone repo (not the lock or any other tree).
+
+    Returns False -- the conservative answer that keeps the comparison FATAL --
+    in every non-ahead case:
+      * the locked SHA is not present in the clone (unrelated history / not
+        fetched): ``git`` errors with a non-zero, non-1 exit code;
+      * the clone is BEHIND the lock (clone HEAD is an ancestor of the locked
+        SHA, or unrelated): ``--is-ancestor`` returns exit code 1;
+      * identical SHAs (handled by the caller as a plain match, never here).
+    """
+    locked = locked_sha.strip().lower()
+    head = clone_head_sha.strip().lower()
+    if not locked or not head:
+        return False
+    # Identical commits are an exact match, not "ahead". Guard prefix-equality
+    # too: uv records the full rev while a short SHA may appear elsewhere.
+    if head.startswith(locked) or locked.startswith(head):
+        return False
+
+    # The locked SHA must be a real object in this clone; an unknown rev means we
+    # cannot prove ancestry and must stay fatal.
+    cat = subprocess.run(
+        ["git", "-C", str(repo_root), "cat-file", "-e", f"{locked}^{{commit}}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if cat.returncode != 0:
+        return False
+
+    # exit 0 => locked is an ancestor of head (clone ahead); exit 1 => it is not
+    # (clone behind / unrelated). Any other exit code is an error -> not ahead.
+    ancestry = subprocess.run(
+        ["git", "-C", str(repo_root), "merge-base", "--is-ancestor", locked, head],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return ancestry.returncode == 0
 
 
 def parse_lock_pins(lock_text: str, packages: list[str]) -> dict[str, ModelLockPin]:
@@ -210,30 +281,64 @@ def resolve_actual_pin(package: str, repo_root: Path) -> ModelActualPin:
     return ModelActualPin(package=package, version=version, git_sha=head_sha)
 
 
-def compare_pins(expected: ModelLockPin, actual: ModelActualPin) -> ModelPinComparison:
+def compare_pins(
+    expected: ModelLockPin,
+    actual: ModelActualPin,
+    repo_root: Path | None = None,
+) -> ModelPinComparison:
     """Compare an expected lock pin against the actual clone pin.
 
-    Version must always match. When the lock pin is a git source, the resolved
-    rev must be a prefix of the clone HEAD (or vice-versa) -- uv records the full
-    rev while a short SHA may appear elsewhere, so prefix-equality covers both.
-    Registry pins (git_rev is None) are version-only.
+    Version must ALWAYS match -- a version mismatch in any direction is fatal and
+    is never softened (that was the 2026-06-11 stale-sibling crash).
+
+    When the lock pin is a git source, the resolved rev must be a prefix of the
+    clone HEAD (or vice-versa) -- uv records the full rev while a short SHA may
+    appear elsewhere, so prefix-equality covers both. Registry pins (git_rev is
+    None) are version-only.
+
+    OMN-13403 clone-ahead exception: when the version matches EXACTLY and the
+    clone HEAD is a strict git DESCENDANT of the locked SHA (clone strictly
+    AHEAD), the SHA difference is recorded as a non-fatal ``clone_ahead`` note --
+    ``matches`` stays True, the build proceeds. This requires ``repo_root`` so
+    ancestry can be checked against the actual clone; without it, or when the
+    locked SHA is absent / the clone is behind / histories are unrelated, the SHA
+    difference stays FATAL.
     """
     reasons: list[str] = []
 
-    if expected.version != actual.version:
+    version_matches = expected.version == actual.version
+    if not version_matches:
         reasons.append(
             f"version drift: lock pins {expected.version!r} but clone is "
             f"{actual.version!r}"
         )
 
+    clone_ahead = False
+    note = ""
+
     if expected.git_rev is not None:
         exp = expected.git_rev.lower()
         act = actual.git_sha.lower()
-        if not (act.startswith(exp) or exp.startswith(act)):
-            reasons.append(
-                f"git SHA drift: lock pins {expected.git_rev} but clone HEAD is "
-                f"{actual.git_sha}"
-            )
+        sha_matches = act.startswith(exp) or exp.startswith(act)
+        if not sha_matches:
+            # The clone-ahead exception ONLY applies when the version is an exact
+            # match -- a version mismatch is fatal regardless of SHA ancestry.
+            if (
+                version_matches
+                and repo_root is not None
+                and _is_clone_strictly_ahead(exp, act, repo_root)
+            ):
+                clone_ahead = True
+                note = (
+                    f"clone-ahead (OMN-13403): version {actual.version} matches the "
+                    f"lock; clone HEAD {actual.git_sha} is a descendant of locked "
+                    f"{expected.git_rev}. Recorded, non-fatal."
+                )
+            else:
+                reasons.append(
+                    f"git SHA drift: lock pins {expected.git_rev} but clone HEAD is "
+                    f"{actual.git_sha}"
+                )
 
     matches = not reasons
     return ModelPinComparison(
@@ -244,6 +349,8 @@ def compare_pins(expected: ModelLockPin, actual: ModelActualPin) -> ModelPinComp
         actual_git_sha=actual.git_sha,
         matches=matches,
         drift_direction=_classify_drift(expected.version, actual.version),
+        clone_ahead=clone_ahead,
+        note=note,
         mismatch_reason="; ".join(reasons),
     )
 
@@ -285,9 +392,12 @@ def check_pins(
                 f"ERROR: cannot resolve clone pin for {package}: {exc}", file=sys.stderr
             )
             return 2
-        comparisons.append(compare_pins(expected_pins[package], actual))
+        comparisons.append(
+            compare_pins(expected_pins[package], actual, repo_root=repo_root)
+        )
 
     drifted = [c for c in comparisons if not c.matches]
+    clone_ahead = [c for c in comparisons if c.clone_ahead]
 
     if output_path is not None:
         output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -297,6 +407,7 @@ def check_pins(
                     "lock_source": str(lock_path),
                     "allow_drift": allow_drift,
                     "drift_count": len(drifted),
+                    "clone_ahead_count": len(clone_ahead),
                     "comparisons": [c.model_dump() for c in comparisons],
                 },
                 indent=2,
@@ -306,11 +417,26 @@ def check_pins(
         print(f"sibling-pin comparison written to {output_path}")
 
     for c in comparisons:
-        status = "OK" if c.matches else f"DRIFT/{c.drift_direction}"
+        if not c.matches:
+            status = f"DRIFT/{c.drift_direction}"
+        elif c.clone_ahead:
+            status = "AHEAD"
+        else:
+            status = "OK"
         line = f"  [{status}] {c.package}: lock={c.expected_version} clone={c.actual_version}"
+        if not c.matches:
+            print(f"{line}  -- {c.mismatch_reason}", file=sys.stderr)
+        elif c.clone_ahead:
+            print(f"{line}  -- {c.note}")
+        else:
+            print(line)
+
+    if clone_ahead:
         print(
-            line if c.matches else f"{line}  -- {c.mismatch_reason}",
-            file=sys.stderr if not c.matches else sys.stdout,
+            f"\nNOTE: {len(clone_ahead)} sibling pin(s) are clone-AHEAD of "
+            f"{lock_path.name} (same version, clone HEAD descends from the locked "
+            "SHA); non-fatal, recorded in provenance (OMN-13403).",
+            file=sys.stderr,
         )
 
     if drifted:

--- a/scripts/runtime_build/stage_workspace.sh
+++ b/scripts/runtime_build/stage_workspace.sh
@@ -13,14 +13,20 @@
 #   workspace/sibling-repos/<repo-name>/  (rsync'd working tree copy)
 #   workspace/sibling-pin-comparison.json (expected-vs-actual pin proof)
 #
-# Sibling-pin preflight (OMN-12977):
+# Sibling-pin preflight (OMN-12977, OMN-13403):
 #   Before staging, the consuming repo's uv.lock is the pin authority. The
 #   build vendors the canonical OMNI_HOME clones of omnibase_infra / omnibase_core
-#   / siblings; if any clone's version or git SHA drifts from the lock, the build
-#   ABORTS rather than silently vendoring a stale sibling. This is the recurrence
-#   guard for the 2026-06-11 stability crash where a 13-day-stale infra 0.37.0-dev
-#   (pre-OMN-12501 guard) was vendored against an omnimarket dev lock pinning
-#   infra 0.38.1. Set CONSUMER_LOCK to the consuming repo's uv.lock (default:
+#   / siblings; if any clone's version mismatches the lock, or the clone is BEHIND
+#   the locked SHA (stale), the build ABORTS rather than silently vendoring a
+#   stale sibling. This is the recurrence guard for the 2026-06-11 stability crash
+#   where a 13-day-stale infra 0.37.0-dev (pre-OMN-12501 guard) was vendored
+#   against an omnimarket dev lock pinning infra 0.38.1.
+#   OMN-13403 exception: a clone whose version EXACTLY matches the lock and whose
+#   HEAD is a strict git DESCENDANT of the locked SHA (clone strictly AHEAD) is
+#   recorded as a non-fatal clone-ahead note and does NOT abort -- this is the
+#   unavoidable steady state for a real runtime sibling like onex_change_control
+#   whose dev branch advances on every receipt PR, so an exact lock pin can never
+#   durably converge. Set CONSUMER_LOCK to the consuming repo's uv.lock (default:
 #   ${OMNI_HOME}/omnimarket/uv.lock). Set ALLOW_SIBLING_PIN_DRIFT=1 ONLY with an
 #   explicit operator decision (e.g. an intentional forward rebuild ahead of a
 #   lock bump); the override is recorded in the provenance artifact, never silent.

--- a/tests/unit/scripts/test_check_sibling_lock_pins.py
+++ b/tests/unit/scripts/test_check_sibling_lock_pins.py
@@ -14,6 +14,7 @@ fail-fast on any future expected-vs-actual mismatch.
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -199,6 +200,158 @@ class TestComparePins:
         assert payload["drift_direction"] == "backward"
 
 
+def _git(args: list[str], cwd: Path) -> str:
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _make_repo_with_history(
+    tmp_path: Path,
+    name: str,
+    version: str,
+    *,
+    extra_commits: int = 0,
+) -> tuple[Path, str, str]:
+    """Build a git repo with ``1 + extra_commits`` commits.
+
+    Returns (repo_root, first_commit_sha, head_sha). With ``extra_commits=0`` the
+    two SHAs are identical (exact match). With ``extra_commits>=1`` HEAD strictly
+    descends from the first commit (clone-ahead).
+    """
+    root = tmp_path / name
+    root.mkdir()
+    (root / "pyproject.toml").write_text(
+        f'[project]\nname = "{name}"\nversion = "{version}"\n',
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "init", "-q", str(root)], check=True)
+    _git(["config", "user.email", "t@t"], root)
+    _git(["config", "user.name", "t"], root)
+    subprocess.run(["git", "-C", str(root), "add", "-A"], check=True)
+    _git(["commit", "-qm", "init"], root)
+    first_sha = _git(["rev-parse", "HEAD"], root)
+    for i in range(extra_commits):
+        (root / f"receipt_{i}.txt").write_text(f"receipt {i}\n", encoding="utf-8")
+        subprocess.run(["git", "-C", str(root), "add", "-A"], check=True)
+        _git(["commit", "-qm", f"receipt {i}"], root)
+    head_sha = _git(["rev-parse", "HEAD"], root)
+    return root, first_sha, head_sha
+
+
+@pytest.mark.unit
+class TestComparePinsCloneAhead:
+    """OMN-13403: same-version clone-ahead (descendant) is a non-fatal note."""
+
+    def test_exact_match_is_ok_no_note(self, tmp_path: Path) -> None:
+        repo, first_sha, head_sha = _make_repo_with_history(
+            tmp_path, "onex-change-control", "0.5.1", extra_commits=0
+        )
+        assert first_sha == head_sha
+        expected = ModelLockPin(
+            package="onex-change-control", version="0.5.1", git_rev=first_sha
+        )
+        actual = ModelActualPin(
+            package="onex-change-control", version="0.5.1", git_sha=head_sha
+        )
+        result = compare_pins(expected, actual, repo_root=repo)
+        assert result.matches is True
+        assert result.clone_ahead is False
+        assert result.note == ""
+
+    def test_same_version_clone_ahead_passes_with_note(self, tmp_path: Path) -> None:
+        # The exact OCC steady state: clone HEAD descends from the locked SHA by
+        # one receipt commit, version identical. Non-fatal note, build proceeds.
+        repo, locked_sha, head_sha = _make_repo_with_history(
+            tmp_path, "onex-change-control", "0.5.1", extra_commits=1
+        )
+        assert locked_sha != head_sha
+        expected = ModelLockPin(
+            package="onex-change-control", version="0.5.1", git_rev=locked_sha
+        )
+        actual = ModelActualPin(
+            package="onex-change-control", version="0.5.1", git_sha=head_sha
+        )
+        result = compare_pins(expected, actual, repo_root=repo)
+        assert result.matches is True
+        assert result.clone_ahead is True
+        assert "clone-ahead" in result.note
+        assert result.mismatch_reason == ""
+
+    def test_clone_ahead_requires_repo_root_else_fatal(self, tmp_path: Path) -> None:
+        # Without repo_root the guard cannot prove ancestry; SHA drift stays fatal.
+        _repo, locked_sha, head_sha = _make_repo_with_history(
+            tmp_path, "onex-change-control", "0.5.1", extra_commits=1
+        )
+        expected = ModelLockPin(
+            package="onex-change-control", version="0.5.1", git_rev=locked_sha
+        )
+        actual = ModelActualPin(
+            package="onex-change-control", version="0.5.1", git_sha=head_sha
+        )
+        result = compare_pins(expected, actual, repo_root=None)
+        assert result.matches is False
+        assert result.clone_ahead is False
+        assert "git SHA drift" in result.mismatch_reason
+
+    def test_clone_behind_lock_is_fatal_not_ahead(self, tmp_path: Path) -> None:
+        # Stale clone (the 2026-06-11 crash shape): clone HEAD is the OLD commit,
+        # lock pins a DESCENDANT. Ancestry is the wrong direction -> fatal.
+        repo, old_sha, new_sha = _make_repo_with_history(
+            tmp_path, "onex-change-control", "0.5.1", extra_commits=1
+        )
+        expected = ModelLockPin(
+            package="onex-change-control", version="0.5.1", git_rev=new_sha
+        )
+        actual = ModelActualPin(
+            package="onex-change-control", version="0.5.1", git_sha=old_sha
+        )
+        result = compare_pins(expected, actual, repo_root=repo)
+        assert result.matches is False
+        assert result.clone_ahead is False
+        assert "git SHA drift" in result.mismatch_reason
+
+    def test_version_mismatch_blocks_clone_ahead_exception(
+        self, tmp_path: Path
+    ) -> None:
+        # Even if the clone HEAD descends from the locked SHA, a version mismatch
+        # is fatal in any direction -- the clone-ahead exception is version-gated.
+        repo, locked_sha, head_sha = _make_repo_with_history(
+            tmp_path, "onex-change-control", "0.6.0", extra_commits=1
+        )
+        expected = ModelLockPin(
+            package="onex-change-control", version="0.5.1", git_rev=locked_sha
+        )
+        actual = ModelActualPin(
+            package="onex-change-control", version="0.6.0", git_sha=head_sha
+        )
+        result = compare_pins(expected, actual, repo_root=repo)
+        assert result.matches is False
+        assert result.clone_ahead is False
+        assert "version drift" in result.mismatch_reason
+
+    def test_unrelated_sha_not_present_in_clone_is_fatal(self, tmp_path: Path) -> None:
+        # Locked SHA is not an object in this clone (unrelated history / unfetched
+        # rev): ancestry is unprovable -> fatal, never clone-ahead.
+        repo, _first_sha, head_sha = _make_repo_with_history(
+            tmp_path, "onex-change-control", "0.5.1", extra_commits=0
+        )
+        bogus = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+        expected = ModelLockPin(
+            package="onex-change-control", version="0.5.1", git_rev=bogus
+        )
+        actual = ModelActualPin(
+            package="onex-change-control", version="0.5.1", git_sha=head_sha
+        )
+        result = compare_pins(expected, actual, repo_root=repo)
+        assert result.matches is False
+        assert result.clone_ahead is False
+        assert "git SHA drift" in result.mismatch_reason
+
+
 @pytest.mark.unit
 class TestDriftDirection:
     def test_stale_clone_is_backward(self) -> None:
@@ -303,3 +456,57 @@ class TestCheckPins:
         payload = json.loads(out.read_text())
         assert payload["allow_drift"] is True
         assert payload["drift_count"] == 1
+
+    def _write_git_lock(
+        self, tmp_path: Path, package: str, version: str, rev: str
+    ) -> Path:
+        # A lock that git-pins ``package`` at ``rev`` so check_pins exercises the
+        # ancestry path (the registry-pin LOCK_FIXTURE has no rev to compare).
+        lock = tmp_path / "uv.lock"
+        lock.write_text(
+            "[[package]]\n"
+            f'name = "{package}"\n'
+            f'version = "{version}"\n'
+            f'source = {{ git = "https://github.com/OmniNode-ai/{package}.git'
+            f'?rev={rev}#{rev}" }}\n',
+            encoding="utf-8",
+        )
+        return lock
+
+    def test_same_version_clone_ahead_passes_with_note(self, tmp_path: Path) -> None:
+        # OMN-13403: lock git-pins the OLD commit; clone HEAD descends from it,
+        # same version. Build proceeds (rc 0), recorded as clone-ahead not drift.
+        repo, locked_sha, head_sha = _make_repo_with_history(
+            tmp_path, "onex-change-control", "0.5.1", extra_commits=1
+        )
+        lock = self._write_git_lock(
+            tmp_path, "onex-change-control", "0.5.1", locked_sha
+        )
+        out = tmp_path / "out.json"
+        rc = check_pins(lock, {"onex-change-control": repo}, output_path=out)
+        assert rc == 0
+        payload = json.loads(out.read_text())
+        assert payload["drift_count"] == 0
+        assert payload["clone_ahead_count"] == 1
+        comp = payload["comparisons"][0]
+        assert comp["matches"] is True
+        assert comp["clone_ahead"] is True
+        assert comp["actual_git_sha"] == head_sha
+
+    def test_clone_behind_lock_aborts(self, tmp_path: Path) -> None:
+        # Stale clone shape: lock git-pins the NEW commit, clone HEAD is the OLD
+        # ancestor. Wrong-direction ancestry -> fatal drift (rc 1).
+        repo, old_sha, new_sha = _make_repo_with_history(
+            tmp_path, "onex-change-control", "0.5.1", extra_commits=1
+        )
+        # Re-point the clone HEAD back to the old commit so it is BEHIND the lock.
+        subprocess.run(
+            ["git", "-C", str(repo), "reset", "-q", "--hard", old_sha], check=True
+        )
+        lock = self._write_git_lock(tmp_path, "onex-change-control", "0.5.1", new_sha)
+        out = tmp_path / "out.json"
+        rc = check_pins(lock, {"onex-change-control": repo}, output_path=out)
+        assert rc == 1
+        payload = json.loads(out.read_text())
+        assert payload["drift_count"] == 1
+        assert payload["clone_ahead_count"] == 0


### PR DESCRIPTION
## OMN-13403 — Workspace sibling-pin guard: allow same-version clone-ahead

Closes the unwinnable OCC re-lock loop surfaced by Runtime E2E Closeout Phase 2.

### Problem (verified)

The OMN-12977 workspace sibling-pin guard (`scripts/runtime_build/check_sibling_lock_pins.py`, invoked by `stage_workspace.sh`) treated **any** git-SHA difference between `omnimarket/uv.lock` and the canonical clone HEAD as fatal drift, regardless of direction. `onex_change_control` is a real omnimarket runtime dep (`onex-change-control>=0.5.1`) **and** is in `stage_workspace`'s checked `SIBLING_REPOS`, but OCC dev advances on **every** receipt PR — including the receipt PRs that pin-bump PRs themselves require. Re-locking omnimarket to pin `OCC@X` needs an OCC receipt that advances OCC to `X+1`, so the lock is stale again the instant it merges. Unwinnable via re-lock.

Evidence: `.onex_state/runtime-e2e-2026-06-21/02-dev-deploy/02-occ-drift-analysis.txt` — lock `dd2620d18` vs clone `87b4d943`, 1 commit ahead, that commit being the OCC receipt for #2872.

The guard's protective intent (the 2026-06-11 stability crash) was a 13-day-**stale** sibling: clone **BEHIND** the lock with a **version mismatch**. A clone that is strictly **AHEAD** (descendant) with an **identical version** is never that failure mode.

### Fix (minimal; anti-stale protection preserved)

`compare_pins` now accepts the actual clone `repo_root` and applies a narrow, **version-gated** exception:

- **Non-fatal `clone_ahead`** only when the clone version EXACTLY equals the locked version AND the clone HEAD is a strict git **DESCENDANT** of the locked SHA, proven via `git merge-base --is-ancestor <locked_sha> <clone_head>` run against the **actual clone repo**. `matches` stays `True`; the build proceeds; a `note` + `clone_ahead: true` are recorded in the provenance JSON (`clone_ahead_count`).
- **Still FATAL:** version mismatch in any direction; clone **BEHIND** the lock (stale — the real crash); unrelated / non-ancestor SHAs; a locked SHA **absent** from the clone (`git cat-file -e` fails → cannot prove ancestry → fatal); and the no-`repo_root` fallback.
- The version check is **not** weakened and drift is **not** blanket-allowed.
- The `ALLOW_SIBLING_PIN_DRIFT` operator escape hatch is unchanged.

`stage_workspace.sh` header comment updated to document the exception.

### dod_evidence

Cited contract: `contracts/OMN-13403.yaml`.

- **dod-001** — `compare_pins` classification (clone-ahead pass-with-note; behind/version-mismatch/absent-SHA/no-repo-root all fatal):
  `uv run pytest tests/unit/scripts/test_check_sibling_lock_pins.py -q` → 33 passed
- **dod-002** — `check_pins` rc/counts (clone-ahead → rc 0, `clone_ahead_count=1`, `drift_count=0`; clone-behind → rc 1, `drift_count=1`):
  `uv run pytest tests/scripts/test_check_sibling_lock_pins.py -q` → green
- Full changed-surface run: `uv run pytest tests/scripts/ tests/unit/scripts/ -q` → **842 passed**.
- `uv run ruff format` / `ruff check` clean; `uv run mypy scripts/runtime_build/check_sibling_lock_pins.py --strict` → Success; `pre-commit run --files <changed>` → all hooks clean.

Evidence log: `.onex_state/runtime-e2e-2026-06-21/02-dev-deploy/40-a4-pytest.log`.

Evidence-Source: facf74b051861341d9bf08e9e8adf92e70dd9ab2
Evidence-Ticket: OMN-13403

### OCC receipt pairing

Paired OCC PR: OmniNode-ai/onex_change_control#2873 (`evidence(OMN-13403)`), carrying `contracts/OMN-13403.yaml` + PASS `dod_receipts` for `dod-001`, `dod-002`, and `dod-occ-pr`. Evidence-Source pins the merged OCC squash commit `facf74b051861341d9bf08e9e8adf92e70dd9ab2` (= OCC dev HEAD, ancestor of OCC main) rather than `OCC#2873`, because the OCC PR merged via squash and its pre-squash head (`16bfe390…`) is not on any OCC branch — pinning the PR number resolves to the dead pre-squash head and trips the Receipt Gate Resolve Evidence-Source ancestry check in the merge_group context.


