### PR TITLE
ci(OMN-12658): runtime image build-time delegation import smoke guard + CI gate

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -193,6 +193,17 @@ jobs:
             ${{ steps.build.outputs.imageid }} \
             python -c "from omnibase_infra.runtime.kernel import bootstrap, main, load_runtime_config; print('Import successful')"
 
+      # OMN-12658: delegation-path import smoke. The Dockerfile RUN step already
+      # fails the build on a skewed wheel; this step re-asserts the same import
+      # on the loaded image so the failure mode is a clearly labeled required
+      # status check on the PR (foundation packages + canonical delegation node).
+      - name: Delegation import smoke (OMN-12658)
+        if: github.ref != 'refs/heads/main'
+        run: |
+          echo "Asserting foundation + delegation node imports on the built image..."
+          docker run --rm ${{ steps.build.outputs.imageid }} \
+            python -c "import omnibase_compat; import omnibase_core; from omnimarket.nodes.node_llm_delegation_call_effect import HandlerLlmDelegationCall; print(f'delegation import smoke OK: omnibase_compat={omnibase_compat.__version__}, omnibase_core={omnibase_core.__version__}, {HandlerLlmDelegationCall.__name__}')"
+
       - name: Verify torch is CPU-only
         if: github.ref != 'refs/heads/main'
         run: |

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -428,6 +428,19 @@ import importlib; \
 [importlib.import_module(m) for m in ('cachetools', 'omnimemory')]; \
 print('generation-path transitive deps verified: cachetools, omnimemory')"
 
+# OMN-12658: build-time import smoke guard for the delegation runtime path.
+# After ALL wheels are installed, import the foundation packages plus the
+# canonical delegation node handler. A skewed omnibase_compat / omnibase_core
+# wheel (or a delegation-node import break) fails the docker build non-zero
+# here — at build time — instead of degrading silently as a runtime
+# entry-point load failure. The docker-build CI job loads this image, so a
+# failing import fails the required status check on the PR.
+RUN /app/.venv/bin/python -c "\
+import omnibase_compat; \
+import omnibase_core; \
+from omnimarket.nodes.node_llm_delegation_call_effect import HandlerLlmDelegationCall; \
+print(f'delegation import smoke OK: omnibase_compat={omnibase_compat.__version__}, omnibase_core={omnibase_core.__version__}, {HandlerLlmDelegationCall.__name__}')"
+
 # Cleanup: remove __pycache__ and .pyc files from venv
 # Note: does NOT touch /root/.cache/uv (that's a cache mount, not persisted in layer)
 RUN find /app/.venv -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true && \

--- a/tests/unit/docker/test_delegation_import_smoke_guard.py
+++ b/tests/unit/docker/test_delegation_import_smoke_guard.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""OMN-12658: assert the runtime image carries a build-time delegation import smoke guard.
+
+These tests pin the existence of the build-time import smoke step in
+``docker/Dockerfile.runtime`` and the re-assertion step in the
+``docker-build`` CI job. The guard imports the foundation packages
+(``omnibase_compat``, ``omnibase_core``) plus the canonical delegation node
+handler after all wheels are installed, so a skewed wheel fails the docker
+build (and therefore the required ``docker-build`` status check) instead of
+degrading silently as a runtime entry-point load failure.
+
+The tests are static (no Docker daemon required) — they guarantee the guard
+cannot be silently deleted without a failing unit test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).parent.parent.parent.parent
+_WORKFLOW_PATH = _PROJECT_ROOT / ".github" / "workflows" / "docker-build.yml"
+
+# Canonical delegation node import asserted by the guard (OMN-12658).
+_DELEGATION_IMPORT = (
+    "from omnimarket.nodes.node_llm_delegation_call_effect "
+    "import HandlerLlmDelegationCall"
+)
+
+
+@pytest.mark.unit
+def test_dockerfile_has_delegation_import_smoke_guard(dockerfile_content: str) -> None:
+    """The runtime Dockerfile must import compat + core + the delegation handler at build time."""
+    assert "import omnibase_compat" in dockerfile_content
+    assert "import omnibase_core" in dockerfile_content
+    assert _DELEGATION_IMPORT in dockerfile_content
+
+
+@pytest.mark.unit
+def test_smoke_guard_runs_after_wheel_installs(dockerfile_content: str) -> None:
+    """The guard must run after ONEX wheels are installed, not before.
+
+    The delegation handler lives in omnimarket; its install step must precede
+    the smoke import so a skewed wheel is actually exercised by the guard.
+    """
+    omnimarket_install_idx = dockerfile_content.find("omnimarket")
+    guard_idx = dockerfile_content.find(_DELEGATION_IMPORT)
+    assert omnimarket_install_idx != -1, (
+        "omnimarket install step missing from Dockerfile"
+    )
+    assert guard_idx != -1, "delegation import smoke guard missing from Dockerfile"
+    assert omnimarket_install_idx < guard_idx, (
+        "delegation import smoke guard must run AFTER the omnimarket install step"
+    )
+
+
+@pytest.mark.unit
+def test_ci_job_reasserts_delegation_import_on_pr() -> None:
+    """The docker-build CI job must re-assert the delegation import on the loaded image."""
+    content = _WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "Delegation import smoke (OMN-12658)" in content
+    assert _DELEGATION_IMPORT in content
+    # The smoke step must run on PRs (where github.ref != main), so a skewed
+    # wheel fails the required status check before merge.
+    assert "github.ref != 'refs/heads/main'" in content


