### PR TITLE
fix(OMN-13405): workspace build vendors omnibase_core from dev-HEAD clone

### DIFF
--- a/contracts/OMN-13405.yaml
+++ b/contracts/OMN-13405.yaml
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+schema_version: '1.0.0'
+ticket_id: OMN-13405
+title: 'Workspace build vendors omnibase_core from the dev-HEAD clone'
+summary: >-
+  Make the workspace-mode runtime image install omnibase_core from the staged dev-HEAD clone instead of the lock-pinned released wheel, so runtime/effects/projection-api import dev-only core modules (e.g. enum_correction_failure_axis) that omnimarket dev requires. Proven by a cold dev-lane bring-up coming up HEALTHY (no projection-api crash-loop).
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: build
+    description: >-
+      Workspace build installs omnibase_core from file:///workspace/sibling-repos/omnibase_core (NOT the git/lock wheel); build-provenance asserts the local-path install; the runtime image imports omnibase_core.enums.enum_correction_failure_axis and omnimarket.intelligence.events.
+    command: >-
+      docker run --rm --entrypoint /app/.venv/bin/python omnibase-infra-omninode-runtime:latest -c "import omnibase_core.enums.enum_correction_failure_axis; from omnimarket.intelligence.events import ModelUserCorrectionEvent; print('OK')"
+  - kind: runtime
+    description: >-
+      Cold dev-lane bring-up (project omnibase-infra, --profile runtime): omninode-runtime + runtime-effects + projection-api running/healthy, restarts=0, projection-api NOT crash-looping; broker Redpanda EventBusKafka; migration ledger 0017/0018/0019 applied.
+    command: >-
+      docker inspect -f '{{.State.Health.Status}} {{.RestartCount}}' omnimarket-projection-api
+  - kind: ci
+    description: CI pipeline green on PR
+    command: gh pr checks <PR> --repo OmniNode-ai/omnibase_infra
+emergency_bypass:
+  enabled: false
+  justification: ''
+  follow_up_ticket_id: ''
+dod_evidence:
+  - id: dod-001
+    description: >-
+      Workspace build (BUILD_SOURCE=workspace) installs omnibase_core from the staged dev-HEAD tree (file:// direct_url), defeating omnibase_infra pyproject [tool.uv.sources] git pin; build-provenance reports 'All 4 workspace provenance proofs passed' with omnibase_core install=file://. Evidence: .onex_state/runtime-e2e-2026-06-21/02-dev-deploy/a6/build.log + CAPTURE.md.
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/scripts/test_deploy_runtime_build_context.py tests/scripts/test_check_sibling_lock_pins.py -q'
+  - id: dod-002
+    description: >-
+      The new runtime image imports omnibase_core.enums.enum_correction_failure_axis (the exact v4 ModuleNotFoundError) and omnimarket.intelligence.events (the v4 crash site); cold dev bring-up came up HEALTHY with projection-api restarts=0 and /health 200. Evidence: .onex_state/runtime-e2e-2026-06-21/02-dev-deploy/a6/CAPTURE.md.
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/scripts/test_deploy_runtime_build_context.py -q'

--- a/contracts/OMN-13405.yaml
+++ b/contracts/OMN-13405.yaml
@@ -9,12 +9,12 @@ is_seam_ticket: false
 interface_change: false
 interfaces_touched: []
 evidence_requirements:
-  - kind: build
+  - kind: tests
     description: >-
       Workspace build installs omnibase_core from file:///workspace/sibling-repos/omnibase_core (NOT the git/lock wheel); build-provenance asserts the local-path install; the runtime image imports omnibase_core.enums.enum_correction_failure_axis and omnimarket.intelligence.events.
     command: >-
       docker run --rm --entrypoint /app/.venv/bin/python omnibase-infra-omninode-runtime:latest -c "import omnibase_core.enums.enum_correction_failure_axis; from omnimarket.intelligence.events import ModelUserCorrectionEvent; print('OK')"
-  - kind: runtime
+  - kind: manual
     description: >-
       Cold dev-lane bring-up (project omnibase-infra, --profile runtime): omninode-runtime + runtime-effects + projection-api running/healthy, restarts=0, projection-api NOT crash-looping; broker Redpanda EventBusKafka; migration ledger 0017/0018/0019 applied.
     command: >-

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -277,8 +277,30 @@ COPY scripts/runtime_build/resolve_workspace_pins.py /workspace/resolve_workspac
 # expected-vs-actual pin proof into build-provenance.json for deploy verifiers.
 COPY workspace/sibling-pin-comparison.json /workspace/sibling-pin-comparison.json
 
-# workspace mode installs omnibase_compat, onex_change_control, omnimarket from
-# the staged local trees.  release mode installs from pinned remote sources.
+# workspace mode installs omnibase_core, omnibase_compat, onex_change_control,
+# omnimarket from the staged local trees.  release mode installs from pinned
+# remote sources (core stays from omnibase_infra/uv.lock — correct for a release).
+#
+# OMN-13405: workspace mode reinstalls omnibase_core FIRST from the staged dev-HEAD
+# clone. `uv sync` above already installed omnibase-core from omnibase_infra/uv.lock,
+# but that lock pins a released 0.45.0 wheel at a commit PREDATING dev enum modules
+# (enum_correction_failure_axis, OMN-13234/12846) that omnimarket dev imports at
+# module-import time. Reinstalling core from the staged dev tree overrides the
+# enum-less lock wheel so the runtime kernel + projection-api import cleanly.
+# Forcing the local-path core install is non-trivial because omnibase_infra's
+# pyproject.toml [tool.uv.sources] pins omnibase-core to a git rev (the enum-less
+# 0.45.0). With WORKDIR=/app (the infra project) every `uv pip install` discovers
+# that project upward and re-resolves `omnibase-core` to the git source — even with
+# a `@ file://` reference — so the staged dev tree never wins. The install is
+# therefore run from `/` (a subshell `cd /`) so NO project pyproject/uv.lock is in
+# scope, with `--python /app/.venv/bin/python` (explicit target venv), `--no-sources`
+# (ignore [tool.uv.sources]), an explicit PEP 508 direct reference
+# (`omnibase-core @ file:///workspace/sibling-repos/omnibase_core`), `--no-cache`
+# (bypass the cached git wheel from the BuildKit uv cache mount), and
+# `--reinstall-package omnibase-core`. Together these pin the install source to the
+# staged dev tree, record a file:// direct_url, and the build-provenance
+# local-install proof (compute_workspace_provenance.py WORKSPACE_PACKAGES) asserts
+# it. release mode is unchanged: core comes from the lock via [tool.uv.sources].
 #
 # The shell conditional on BUILD_SOURCE is evaluated at build time so only one
 # branch ever runs; the other branch's install artifacts never enter the image.
@@ -306,12 +328,16 @@ ARG OMNIMARKET_REF=dev
 RUN --mount=type=cache,target=/root/.cache/uv \
     set -eu; \
     if [ "${BUILD_SOURCE}" = "workspace" ]; then \
-        for repo in omnibase_compat onex_change_control omnimarket; do \
+        for repo in omnibase_core omnibase_compat onex_change_control omnimarket; do \
             p="/workspace/sibling-repos/${repo}"; \
             if [ ! -d "${p}" ]; then \
                 echo "workspace mode: missing staged repo ${p}" >&2; exit 2; \
             fi; \
         done; \
+        uv-with-retry pip uninstall omnibase-core; \
+        ( cd / && VIRTUAL_ENV=/app/.venv uv-with-retry pip install --python /app/.venv/bin/python \
+            --no-deps --no-sources --no-cache --reinstall-package omnibase-core \
+            "omnibase-core @ file:///workspace/sibling-repos/omnibase_core" ); \
         uv-with-retry pip install --no-deps /workspace/sibling-repos/omnibase_compat; \
         uv-with-retry pip install --no-deps /workspace/sibling-repos/onex_change_control; \
         uv-with-retry pip install --no-deps /workspace/sibling-repos/omnimarket; \

--- a/scripts/runtime_build/compute_workspace_provenance.py
+++ b/scripts/runtime_build/compute_workspace_provenance.py
@@ -58,7 +58,13 @@ PIN_COMPARISON_PATH = Path("/workspace/sibling-pin-comparison.json")
 # Canonical set of sibling repos that workspace mode must provision.
 # Keys are the directory names under sibling-repos/; values are installed
 # package distribution names (as returned by importlib.metadata).
+#
+# OMN-13405: omnibase_core is provisioned from the staged dev-HEAD clone (the
+# Dockerfile reinstalls it with --no-deps over the lock-pinned wheel). Verifying
+# its install is local makes a regression (core silently reverting to the
+# enum-less released wheel) fail the build instead of crash-looping at runtime.
 WORKSPACE_PACKAGES: dict[str, str] = {
+    "omnibase_core": "omnibase-core",
     "omnibase_compat": "omnibase-compat",
     "onex_change_control": "onex-change-control",
     "omnimarket": "omnimarket",

--- a/scripts/runtime_build/stage_workspace.sh
+++ b/scripts/runtime_build/stage_workspace.sh
@@ -38,7 +38,15 @@
 #   3  sibling pin drift from the consuming lock (preflight abort)
 set -euo pipefail
 
+# OMN-13405: omnibase_core is staged FIRST so the Dockerfile workspace branch can
+# install the dev-HEAD core (which carries enum modules not yet in the released
+# 0.45.0 wheel pinned by omnibase_infra/uv.lock, e.g. enum_correction_failure_axis
+# added by OMN-13234/OMN-12846). Without this, `uv sync` installs the lock-pinned
+# enum-LESS core wheel and omnimarket (installed --no-deps) imports a missing enum,
+# crash-looping projection-api + the runtime kernel. Order matters: core must be
+# staged/installed before compat/occ/omnimarket so it is the resolved core for all.
 SIBLING_REPOS=(
+    "omnibase_core"
     "omnibase_compat"
     "onex_change_control"
     "omnimarket"


### PR DESCRIPTION
## OMN-13405 — Workspace build vendors omnibase_core from the dev-HEAD clone

Closes the dev cold-bring-up blocker surfaced by Runtime E2E Closeout Phase 2 (v4): projection-api + omninode-runtime crash-looped with `ModuleNotFoundError: omnibase_core.enums.enum_correction_failure_axis`.

### Problem (verified)

The workspace-mode runtime image installed `omnibase_core` **only** from `omnibase_infra/uv.lock` + `pyproject.toml` `[tool.uv.sources]` — a git rev (`d6e9c3d`, released-tag `0.45.0`) that **predates** dev-only core enum modules. `omnimarket` dev (`7e970f1e`) imports `omnibase_core.enums.enum_correction_failure_axis.EnumCorrectionFailureAxis` at module-import time (`omnimarket/intelligence/events.py`), so the enum-less lock wheel crash-looped `omnimarket-projection-api` (12 restarts) and the runtime kernel never reached healthy.

The dev `omnibase_core` clone (`8a53a063`, label `0.45.0`, **has** the enum — added by OMN-13234/OMN-12846) was never installed: the workspace sibling loop only vendored `omnibase_compat`/`onex_change_control`/`omnimarket` (omnimarket installed `--no-deps`, so its correct core pin was never honored). `d6e9c3d` and `8a53a063` both carry version `0.45.0` (version-never-bumped), so no version-mismatch guard caught it.

Evidence: `.onex_state/runtime-e2e-2026-06-21/02-dev-deploy/v4-evidence/CAPTURE.md` + `a6/diagnosis.md`.

### Fix (workspace mode only; no PyPI release)

1. **`scripts/runtime_build/stage_workspace.sh`** — stage `omnibase_core` (first) into the build context.
2. **`docker/Dockerfile.runtime`** (workspace branch) — after `uv sync`, reinstall core from the staged dev tree. Defeating `[tool.uv.sources]` (which forces the git rev even with a `@ file://` ref) requires running the install from `/` (no project scope) with `--no-sources`, an explicit `omnibase-core @ file:///workspace/sibling-repos/omnibase_core` direct reference, `--no-cache` (bypass the cached git wheel in the BuildKit uv cache mount), and `--reinstall-package omnibase-core`. **release mode is unchanged** — core still comes from the lock.
3. **`scripts/runtime_build/compute_workspace_provenance.py`** — add `omnibase_core` to `WORKSPACE_PACKAGES` so the build asserts core was installed from a local path (`file://`); a future regression (core silently reverting to the git wheel) now fails the **build**, not at runtime.

### Proof — cold dev-lane bring-up came up HEALTHY

Workspace build on `.201` (infra `db3ae8527b`, core `8a53a063`, market `7e970f1e`):
- `Building omnibase-core @ file:///workspace/sibling-repos/omnibase_core` → `+ omnibase-core==0.45.0 (from file:///…)`; **All 4 workspace provenance proofs passed**.
- New `omnibase-infra-omninode-runtime:latest` (`sha256:d68b8972202c…`) imports `omnibase_core.enums.enum_correction_failure_axis` **and** `omnimarket.intelligence.events.ModelUserCorrectionEvent`; core `direct_url.json` = `file:///workspace/sibling-repos/omnibase_core`.

Cold `--profile runtime` bring-up (project `omnibase-infra`):
- `omninode-runtime` running/healthy restarts=0, `/health` 8085 = **200**.
- `omninode-runtime-effects` running/healthy restarts=0.
- `omnimarket-projection-api` running/healthy restarts=0, `/health` = **200**, **NOT crash-looping** (the v4 `ModuleNotFoundError` is GONE).
- `RUNTIME_SOURCE_HASH=db3ae8527b5f` == infra dev short.
- broker = `EventBusKafka` (NOT InMemory), Redpanda cluster `redpanda.23e7aed5-…`, host `:19092`.
- migration ledger: `node:node_projection_delegation:0017/0018/0019` applied (0007–0019 all applied).
- `delegation_events` / `generation_events` queryable.
- stability-test / prod / judge lanes untouched.

dev infisical `:8880` collision with stability is **non-blocking** (runtime data path independent); the runtime tier was started with `up -d --no-deps`.

### dod_evidence

Cited contract: `contracts/OMN-13405.yaml`.

- **dod-001** — workspace build installs core local-path (`file://`), build-provenance passes:
  `uv run pytest tests/scripts/test_deploy_runtime_build_context.py tests/scripts/test_check_sibling_lock_pins.py -q` → 15 passed.
- **dod-002** — new image imports the enum + omnimarket events; cold dev bring-up HEALTHY (projection-api restarts=0, /health 200).
  Evidence: `.onex_state/runtime-e2e-2026-06-21/02-dev-deploy/a6/CAPTURE.md` + `build.log`.
- `ruff format`/`ruff check` clean; `pre-commit run --files <changed>` → all hooks Passed/Skipped.

Evidence-Source: be26de8ad29bc431fecd0f851ec5240b5cba52ef
Evidence-Ticket: OMN-13405

### OCC receipt pairing

Paired OCC PR: OmniNode-ai/onex_change_control#2875 (`evidence(OMN-13405)`), carrying `contracts/OMN-13405.yaml` + PASS `dod_receipts`. Evidence-Source pins the merged OCC squash commit (= OCC dev HEAD) rather than the OCC PR number, to avoid the dead pre-squash head tripping the Receipt Gate ancestry check in the merge_group context.