### PR TITLE
feat(OMN-13030): per-repo VCS provenance in build-provenance.json + evidence-probe gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,20 @@ jobs:
       - name: Check Plugin* lifecycle class guard (OMN-13284, relocated to omnibase_core)
         run: uv run pre-commit run no-plugin-daemon-classes --all-files
 
+      # OMN-13030: Deployed-SHA claims in handoff/OCC/evidence docs must carry an
+      # adjacent `docker exec <container> cat /app/build-provenance.json` probe.
+      # Enforcement, not detection: this runs the same gate as the pre-commit hook
+      # over the docs tree so a bypassed local hook fails the PR.
+      - name: Evidence provenance-probe gate (OMN-13030)
+        run: |
+          shopt -s globstar nullglob
+          docs_files=(docs/**/*.md)
+          if [ ${#docs_files[@]} -gt 0 ]; then
+            for f in "${docs_files[@]}"; do
+              uv run python scripts/check_evidence_provenance_probe.py --file "$f"
+            done
+          fi
+
       - name: Check handler Any signature gate (OMN-10820)
         run: PYTHONPATH=src uv run python -m omnibase_infra.validators.handler_any_signature --max-violations 0 src/omnibase_infra
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -321,11 +321,7 @@ repos:
         # repo-root path (validation/) that does not exist here, so the hook is
         # pinned to the canonical config/validation path to match CI (OMN-13247).
         entry: >-
-          uv run --frozen python -c "import sys; from pathlib import Path;
-          from omnibase_core.validation.validator_runtime_profiles import ValidatorRuntimeProfiles;
-          r = ValidatorRuntimeProfiles(allowlist_path=Path('config/validation/runtime_profiles_allowlist.yaml')).validate(Path('src'));
-          [print(f'[{i.severity.value}] {i.file_path}:{i.line_number}: {i.message}') for i in r.issues];
-          sys.exit(0 if r.is_valid else 1)"
+          uv run --frozen python -c "import sys; from pathlib import Path; from omnibase_core.validation.validator_runtime_profiles import ValidatorRuntimeProfiles; r = ValidatorRuntimeProfiles(allowlist_path=Path('config/validation/runtime_profiles_allowlist.yaml')).validate(Path('src')); [print(f'[{i.severity.value}] {i.file_path}:{i.line_number}: {i.message}') for i in r.issues]; sys.exit(0 if r.is_valid else 1)"
         language: system
         files: 'contract\.yaml$'
         pass_filenames: false
@@ -667,6 +663,19 @@ repos:
         language: system
         pass_filenames: false
         types_or: [markdown, yaml]
+        stages: [pre-commit]
+      # OMN-13030: Evidence provenance-probe gate.
+      # Rejects any staged markdown handoff/OCC/evidence doc that asserts a
+      # "deployed sha / running digest / promoted revision" claim WITHOUT an
+      # adjacent `docker exec <container> cat /app/build-provenance.json` probe
+      # citation. A deployed-SHA claim must be proven against the image's baked
+      # provenance manifest, not copied from a build log or memory.
+      - id: check-evidence-provenance-probe
+        name: Deployed-SHA claims require adjacent provenance-probe (OMN-13030)
+        entry: uv run --frozen python scripts/check_evidence_provenance_probe.py --staged
+        language: system
+        pass_filenames: false
+        types_or: [markdown]
         stages: [pre-commit]
       # Skip-token rejection gate (OMN-11412 / OMN-10414)
       # Blocks [skip-*] bypass tokens in staged markdown/yaml/txt files.

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -277,6 +277,13 @@ COPY scripts/runtime_build/resolve_workspace_pins.py /workspace/resolve_workspac
 # expected-vs-actual pin proof into build-provenance.json for deploy verifiers.
 COPY workspace/sibling-pin-comparison.json /workspace/sibling-pin-comparison.json
 
+# Copy the per-repo VCS provenance emitted by stage_workspace.sh (OMN-13030). A
+# committed placeholder makes this COPY always valid; workspace mode overwrites
+# it with the real per-repo {vcs_ref, vcs_dirty, vcs_branch} so
+# compute_workspace_provenance.py can fold it into build-provenance.json for
+# deploy verifiers. Release mode ignores it.
+COPY workspace/sibling-vcs-provenance.json /workspace/sibling-vcs-provenance.json
+
 # workspace mode installs omnibase_core, omnibase_compat, onex_change_control,
 # omnimarket from the staged local trees.  release mode installs from pinned
 # remote sources (core stays from omnibase_infra/uv.lock — correct for a release).
@@ -356,7 +363,7 @@ RUN set -eu; \
     if [ "${BUILD_SOURCE}" = "workspace" ]; then \
         /app/.venv/bin/python /workspace/compute_workspace_provenance.py; \
     else \
-        printf '{\n  "build_source": "release",\n  "build_time": "%s",\n  "vcs_ref": "%s",\n  "proofs": [],\n  "lock_pin_comparison": []\n}\n' \
+        printf '{\n  "build_source": "release",\n  "build_time": "%s",\n  "infra_vcs_ref": "%s",\n  "proofs": [],\n  "per_repo_vcs_provenance": {"siblings": {}},\n  "lock_pin_comparison": []\n}\n' \
             "${BUILD_DATE:-unknown}" "${VCS_REF:-unknown}" > /app/build-provenance.json; \
     fi
 

--- a/docs/templates/runtime-deploy-handoff-template.md
+++ b/docs/templates/runtime-deploy-handoff-template.md
@@ -1,0 +1,54 @@
+# Runtime Deploy Handoff — <OMN-XXXX> — <YYYY-MM-DD>
+
+> Template for any handoff/OCC doc that claims a runtime was deployed/redeployed.
+> Per OMN-13030, every "deployed SHA" claim must be proven against the image's
+> baked `/app/build-provenance.json`, never copied from a build log or memory.
+> The `check-evidence-provenance-probe` pre-commit + CI gate rejects a
+> deployed-SHA claim without an adjacent `docker exec ... cat
+> /app/build-provenance.json` probe.
+
+## Lane
+
+- Lane: `<dev | stability-test | prod>`
+- Compose project: `<omnibase-infra | omnibase-infra-stability-test | ...>`
+- verified: `<YYYY-MM-DDTHH:MMZ>` via `<probe command>`
+
+## Per-container deployed SHA table
+
+Fill one row per running runtime container. The `infra_vcs_ref` and per-sibling
+`vcs_ref` columns are read DIRECTLY from each container's baked provenance
+manifest (see probe block below) — do not hand-copy from a build log.
+
+| Container | `infra_vcs_ref` | `omnibase_core` vcs_ref | `omnimarket` vcs_ref | `onex_change_control` vcs_ref | dirty? |
+|-----------|-----------------|-------------------------|----------------------|-------------------------------|--------|
+| `<container-1>` | `<sha>` | `<sha>` | `<sha>` | `<sha>` | `<true/false>` |
+| `<container-2>` | `<sha>` | `<sha>` | `<sha>` | `<sha>` | `<true/false>` |
+
+## Provenance probe (EFFECT — reads the image's own manifest)
+
+Paste the verbatim output of probing `/app/build-provenance.json` from each
+running container. This is the citation that substantiates the SHA table above.
+
+```bash
+docker exec <runtime-container> cat /app/build-provenance.json
+```
+
+```json
+{
+  "build_source": "workspace",
+  "build_time": "<...>",
+  "infra_vcs_ref": "<...>",
+  "per_repo_vcs_provenance": {
+    "siblings": {
+      "omnibase_core": {"vcs_ref": "<...>", "vcs_dirty": false, "vcs_branch": "dev"},
+      "omnimarket": {"vcs_ref": "<...>", "vcs_dirty": false, "vcs_branch": "dev"}
+    }
+  }
+}
+```
+
+## Health proof
+
+- Probe: `<command>`
+- Result: `<HEALTHY | ...>`
+- verified: `<YYYY-MM-DDTHH:MMZ>` via `<command>`

--- a/scripts/check_evidence_provenance_probe.py
+++ b/scripts/check_evidence_provenance_probe.py
@@ -1,0 +1,197 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""check_evidence_provenance_probe.py — Pre-commit gate: reject a "deployed SHA"
+claim in a handoff/OCC/evidence doc that lacks an adjacent provenance-probe
+citation (OMN-13030).
+
+THE CLASS FIX: deploy/handoff docs routinely assert "the runtime is now running
+SHA <x>" copied from a build log or memory, never from the image itself. The
+ground truth is baked into the image at /app/build-provenance.json. This gate
+makes a deployed-SHA claim unwritable unless the same document shows the output
+of probing that file from the running container.
+
+RULE: Any staged markdown file that contains a "deployed sha" / "deployed
+digest" / "running sha" style claim MUST carry a provenance-probe citation
+within a small window of lines around the claim. The accepted probe is a
+`docker exec <container> cat .../build-provenance.json` invocation (the EFFECT
+that reads the image's own provenance manifest), optionally with `ssh ...`
+prefix for a remote host.
+
+Exit codes:
+  0 — every deployed-SHA claim has an adjacent provenance-probe citation
+  1 — one or more claims lack the adjacent probe
+
+Usage (pre-commit):
+  python scripts/check_evidence_provenance_probe.py --staged
+  python scripts/check_evidence_provenance_probe.py --file path/to/handoff.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# A concrete deployed-SHA claim: a deployed/running/promoted/live/redeployed
+# assertion that carries an ACTUAL SHA value on the same line. Abstract mentions
+# of the words "deployed sha" (schema field descriptions, artifact-file captions,
+# status definitions) are NOT claims — only an asserted concrete digest is. The
+# value must be a >=7-hex-char git short/long SHA or a `sha256:` image digest.
+_CLAIM_VERB = r"(?:deployed|running|promoted|live|redeployed)"
+_SHA_WORD = r"(?:sha|digest|revision|commit)"
+_SHA_VALUE = r"(?:sha256:[0-9a-f]{12,}|\b[0-9a-f]{7,40}\b)"
+_DEPLOYED_SHA_CLAIM = re.compile(
+    rf"\b{_CLAIM_VERB}\b[^\n]{{0,80}}?\b{_SHA_WORD}\b[^\n]{{0,40}}?{_SHA_VALUE}",
+    re.IGNORECASE,
+)
+
+# The accepted provenance probe: a docker-exec read of the image's baked
+# build-provenance manifest. Accepts an optional ssh prefix for remote hosts.
+_PROVENANCE_PROBE = re.compile(
+    r"docker\s+exec\b[^\n]*\bcat\b[^\n]*build-provenance\.json",
+    re.IGNORECASE,
+)
+
+# Number of lines on each side of a claim within which a probe must appear for
+# the claim to be considered substantiated. A probe block immediately above or
+# below the claim is the expected shape.
+_PROBE_WINDOW_LINES = 15
+
+# Files exempt from the gate (this script itself, test fixtures, the schema doc
+# which references build-provenance.json structurally, and docs/templates/ which
+# DEMONSTRATE the required shape rather than assert a real deployment).
+_EXEMPT_PATH_PATTERNS = [
+    re.compile(r"^tests/"),
+    re.compile(r"^docs/templates/"),
+    re.compile(r"scripts/check_evidence_provenance_probe\.py$"),
+    re.compile(r"build-provenance-schema\.json$"),
+]
+
+
+def _is_exempt(path: str) -> bool:
+    return any(p.search(path) for p in _EXEMPT_PATH_PATTERNS)
+
+
+def _probe_in_window(lines: list[str], claim_idx: int) -> bool:
+    lo = max(0, claim_idx - _PROBE_WINDOW_LINES)
+    hi = min(len(lines), claim_idx + _PROBE_WINDOW_LINES + 1)
+    window = "\n".join(lines[lo:hi])
+    return bool(_PROVENANCE_PROBE.search(window))
+
+
+def check_file(path: Path) -> list[str]:
+    """Check a single file. Returns a list of violation messages."""
+    violations: list[str] = []
+    rel = str(path)
+
+    if _is_exempt(rel):
+        return violations
+
+    try:
+        content = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return violations  # file disappeared between staging and check
+
+    lines = content.splitlines()
+    for idx, line in enumerate(lines):
+        stripped = line.lstrip()
+        # Markdown headings and blockquote meta-lines describe structure/guidance,
+        # not a runtime deployment assertion. A real "deployed SHA" claim is a
+        # normal statement or table row.
+        if stripped.startswith(("#", ">")):
+            continue
+        if not _DEPLOYED_SHA_CLAIM.search(line):
+            continue
+        if _probe_in_window(lines, idx):
+            continue
+        violations.append(
+            f"{rel}:{idx + 1}: deployed-SHA claim without an adjacent "
+            f"provenance-probe citation. Add the output of "
+            f"`docker exec <runtime-container> cat /app/build-provenance.json` "
+            f"within {_PROBE_WINDOW_LINES} lines of the claim so the deployed "
+            f"SHA is proven against the image's baked provenance manifest, not "
+            f"copied from a build log or memory (OMN-13030). Claim: "
+            f"{line.strip()[:80]!r}"
+        )
+
+    return violations
+
+
+def check_staged() -> list[str]:
+    """Check all staged markdown files for unsubstantiated deployed-SHA claims."""
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--cached", "--name-only", "--diff-filter=ACM"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        print(f"ERROR: git diff failed: {exc}", file=sys.stderr)
+        return []
+
+    staged_files = [f.strip() for f in result.stdout.splitlines() if f.strip()]
+    violations: list[str] = []
+
+    for rel_path in staged_files:
+        if not rel_path.endswith(".md"):
+            continue
+        path = Path(rel_path)
+        if not path.exists():
+            continue
+        violations.extend(check_file(path))
+
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Pre-commit gate: reject deployed-SHA claims in evidence/handoff "
+            "docs that lack an adjacent provenance-probe citation (OMN-13030)"
+        )
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--staged",
+        action="store_true",
+        help="Check all staged markdown files (pre-commit mode)",
+    )
+    group.add_argument(
+        "--file",
+        type=Path,
+        dest="file_path",
+        metavar="FILE",
+        help="Check a single file",
+    )
+    args = parser.parse_args(argv)
+
+    if args.staged:
+        violations = check_staged()
+    else:
+        violations = check_file(args.file_path)
+
+    if violations:
+        print(
+            "EVIDENCE-PROVENANCE GATE: deployed-SHA claim without adjacent "
+            "provenance-probe citation",
+            file=sys.stderr,
+        )
+        for v in violations:
+            print(f"  {v}", file=sys.stderr)
+        print(
+            "\nProve the deployed SHA against the image: "
+            "`docker exec <container> cat /app/build-provenance.json` "
+            "(OMN-13030).",
+            file=sys.stderr,
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/deploy-runtime.sh
+++ b/scripts/deploy-runtime.sh
@@ -1410,6 +1410,18 @@ if spec and spec.origin:
         "${repo_root}/workspace/sibling-pin-comparison.json" \
         "${deploy_target}/workspace/sibling-pin-comparison.json"
 
+    # Carry the per-repo VCS provenance file Dockerfile.runtime COPYs
+    # (workspace/sibling-vcs-provenance.json, OMN-13030). Same rationale as the
+    # pin-comparison file above: the sibling-repos/ rsync only covers the
+    # subdirectory, so without this the deployed build context lacks the file and
+    # `docker build` fails on the COPY. Release mode ships the committed
+    # placeholder; workspace mode ships the real per-repo {vcs_ref, vcs_dirty,
+    # vcs_branch} stage_workspace.sh wrote into the repo root.
+    log_cmd "rsync -a workspace/sibling-vcs-provenance.json -> deployed"
+    rsync -a \
+        "${repo_root}/workspace/sibling-vcs-provenance.json" \
+        "${deploy_target}/workspace/sibling-vcs-provenance.json"
+
     # 6. Migration scripts (bind-mounted by docker-compose.infra.yml)
     log_info "Syncing migration scripts..."
     mkdir -p "${deploy_target}/scripts"

--- a/scripts/runtime_build/build-provenance-schema.json
+++ b/scripts/runtime_build/build-provenance-schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://omninode.ai/schemas/build-provenance.json",
+  "title": "RuntimeBuildProvenance",
+  "description": "Schema for /app/build-provenance.json baked into the omninode-runtime image. Records the build source, the building infra repo's own VCS ref (infra_vcs_ref), per-sibling-repo VCS provenance (vcs_ref/vcs_dirty/vcs_branch), workspace install proofs, and sibling lock-pin comparisons. Written by scripts/runtime_build/compute_workspace_provenance.py (workspace mode) or the Dockerfile release-mode printf (OMN-13030).",
+  "type": "object",
+  "required": ["build_source", "build_time", "infra_vcs_ref"],
+  "additionalProperties": true,
+  "properties": {
+    "build_source": {
+      "type": "string",
+      "enum": ["workspace", "release"],
+      "description": "Whether the image was built from staged local sibling trees (workspace) or pinned remote sources (release)."
+    },
+    "build_time": {
+      "type": "string",
+      "description": "BUILD_DATE build-arg, or 'unknown'."
+    },
+    "infra_vcs_ref": {
+      "type": "string",
+      "description": "The building omnibase_infra repo's own git ref (VCS_REF build-arg). Renamed from the ambiguous top-level 'vcs_ref' in OMN-13030 to disambiguate the host infra ref from per-sibling refs."
+    },
+    "per_repo_vcs_provenance": {
+      "type": "object",
+      "description": "Per-sibling-repo VCS provenance captured by stage_workspace.sh at staging time. Empty in release mode (siblings come from pinned remote sources, not staged clones).",
+      "properties": {
+        "siblings": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "required": ["vcs_ref", "vcs_dirty", "vcs_branch"],
+            "additionalProperties": false,
+            "properties": {
+              "vcs_ref": {
+                "type": "string",
+                "description": "The sibling clone's HEAD commit SHA at staging time."
+              },
+              "vcs_dirty": {
+                "type": "boolean",
+                "description": "True if the sibling clone had uncommitted changes (git status --porcelain non-empty) at staging time."
+              },
+              "vcs_branch": {
+                "type": "string",
+                "description": "The sibling clone's checked-out branch (git rev-parse --abbrev-ref HEAD); 'HEAD' for a detached checkout."
+              }
+            }
+          }
+        }
+      }
+    },
+    "proofs": {
+      "type": "array",
+      "description": "Per-sibling workspace install proofs (digest + local-install assertion)."
+    },
+    "pin_comparison": {
+      "type": "array",
+      "description": "Expected-vs-actual sibling lock-pin comparison computed during the provenance pass."
+    },
+    "sibling_pin_comparison": {
+      "type": ["object", "null"],
+      "description": "The preflight's expected-vs-actual sibling-pin comparison artifact, folded in for deploy verifiers."
+    }
+  }
+}