### PR DESCRIPTION
## OMN-12658 (Wave E) — Runtime image build-time import smoke guard + CI gate

Adds a build-time import smoke step to the runtime image so a skewed foundation wheel fails the build instead of degrading silently at runtime.

### What changed
- `docker/Dockerfile.runtime`: after all wheels install, a `RUN` step imports `omnibase_compat`, `omnibase_core`, and the canonical delegation node handler `omnimarket.nodes.node_llm_delegation_call_effect.HandlerLlmDelegationCall`. Any import failure exits the docker build non-zero.
- `.github/workflows/docker-build.yml`: the `docker-build` job (runs on PRs touching `docker/**`/`Dockerfile*`) loads the image and re-asserts the same delegation import as a labeled step ("Delegation import smoke (OMN-12658)"). A skewed wheel fails this required status check before merge.
- `tests/unit/docker/test_delegation_import_smoke_guard.py`: static unit tests pin the guard in both the Dockerfile and the CI job so it cannot be silently removed; asserts the guard runs AFTER the omnimarket install.

### Enforcement (not detection)
The build-time `RUN` is the enforcement: the image cannot build with a skewed `omnibase_compat`/`omnibase_core` wheel or a broken delegation import. The `docker-build` job is the PR-required surface that loads/exercises it.

### Scope
Runtime image only (evidence + delegation node imports). Does not touch OMN-12584 runner-image work.

### DoD evidence
- `dod_evidence`: Local proof that the smoke import path is correct against the omnimarket clone:
  `from omnimarket.nodes.node_llm_delegation_call_effect import HandlerLlmDelegationCall` → `OMNIMARKET IMPORT OK HandlerLlmDelegationCall`.
- `scripts/check_dockerfile_pins.py --dockerfile docker/Dockerfile.runtime` → "Dockerfile pin check passed".
- New unit tests: 3 passed (`tests/unit/docker/test_delegation_import_smoke_guard.py`).
- Full docker unit dir: 82 passed, 3 skipped.
- `pre-commit run --files <changed>`: clean (vendor-sync hook passes against omnimarket@origin/dev).
- The red-CI failure-mode proof (PR pinning a skewed `omnibase_compat` wheel → docker build fails with import error) is captured by the CI `docker-build` job exercising the build-time RUN; see the run on this PR.

dod_evidence: build-time import smoke guard added to docker/Dockerfile.runtime + docker-build CI re-assertion; pin check + docker unit tests green; import path verified against omnimarket clone.

Evidence-Source: 1fb0277273247c7980aa5177388db8578899ccc2
Evidence-Ticket: OMN-12658

Pre-existing (NOT introduced by this PR, fails identically on a clean origin/dev worktree):
- `tests/integration/registration/e2e/test_two_way_registration_e2e.py::...test_registry_receives_introspection_event` — AssertionError "Expected ModelNodeRegistrationAccepted, got ModelNodeBecameActive" (in-memory event-bus ordering, unrelated to Docker/CI change).
Paired OCC receipt PR: https://github.com/OmniNode-ai/onex_change_control/pull/2917 (head 6022f3d2c996d9a7e737570e9d6667fad5639217)