### PR TITLE
fix(OMN-13406): harden flat migration 087 drop_stale_delegation_events_decoy with CASCADE

### DIFF
--- a/contracts/OMN-13406.yaml
+++ b/contracts/OMN-13406.yaml
@@ -1,0 +1,46 @@
+schema_version: "1.0.0"
+ticket_id: "OMN-13406"
+title: "Harden flat migration 087_drop_stale_delegation_events_decoy with CASCADE (warm-DB apply fails)"
+summary: >
+  Flat forward migration 087 used a bare `DROP TABLE IF EXISTS delegation_events` (no CASCADE). On a WARM omnibase_infra DB carrying the stale decoy delegation_events (40 rows on stability) plus its dead dependent views, Postgres refuses the drop (other objects depend on it) → forward-migration exits 3 → blocks node migrations 0017/0018/0019. Cold dev had no decoy so it passed there; stability hit it and remediated by a manual CASCADE drop (infra DB only; live omnidash_analytics.delegation_events untouched), and PROD would hit the identical blocker on first forward-migration. The fix changes the drop to `DROP TABLE IF EXISTS public.delegation_events CASCADE;`. The five dependent views the CASCADE removes (projection_delegation_summary, projection_delegation_model_routing, projection_delegation_quality_gate, projection_delegation_token_usage from node 0010; projection_delegation_savings from node_projection_savings 076) are DEAD copies that exist only in the omnibase_infra DB — created there historically when NODE_POSTGRES_DB defaulted to POSTGRES_DB(=omnibase_infra) before the node runner was repointed to omnidash_analytics. The LIVE views of the same names live in omnidash_analytics, are rebuilt there by the same node migrations under NODE_POSTGRES_DB=omnidash_analytics, and are NEVER touched by this flat infra migration (it runs only against POSTGRES_DB=omnibase_infra). The id-based runner (schema_migrations PRIMARY KEY, no checksum) skips 087 on lanes that already applied it, so editing it re-runs nowhere already-migrated and is a harmless no-op on cold DBs.
+
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-001"
+    description: >
+      Scratch acceptance proof on a throwaway Postgres 16 (--rm): (a) WARM DB with a decoy delegation_events + dependent view → hardened 087 succeeds and drops BOTH; (b) DB with NO decoy → 087 is a clean no-op success; (neg) WARM DB + the OLD bare DROP (no CASCADE) → Postgres refuses (reproduces the original blocker).
+
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "grep -q 'OVERALL: PASS' docs/evidence/OMN-13406/087-cascade-scratch-proof.md"
+  - id: "dod-002"
+    description: >
+      Migration sequence validator passes with the CASCADE-hardened 087 (no duplicate sequence numbers; still a single flat file).
+
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run python scripts/validation/validate_migration_sequence.py"
+  - id: "dod-deploy"
+    description: >
+      Deploy-gate evidence: 087 remains an idempotent DROP TABLE IF EXISTS targeting the stale decoy in the omnibase_infra DB, applied by the canonical forward-migration runner on the next redeploy. CASCADE only adds removal of the decoy's dead dependent views (same DB). REQUIRED_PROJECTION_TABLES checks target omnidash_analytics (the live table/views), so the drop does not break the migration gate; after merge, the prod promotion forward-migration clears the decoy automatically with no manual prod DB mutation.
+
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "echo 'deploy-gate: OMN-13406 hardens flat 087 to DROP TABLE IF EXISTS ... CASCADE on the stale unread decoy in the omnibase_infra DB; live delegation_events + projection views in omnidash_analytics are untouched'"
+  - id: "dod-occ-pr"
+    description: >
+      OCC evidence PR carries the central contracts/OMN-13406.yaml and the PASS dod_receipts consumed by the omnibase_infra PR Receipt Gate.
+
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "grep -c '^ticket_id: \"OMN-13406\"$' contracts/OMN-13406.yaml"

--- a/docker/migrations/forward/087_drop_stale_delegation_events_decoy.sql
+++ b/docker/migrations/forward/087_drop_stale_delegation_events_decoy.sql
@@ -20,5 +20,26 @@
 -- omnidash_analytics copy (a different database the flat runner never touches).
 -- No flat infra migration and no infra source reads delegation_events from the
 -- omnibase_infra DB, so the drop is safe. Idempotent for already-cleaned volumes.
