### PR TITLE
fix(OMN-13469): durabilize dev redpanda partition cap via .bootstrap.yaml

### DIFF
--- a/docker/catalog/services/redpanda.yaml
+++ b/docker/catalog/services/redpanda.yaml
@@ -17,6 +17,11 @@ healthcheck:
   start_period_s: 30
 volumes:
   - redpanda_data:/var/lib/redpanda/data
+  # OMN-13469: bootstrap.yaml is the volume-reset-proof primary mechanism for
+  # setting the cluster partition cap. Applied on first cluster formation before
+  # any topics are created. Belt #1 (reset-proof); --set flag = belt #2;
+  # redpanda-partition-cap init service = belt #3.
+  - ./redpanda/.bootstrap.yaml:/etc/redpanda/.bootstrap.yaml:ro
 depends_on: []
 restart: unless-stopped
 resources: null

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -368,6 +368,11 @@ services:
       # OMN-7302: raise partition cap from default 1000 to 7000 to prevent
       # "Not enough resources" failures when topic count × partitions exceeds
       # the per-shard limit.
+      # NOTE: --set is a node-startup flag that may not persist to cluster config
+      # on a fresh volume. The primary reset-proof mechanism is .bootstrap.yaml
+      # (mounted below). The redpanda-partition-cap init service also applies the
+      # value via rpk cluster config set post-startup. All three layers agree on
+      # 7000. (OMN-13469)
       - --set topic_partitions_per_shard=7000
     ports:
       - "${REDPANDA_EXTERNAL_PORT:-19092}:19092"
@@ -379,6 +384,12 @@ services:
       - "${REDPANDA_ADMIN_PORT:-9644}:9644"
     volumes:
       - redpanda_data:/var/lib/redpanda/data
+      # OMN-13469: .bootstrap.yaml is the volume-reset-proof primary mechanism.
+      # Redpanda reads this file on first cluster formation (fresh volume) and
+      # applies the config before any topics are created. This is belt #1;
+      # the --set flag above is belt #2; the redpanda-partition-cap init service
+      # is belt #3. Do NOT apply to prod/stability/judge (follow-up: OMN-13469).
+      - ./redpanda/.bootstrap.yaml:/etc/redpanda/.bootstrap.yaml:ro
     networks:
       - omnibase-infra-network
     healthcheck:

--- a/docker/redpanda/.bootstrap.yaml
+++ b/docker/redpanda/.bootstrap.yaml
@@ -1,0 +1,14 @@
+# OMN-13469: Redpanda cluster bootstrap configuration.
+# Mounted read-only into the redpanda container at /etc/redpanda/.bootstrap.yaml.
+# Redpanda reads this file on FIRST cluster formation (fresh volume) and applies
+# these values before any topics are created — making the partition cap
+# volume-reset-proof.
+#
+# Belt-and-suspenders:
+#   Primary (reset-proof):  this file (applied on fresh volume / first boot)
+#   Secondary (warm restart): --set flag in compose command
+#   Tertiary (post-start):   redpanda-partition-cap init service (rpk cluster config set)
+#
+# All three layers must agree. Edit all three if the target value changes.
+topic_partitions_per_shard: 7000
+topic_memory_per_partition: 1048576


### PR DESCRIPTION
## fix(OMN-13469): durabilize dev redpanda partition cap via .bootstrap.yaml

### Root Cause (verified live)

Fresh Redpanda volume boots with DEFAULT cluster cap `topic_partitions_per_shard=1000` (single shard). With ~1392 contract topics, the broker jams at ~995 with `BROKER_NOT_AVAILABLE`, leaving the runtime stuck `runtime_pending`.

**Why existing mechanisms fail on fresh volume / partial recreate:**
- `--set topic_partitions_per_shard=7000` passed to `redpanda start` is a node-startup hint, NOT a persistent cluster config write — it does not survive fresh volume formation.
- `redpanda-partition-cap` init service (`restart:"no"`) runs once on initial stack creation but does NOT re-run after a volume reset or partial recreate.

### Fix

Added `docker/redpanda/.bootstrap.yaml`:
```yaml
topic_partitions_per_shard: 7000
topic_memory_per_partition: 1048576
```

Mounted read-only into the `redpanda` container at `/etc/redpanda/.bootstrap.yaml`. Redpanda reads this file on **first cluster formation** (fresh volume), applying the config before any topics are created — making the partition cap volume-reset-proof.

### Belt-and-suspenders (all three layers agree on 7000)

| Layer | Mechanism | Applies when |
|-------|-----------|-------------|
| **1 (primary, reset-proof)** | `.bootstrap.yaml` ← this PR | Fresh volume / first cluster formation |
| **2 (warm restart)** | `--set topic_partitions_per_shard=7000` in compose command | Node startup (existing) |
| **3 (post-boot)** | `redpanda-partition-cap` init service via `rpk cluster config set` | After `redpanda` healthy (existing) |

Belts #2 and #3 are NOT removed — they are harmless and help on warm restarts. Comment added referencing OMN-13469 to explain the layering.

### Files Changed

- `docker/redpanda/.bootstrap.yaml` (new) — cluster bootstrap config, 7000 partitions/shard
- `docker/docker-compose.infra.yml` — added bootstrap.yaml mount + clarifying comment
- `docker/catalog/services/redpanda.yaml` — added bootstrap.yaml mount to catalog manifest

### Scope

**Dev compose only** (`docker-compose.infra.yml` + `docker/catalog/services/redpanda.yaml`). Prod/stability/judge lanes have independent rpk-based cap management and are NOT touched by this PR. Follow-up: extend to prod/stability for full parity (tracked under OMN-13469).

### Validation

- `docker-compose -f docker/docker-compose.infra.yml config -q` passes (syntax valid; env-var interpolation warning is pre-existing)
- `pre-commit run --files docker/docker-compose.infra.yml docker/catalog/services/redpanda.yaml docker/redpanda/.bootstrap.yaml` — all hooks pass

Evidence-Source: 815310265ba79c283c718c1524e1ebab6315f04e
Evidence-Ticket: OMN-13469