--- a/scripts/runtime_build/compute_workspace_provenance.py
+++ b/scripts/runtime_build/compute_workspace_provenance.py
@@ -54,6 +54,13 @@ CONSUMING_REPO = "omnimarket"
 # so deploy verifiers can assert the build honored the consuming repo's lock
 # (OMN-12977). Absent only for builds staged before the preflight existed.
 PIN_COMPARISON_PATH = Path("/workspace/sibling-pin-comparison.json")
+# Per-repo VCS provenance emitted by stage_workspace.sh (OMN-13030): records
+# {vcs_ref, vcs_dirty, vcs_branch} for every staged sibling at staging time,
+# where the source clone's git history is still reachable (rsync strips .git
+# from the staged tree, so this is the ONLY recoverable VCS identity). Folded
+# into the manifest so a deploy verifier can prove which commit (and clean/dirty
+# state) of each sibling was vendored.
+VCS_PROVENANCE_PATH = Path("/workspace/sibling-vcs-provenance.json")
 
 # Canonical set of sibling repos that workspace mode must provision.
 # Keys are the directory names under sibling-repos/; values are installed
@@ -147,6 +154,34 @@ def _load_pin_comparison(errors: list[str]) -> dict[str, object] | None:
             "drift(s) -- the build vendored stale siblings (OMN-12977)."
         )
     return comparison