+--
+-- OMN-13406: CASCADE is required. On a WARM omnibase_infra DB the decoy
+-- delegation_events carries dead dependent views, created in this same DB by the
+-- same pre-repointing default (NODE_POSTGRES_DB=POSTGRES_DB=omnibase_infra) that
+-- created the decoy table. The node migrations build these views FROM
+-- delegation_events:
+--   * projection_delegation_summary       (node:node_projection_delegation:0010_create_delegation_dashboard_projection_views.sql)
+--   * projection_delegation_model_routing (node:node_projection_delegation:0010_...)
+--   * projection_delegation_quality_gate  (node:node_projection_delegation:0010_...)
+--   * projection_delegation_token_usage   (node:node_projection_delegation:0010_...)
+--   * projection_delegation_savings       (node:node_projection_savings:076_create_delegation_savings_projection_view.sql)
+-- Every one of these is a DEAD copy that exists ONLY in the omnibase_infra DB; the
+-- LIVE views of the same names live in omnidash_analytics, are rebuilt there by
+-- those same node migrations under NODE_POSTGRES_DB=omnidash_analytics, and are
+-- NEVER touched by this flat infra migration (it runs only against POSTGRES_DB).
+-- A bare DROP refuses because of these dependents (Postgres exit 3) → forward
+-- migration fails → blocks 0017/0018/0019. CASCADE removes the decoy table and its
+-- dead dependent views together. On a cold/already-cleaned omnibase_infra DB there
+-- is no decoy and no dependents, so the CASCADE is a harmless no-op (IF EXISTS).
+-- The id-based runner (schema_migrations PRIMARY KEY, no checksum) skips this file
+-- on lanes that already applied it, so this edit re-runs nowhere already-migrated.
 
-DROP TABLE IF EXISTS public.delegation_events;
+DROP TABLE IF EXISTS public.delegation_events CASCADE;

--- a/docker/migrations/schema_fingerprint.sha256
+++ b/docker/migrations/schema_fingerprint.sha256
@@ -1,6 +1,6 @@
 # Schema migration fingerprint for omnibase_infra (auto-generated)
 # Regenerate: python scripts/check_schema_fingerprint.py stamp
 # Verify:     python scripts/check_schema_fingerprint.py verify
-sha256:cd084fa033d24de80238a10c51d0b2344502917f5054def16b44ddb570976ba2
-generated_at: 2026-06-20T18:36:08Z
+sha256:e61840997e1a224e21ba7f9c6c622a293409ac062ea4e8902c0f6f221c301075
+generated_at: 2026-06-21T11:14:49Z
 migration_file_count: 72

--- a/docs/evidence/OMN-13406/087-cascade-scratch-proof.md
+++ b/docs/evidence/OMN-13406/087-cascade-scratch-proof.md
@@ -1,0 +1,53 @@
+# OMN-13406 — 087 CASCADE scratch acceptance proof
+
+Throwaway Postgres 16 (`docker run --rm postgres:16` on .201), torn down after the run.
+Proves: (a) WARM DB (decoy + dependent view) → hardened 087 succeeds, drops both;
+(b) COLD DB (no decoy) → clean no-op; (neg) OLD bare DROP (no CASCADE) → Postgres refuses
+(reproduces the original blocker that the CASCADE fixes).
+
+```
+[harness] starting throwaway postgres:16 container (--rm) ...
+[harness] postgres ready
+[harness] executing proof inside container ...
+====================================================================
+OMN-13406 087 CASCADE scratch proof  (2026-06-21T10:58:30Z)
+postgres server version: 16.14 (Debian 16.14-1.pgdg13+1)
+hardened 087 DROP line under test:
+45:DROP TABLE IF EXISTS public.delegation_events CASCADE;
+====================================================================
+
+### Scenario (a): WARM DB (decoy table + dependent view) -> hardened 087 (CASCADE)
+NOTICE:  database "scratch_a" does not exist, skipping
+  pre:  table_exists=t  view_exists=t  decoy_rows=40
+  --- running hardened 087.sql against scratch_a ---
+DROP TABLE
+  087 exit: 0 (SUCCESS)
+psql:/work/087.sql:45: NOTICE:  drop cascades to view projection_delegation_summary
+  post: table_dropped=t  view_dropped=t
+  VERDICT (a): PASS — decoy table AND dependent view both dropped.
+
+### Scenario (b): COLD DB (no decoy) -> hardened 087 (clean no-op)
+NOTICE:  database "scratch_b" does not exist, skipping
+  pre:  delegation_events_absent=t
+  --- running hardened 087.sql against scratch_b ---
+DROP TABLE
+  087 exit: 0 (SUCCESS / no-op)
+psql:/work/087.sql:45: NOTICE:  table "delegation_events" does not exist, skipping
+  post: delegation_events_absent=t
+  VERDICT (b): PASS — clean no-op on cold DB.
+
+### Negative control: WARM DB + OLD bare DROP (no CASCADE) -> expected FAIL
+NOTICE:  database "scratch_neg" does not exist, skipping
+  --- running OLD bare 'DROP TABLE IF EXISTS public.delegation_events;' (ON_ERROR_STOP) ---
+ERROR:  cannot drop table delegation_events because other objects depend on it
+DETAIL:  view projection_delegation_summary depends on table delegation_events
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+  bare DROP exit: NONZERO (EXPECTED — Postgres refused; confirms the original blocker)
+  VERDICT (neg): PASS — bare DROP reproduces the warm-DB failure the CASCADE fixes.
+
+====================================================================
+OVERALL: PASS — (a) CASCADE drops decoy+view, (b) cold no-op, (neg) bare DROP fails.
+[harness] proof exit code: 0
+[harness] tearing down throwaway container ...
+[harness] container removed.
+```