+
+
+def _load_vcs_provenance(errors: list[str]) -> dict[str, object]:
+    """Load stage_workspace.sh's per-repo VCS provenance (OMN-13030).
+
+    Returns the parsed {"siblings": {...}} dict. A workspace build whose VCS
+    provenance is absent or carries no sibling entries means stage_workspace.sh
+    did not stamp the per-repo git identity — the staged tree is unverifiable,
+    so this is recorded as an error and fails the build (consistent with the
+    fail-closed stance the staging step already takes on an unreadable HEAD).
+    """
+    if not VCS_PROVENANCE_PATH.exists():
+        errors.append(
+            f"Missing per-repo VCS provenance: {VCS_PROVENANCE_PATH}. "
+            "stage_workspace.sh must stamp per-repo {vcs_ref, vcs_dirty, "
+            "vcs_branch} before the workspace build (OMN-13030)."
+        )
+        return {"siblings": {}}
+    parsed: dict[str, object] = json.loads(
+        VCS_PROVENANCE_PATH.read_text(encoding="utf-8")
+    )
+    siblings = parsed.get("siblings", {})
+    if not isinstance(siblings, dict) or not siblings:
+        errors.append(
+            "Per-repo VCS provenance has no sibling entries; the staged tree "
+            "is unverifiable (OMN-13030)."
+        )
+    return {"siblings": siblings if isinstance(siblings, dict) else {}}
 
 
 def main() -> int:
@@ -261,11 +296,18 @@ def main() -> int:
     # operator override was used, this records expected-vs-actual durably.
     sibling_pin_comparison = _load_pin_comparison(errors)
 
+    # OMN-13030: per-repo VCS provenance stamped by stage_workspace.sh.
+    per_repo_vcs_provenance = _load_vcs_provenance(errors)
+
     manifest = {
         "build_source": "workspace",
         "build_time": os.environ.get("BUILD_DATE", "unknown"),
-        "vcs_ref": os.environ.get("VCS_REF", "unknown"),
+        # Renamed from the ambiguous top-level "vcs_ref" (OMN-13030): this is the
+        # building omnibase_infra repo's OWN ref, distinct from the per-sibling
+        # refs now recorded under "per_repo_vcs_provenance".
+        "infra_vcs_ref": os.environ.get("VCS_REF", "unknown"),
         "proofs": proofs,
+        "per_repo_vcs_provenance": per_repo_vcs_provenance,
         "pin_comparison": pin_comparison,
         "sibling_pin_comparison": sibling_pin_comparison,
     }

--- a/scripts/runtime_build/stage_workspace.sh
+++ b/scripts/runtime_build/stage_workspace.sh
@@ -103,6 +103,18 @@ fi
 STAGING_DIR="workspace/sibling-repos"
 mkdir -p "${STAGING_DIR}"
 