### PR DESCRIPTION
## OMN-13406 — Harden flat migration 087 with CASCADE (warm-DB apply fails)

Changes the bare `DROP TABLE IF EXISTS delegation_events` in
`docker/migrations/forward/087_drop_stale_delegation_events_decoy.sql` to
`DROP TABLE IF EXISTS public.delegation_events CASCADE;` (keeps `IF EXISTS`, keeps the DB-targeting guard).

### The bug (verified live on stability)
On a WARM `omnibase_infra` DB the stale decoy `delegation_events` (40 rows on stability) carries dead
dependent views. A bare DROP refuses — `ERROR: cannot drop table delegation_events because other objects
depend on it` — so the forward-migration runner (`ON_ERROR_STOP=1`) exits 3 and blocks node migrations
0017/0018/0019. Cold dev had no decoy, so it passed there; the stability promotion remediated with a manual
CASCADE drop. PROD would hit the identical blocker on its first forward-migration.

### Which objects CASCADE drops — all decoy-tied dead copies, no live objects
The 5 dependent views are built `FROM delegation_events`:

| view | created by | DB it lives in (this drop targets) |
|------|-----------|-------------------------------------|
| projection_delegation_summary | node_projection_delegation/0010 | omnibase_infra (DEAD decoy copy) |
| projection_delegation_model_routing | node_projection_delegation/0010 | omnibase_infra (DEAD decoy copy) |
| projection_delegation_quality_gate | node_projection_delegation/0010 | omnibase_infra (DEAD decoy copy) |
| projection_delegation_token_usage | node_projection_delegation/0010 | omnibase_infra (DEAD decoy copy) |
| projection_delegation_savings | node_projection_savings/076 | omnibase_infra (DEAD decoy copy) |

These copies exist in the `omnibase_infra` DB only because the node-migration runner historically defaulted
`NODE_POSTGRES_DB` to `POSTGRES_DB`(=`omnibase_infra`) before it was repointed to `omnidash_analytics` —
the same default that created the decoy table. The LIVE views of the same names live in `omnidash_analytics`,
are rebuilt there by those same node migrations under `NODE_POSTGRES_DB=omnidash_analytics`, and are
**never touched** by this flat infra migration: the flat-sequence loop in `scripts/run-forward-migrations.sh`
runs only against `POSTGRES_DB` (=`omnibase_infra`). None look live — all 5 are decoy-tied.

### Runner safety
The runner is id-based: `public.schema_migrations` keys on `migration_id` (PRIMARY KEY) and stores a literal
`'applied-by-runner'` string, not a real checksum. Lanes that already recorded `docker/087_*` skip it by id;
editing the file re-runs nowhere already-migrated. Cold DBs have no decoy → `CASCADE` is a harmless `IF EXISTS`
no-op.

### MANDATORY scratch acceptance proof — PASS
Throwaway Postgres 16 (`docker run --rm postgres:16`, torn down after the run):
- (a) WARM DB with decoy `delegation_events` (40 rows) + dependent view → hardened 087 succeeds, drops BOTH
  (`NOTICE: drop cascades to view projection_delegation_summary`; table_dropped=t view_dropped=t).
- (b) DB with NO decoy → 087 is a clean no-op success (`NOTICE: table "delegation_events" does not exist, skipping`).
- (neg) WARM DB + the OLD bare DROP (no CASCADE) → Postgres refuses (`cannot drop table ... other objects
  depend on it`), reproducing the exact original blocker the CASCADE fixes.

`OVERALL: PASS`. Full log: `docs/evidence/OMN-13406/087-cascade-scratch-proof.md`.

### dod_evidence
`contracts/OMN-13406.yaml` (dod-001 scratch proof, dod-002 migration-sequence validator PASS,
dod-deploy, dod-occ-pr). Migration-sequence validator (`scripts/validation/validate_migration_sequence.py`)
exits 0 locally with the hardened 087.

### After merge
The prod promotion's forward-migration clears the decoy automatically (CASCADE) on first run — no manual prod
DB mutation needed.

Closes OMN-13406.

Evidence-Source: OCC#2876
Evidence-Ticket: OMN-13406