+# ---------------------------------------------------------------------------
+# Per-repo VCS provenance (OMN-13030): record {vcs_ref, vcs_dirty, vcs_branch}
+# for every sibling at staging time. rsync drops .git, so the staged tree has
+# no recoverable VCS identity inside the image — this is the only point in the
+# build where the source clone's git history is reachable. The manifest is
+# folded into /app/build-provenance.json by compute_workspace_provenance.py so a
+# deploy verifier can prove EXACTLY which commit (and clean/dirty state) of each
+# sibling was vendored. A sibling whose git history cannot be read is an
+# unverifiable build and ABORTS (no silent "unknown" stamp).
+# ---------------------------------------------------------------------------
+VCS_PROVENANCE_OUT="workspace/sibling-vcs-provenance.json"
+
 missing=()
 for repo in "${SIBLING_REPOS[@]}"; do
     src="${OMNI_HOME}/${repo}"
@@ -119,6 +131,7 @@ if [[ ${#missing[@]} -gt 0 ]]; then
     exit 2
 fi
 
+vcs_entries=()
 for repo in "${SIBLING_REPOS[@]}"; do
     src="${OMNI_HOME}/${repo}"
     dst="${STAGING_DIR}/${repo}"
@@ -133,12 +146,45 @@ for repo in "${SIBLING_REPOS[@]}"; do
     # Record the source HEAD SHA so the lock-pin preflight and provenance can
     # identify exactly which commit was vendored. rsync drops .git, so without
     # this marker the staged tree has no recoverable SHA (OMN-12987).
-    if git -C "${src}" rev-parse HEAD >/dev/null 2>&1; then
-        git -C "${src}" rev-parse HEAD > "${dst}/.build-sha"
-    else
+    if ! vcs_ref="$(git -C "${src}" rev-parse HEAD 2>/dev/null)"; then
         echo "ERROR: cannot resolve HEAD SHA for ${src}; refusing to stage an unverifiable tree" >&2
         exit 3
     fi
+    echo "${vcs_ref}" > "${dst}/.build-sha"
+
+    # OMN-13030: capture full per-repo VCS provenance at staging time. A repo
+    # whose git history is unreadable for the branch/status probes is just as
+    # unverifiable as one missing a HEAD SHA — abort rather than stamp "unknown".
+    if ! vcs_branch="$(git -C "${src}" rev-parse --abbrev-ref HEAD 2>/dev/null)"; then
+        echo "ERROR: cannot resolve branch for ${src}; refusing to stage an unverifiable tree (OMN-13030)" >&2
+        exit 3
+    fi
+    if ! status_out="$(git -C "${src}" status --porcelain 2>/dev/null)"; then
+        echo "ERROR: cannot resolve working-tree status for ${src}; refusing to stage an unverifiable tree (OMN-13030)" >&2
+        exit 3
+    fi
+    if [[ -n "${status_out}" ]]; then
+        vcs_dirty="true"
+    else
+        vcs_dirty="false"
+    fi
+    vcs_entries+=("$(printf '    "%s": {"vcs_ref": "%s", "vcs_dirty": %s, "vcs_branch": "%s"}' \
+        "${repo}" "${vcs_ref}" "${vcs_dirty}" "${vcs_branch}")")
 done
 
+# Emit the per-repo VCS provenance manifest. compute_workspace_provenance.py
+# folds this into /app/build-provenance.json under "per_repo_vcs_provenance".
+{
+    printf '{\n  "siblings": {\n'
+    for i in "${!vcs_entries[@]}"; do
+        if [[ "${i}" -lt $((${#vcs_entries[@]} - 1)) ]]; then
+            printf '%s,\n' "${vcs_entries[$i]}"
+        else
+            printf '%s\n' "${vcs_entries[$i]}"
+        fi
+    done
+    printf '  }\n}\n'
+} > "${VCS_PROVENANCE_OUT}"
+
 echo "workspace staging complete: ${#SIBLING_REPOS[@]} repos staged to ${STAGING_DIR}"
+echo "per-repo VCS provenance written to ${VCS_PROVENANCE_OUT}"

--- a/tests/scripts/test_deploy_runtime_build_context.py
+++ b/tests/scripts/test_deploy_runtime_build_context.py
@@ -284,4 +284,8 @@ def test_stage_workspace_emits_build_sha_marker() -> None:
         DEPLOY_SCRIPT.parent / "runtime_build" / "stage_workspace.sh"
     ).read_text(encoding="utf-8")
 
-    assert 'git -C "${src}" rev-parse HEAD > "${dst}/.build-sha"' in stage_script
+    # OMN-13030 refactored the SHA capture to a variable (reused for the
+    # per-repo VCS provenance manifest), so assert the marker is still written
+    # from the resolved HEAD SHA.
+    assert 'git -C "${src}" rev-parse HEAD' in stage_script
+    assert 'echo "${vcs_ref}" > "${dst}/.build-sha"' in stage_script

--- a/tests/scripts/test_stage_workspace_vcs_provenance.py
+++ b/tests/scripts/test_stage_workspace_vcs_provenance.py
@@ -1,0 +1,230 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""OMN-13030: per-repo VCS provenance in build-provenance.json.
+
+Covers the staging-time capture of {vcs_ref, vcs_dirty, vcs_branch} for each
+sibling repo, the fail-non-zero behavior when a sibling has no git history, and
+the manifest fold-in (infra_vcs_ref rename + per_repo_vcs_provenance block).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+STAGE_SCRIPT = REPO_ROOT / "scripts" / "runtime_build" / "stage_workspace.sh"
+PROVENANCE_SCRIPT = (
+    REPO_ROOT / "scripts" / "runtime_build" / "compute_workspace_provenance.py"
+)
+SCHEMA_FILE = REPO_ROOT / "scripts" / "runtime_build" / "build-provenance-schema.json"
+
+SIBLING_REPOS = (
+    "omnibase_core",
+    "omnibase_compat",
+    "onex_change_control",
+    "omnimarket",
+)
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
+    )
+
+
+# Distribution names (as they appear in uv.lock / pyproject) keyed by repo dir.
+_DIST_NAME = {
+    "omnibase_core": "omnibase-core",
+    "omnibase_compat": "omnibase-compat",
+    "onex_change_control": "onex-change-control",
+    "omnimarket": "omnimarket",
+    "omnibase_infra": "omnibase-infra",
+    "omnibase_spi": "omnibase-spi",
+}
+_PIN_VERSION = "9.9.9"
+
+
+def _init_repo(path: Path, dist: str, *, dirty: bool = False) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    _git(path, "init", "-q", "-b", "dev")
+    _git(path, "config", "user.email", "t@t.t")
+    _git(path, "config", "user.name", "t")
+    # Version matches the synthetic lock pin so the preflight resolves clean.
+    (path / "pyproject.toml").write_text(
+        f"[project]\nname = '{dist}'\nversion = '{_PIN_VERSION}'\n",
+        encoding="utf-8",
+    )
+    _git(path, "add", "-A")
+    _git(path, "commit", "-q", "-m", "init")
+    if dirty:
+        (path / "pyproject.toml").write_text(
+            f"[project]\nname = '{dist}'\nversion = '{_PIN_VERSION}'\n# dirty\n",
+            encoding="utf-8",
+        )
+
+
+def _write_consumer_lock(omni_home: Path) -> None:
+    """Write a uv.lock pinning every vendored sibling at _PIN_VERSION."""
+    blocks = []
+    for dist in _DIST_NAME.values():
+        blocks.append(f'[[package]]\nname = "{dist}"\nversion = "{_PIN_VERSION}"\n')
+    (omni_home / "omnimarket" / "uv.lock").write_text(
+        "\n".join(blocks), encoding="utf-8"
+    )
+
+
+def _make_omni_home(tmp_path: Path, *, dirty_repo: str | None = None) -> Path:
+    omni_home = tmp_path / "omni_home"
+    for repo in SIBLING_REPOS:
+        _init_repo(omni_home / repo, _DIST_NAME[repo], dirty=(repo == dirty_repo))
+    # omnibase_infra (the building repo) + spi must exist for the preflight.
+    for repo in ("omnibase_infra", "omnibase_spi"):
+        _init_repo(omni_home / repo, _DIST_NAME[repo])
+    _write_consumer_lock(omni_home)
+    return omni_home
+
+
+def _run_stage(omni_home: Path, build_ctx: Path) -> subprocess.CompletedProcess[str]:
+    (build_ctx / "workspace").mkdir(parents=True, exist_ok=True)
+    env = {
+        **os.environ,
+        "OMNI_HOME": str(omni_home),
+        # Synthetic clones are pinned at _PIN_VERSION matching the consumer lock,
+        # so the preflight resolves clean without an allow-drift override.
+        "CONSUMER_LOCK": str(omni_home / "omnimarket" / "uv.lock"),
+    }
+    return subprocess.run(
+        ["bash", str(STAGE_SCRIPT)],
+        cwd=build_ctx,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.mark.unit
+def test_stage_writes_per_repo_vcs_provenance(tmp_path: Path) -> None:
+    omni_home = _make_omni_home(tmp_path, dirty_repo="omnimarket")
+    build_ctx = tmp_path / "ctx"
+    result = _run_stage(omni_home, build_ctx)
+    assert result.returncode == 0, result.stderr
+
+    manifest_path = build_ctx / "workspace" / "sibling-vcs-provenance.json"
+    assert manifest_path.exists(), result.stderr
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    siblings = manifest["siblings"]
+    assert set(siblings) == set(SIBLING_REPOS)
+    for repo in SIBLING_REPOS:
+        entry = siblings[repo]
+        assert len(entry["vcs_ref"]) == 40  # full SHA
+        assert entry["vcs_branch"] == "dev"
+        assert isinstance(entry["vcs_dirty"], bool)
+    # The dirty repo is flagged; clean repos are not.
+    assert siblings["omnimarket"]["vcs_dirty"] is True
+    assert siblings["omnibase_core"]["vcs_dirty"] is False
+
+
+@pytest.mark.unit
+def test_stage_aborts_when_sibling_has_no_git_history(tmp_path: Path) -> None:
+    omni_home = _make_omni_home(tmp_path)
+    # Destroy one sibling's git history -> unverifiable tree -> must abort.
+    subprocess.run(["rm", "-rf", str(omni_home / "omnibase_core" / ".git")], check=True)
+    build_ctx = tmp_path / "ctx"
+    result = _run_stage(omni_home, build_ctx)
+    # DoD (OMN-13030): a missing sibling git history must fail the build non-zero.
+    # The failure may surface in the pin preflight (which also git-resolves clone
+    # SHAs) or in the staging loop's vcs-provenance capture; either is a hard
+    # abort — never a silent "unknown" stamp.
+    assert result.returncode != 0
+    assert (
+        "cannot resolve clone pin" in result.stderr
+        or "unverifiable tree" in result.stderr
+    )
+    # The unverifiable tree must NOT have produced a VCS provenance manifest.
+    assert not (build_ctx / "workspace" / "sibling-vcs-provenance.json").exists()
+
+
+@pytest.mark.unit
+def test_manifest_uses_infra_vcs_ref_and_folds_vcs_provenance(tmp_path: Path) -> None:
+    """compute_workspace_provenance folds the staged VCS provenance and renames
+    the ambiguous top-level vcs_ref -> infra_vcs_ref."""
+    # Build a synthetic image-layout tree the provenance script expects.
+    sib_dir = tmp_path / "sibling-repos"
+    venv_dir = tmp_path / "app" / ".venv"
+    app_dir = tmp_path / "app"
+    app_dir.mkdir(parents=True)
+    for repo in (
+        "omnibase_core",
+        "omnibase_compat",
+        "onex_change_control",
+        "omnimarket",
+    ):
+        (sib_dir / repo).mkdir(parents=True)
+        (sib_dir / repo / "f.py").write_text("x=1\n", encoding="utf-8")
+    (sib_dir / "omnimarket" / "uv.lock").write_text("", encoding="utf-8")
+
+    vcs_prov = tmp_path / "sibling-vcs-provenance.json"
+    vcs_prov.write_text(
+        json.dumps(
+            {
+                "siblings": {
+                    "omnibase_core": {
+                        "vcs_ref": "a" * 40,
+                        "vcs_dirty": False,
+                        "vcs_branch": "dev",
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    # Patch the module-level paths so the script runs against the temp layout
+    # without needing the in-image /workspace + /app absolute paths.
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("cwp_under_test", PROVENANCE_SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    mod.SIBLING_REPOS_DIR = sib_dir
+    mod.VENV_DIR = venv_dir
+    mod.OUTPUT_MANIFEST = app_dir / "build-provenance.json"
+    mod.PIN_COMPARISON_PATH = tmp_path / "no-such-pin.json"
+    mod.VCS_PROVENANCE_PATH = vcs_prov
+
+    os.environ["VCS_REF"] = "deadbeef"
+    rc = mod.main()
+    # Install proofs will fail (packages not installed) -> rc 1, but the manifest
+    # is still written with the renamed field + folded VCS provenance.
+    manifest = json.loads(mod.OUTPUT_MANIFEST.read_text(encoding="utf-8"))
+    assert "vcs_ref" not in manifest
+    assert manifest["infra_vcs_ref"] == "deadbeef"
+    assert (
+        manifest["per_repo_vcs_provenance"]["siblings"]["omnibase_core"]["vcs_ref"]
+        == "a" * 40
+    )
+    assert rc in (0, 1)  # rc depends on install proofs, not on this ticket's fields
+
+
+@pytest.mark.unit
+def test_schema_declares_per_repo_vcs_provenance_and_infra_vcs_ref() -> None:
+    schema = json.loads(SCHEMA_FILE.read_text(encoding="utf-8"))
+    assert "infra_vcs_ref" in schema["properties"]
+    sibling_schema = schema["properties"]["per_repo_vcs_provenance"]["properties"][
+        "siblings"
+    ]["additionalProperties"]
+    assert set(sibling_schema["required"]) == {"vcs_ref", "vcs_dirty", "vcs_branch"}

--- a/tests/unit/scripts/test_check_evidence_provenance_probe.py
+++ b/tests/unit/scripts/test_check_evidence_provenance_probe.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""OMN-13030: evidence provenance-probe gate.
+
+A deployed-SHA claim in a handoff/OCC/evidence doc must carry an adjacent
+`docker exec <container> cat /app/build-provenance.json` probe citation.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "scripts" / "check_evidence_provenance_probe.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("evidence_probe", SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.mark.unit
+def test_claim_without_probe_is_rejected(tmp_path: Path) -> None:
+    mod = _load()
+    doc = tmp_path / "handoff.md"
+    doc.write_text(
+        "# Deploy\n\nThe runtime is now running sha abc1234 on the dev lane.\n",
+        encoding="utf-8",
+    )
+    violations = mod.check_file(doc)
+    assert violations
+    assert "provenance-probe" in violations[0]
+
+
+@pytest.mark.unit
+def test_claim_with_adjacent_probe_passes(tmp_path: Path) -> None:
+    mod = _load()
+    doc = tmp_path / "handoff.md"
+    doc.write_text(
+        "# Deploy\n\n"
+        "Deployed sha abc1234 to dev.\n\n"
+        "```bash\n"
+        "docker exec omninode-runtime cat /app/build-provenance.json\n"
+        "```\n",
+        encoding="utf-8",
+    )
+    assert mod.check_file(doc) == []
+
+
+@pytest.mark.unit
+def test_doc_without_any_claim_passes(tmp_path: Path) -> None:
+    mod = _load()
+    doc = tmp_path / "notes.md"
+    doc.write_text("# Notes\n\nThis doc makes no deploy claims.\n", encoding="utf-8")
+    assert mod.check_file(doc) == []
+
+
+@pytest.mark.unit
+def test_remote_ssh_docker_exec_probe_accepted(tmp_path: Path) -> None:
+    mod = _load()
+    doc = tmp_path / "handoff.md"
+    doc.write_text(
+        "Promoted revision deadbeef.\n\n"
+        "ssh jonah@host docker exec runtime cat /app/build-provenance.json\n",
+        encoding="utf-8",
+    )
+    assert mod.check_file(doc) == []

--- a/workspace/sibling-vcs-provenance.json
+++ b/workspace/sibling-vcs-provenance.json
@@ -1,0 +1,4 @@
+{
+  "siblings": {},
+  "_note": "Placeholder committed so the Dockerfile COPY always resolves. In workspace mode, stage_workspace.sh overwrites this with the real per-repo {vcs_ref, vcs_dirty, vcs_branch} provenance (OMN-13030). Release mode ignores it."
+}


### PR DESCRIPTION
## Summary (OMN-13030, Wave E)

Runtime fresh-deploy hardening + build provenance. Stamps per-sibling git identity into the runtime image's baked provenance manifest and adds an evidence-lint gate so deployed-SHA claims must be proven against that manifest.

### What changed
- **`scripts/runtime_build/stage_workspace.sh`** — stamps per-sibling `{vcs_ref, vcs_dirty, vcs_branch}` into `workspace/sibling-vcs-provenance.json` at staging time (the only point where the source clone's git history is reachable; rsync strips `.git` from the staged tree). A sibling whose git history (HEAD, branch, or status) is unreadable **aborts the build non-zero** rather than stamping `unknown`.
- **`scripts/runtime_build/compute_workspace_provenance.py`** — folds the per-repo VCS provenance into `/app/build-provenance.json` under `per_repo_vcs_provenance`, and renames the ambiguous top-level `vcs_ref` → **`infra_vcs_ref`** (the building infra repo's own ref, distinct from the per-sibling refs). No consumer read the old JSON `vcs_ref` field.
- **`scripts/runtime_build/build-provenance-schema.json`** — JSON Schema for the manifest.
- **`scripts/check_evidence_provenance_probe.py`** + **`.pre-commit-config.yaml`** + **`.github/workflows/ci.yml`** — evidence-lint gate (pre-commit + required CI step): rejects any handoff/OCC/evidence doc asserting a **concrete** deployed SHA without an adjacent `docker exec <container> cat /app/build-provenance.json` probe. Enforcement, not detection.
- **`docs/templates/runtime-deploy-handoff-template.md`** — per-container SHA table + provenance-probe block.
- **`docker/Dockerfile.runtime`** + **`scripts/deploy-runtime.sh`** — COPY/sync the new VCS-provenance file; release-mode manifest uses `infra_vcs_ref` + empty `per_repo_vcs_provenance`.

### DoD
- `docker exec <runtime-container> cat /app/build-provenance.json` shows per-repo `{vcs_ref, vcs_dirty, vcs_branch}` for all siblings (materializes on next image build).
- A build with a missing sibling git history exits non-zero — `tests/scripts/test_stage_workspace_vcs_provenance.py`.
- evidence-lint rejects a deployed-SHA claim without adjacent provenance-probe — `tests/unit/scripts/test_check_evidence_provenance_probe.py`.
- Affected suites green (5827 passed: tests/scripts, tests/unit/scripts, tests/unit/infra, tests/unit/runtime); pre-commit (shellcheck/ruff/evidence-probe) clean.

OMN-13030
dod_evidence: tests/scripts/test_stage_workspace_vcs_provenance.py, tests/unit/scripts/test_check_evidence_provenance_probe.py
Evidence-Source: 751d2325de6863835f8254cb8223e2413e559b89
Evidence-Ticket: OMN-13030