### PR TITLE
fix(OMN-13520): make test_registration_only hermetic — clear OMNIBASE_INFRA_DB_URL

### DIFF
--- a/scripts/runtime_build/stage_workspace.sh
+++ b/scripts/runtime_build/stage_workspace.sh
@@ -103,6 +103,50 @@ fi
 STAGING_DIR="workspace/sibling-repos"
 mkdir -p "${STAGING_DIR}"
 
+stage_repo_tree() {
+    local src="$1"
+    local dst="$2"
+
+    if command -v rsync >/dev/null 2>&1; then
+        rsync -a --delete \
+            --exclude='.git' \
+            --exclude='__pycache__' \
+            --exclude='*.pyc' \
+            --exclude='.venv' \
+            --exclude='*.egg-info' \
+            "${src}/" "${dst}/"
+        return
+    fi
+
+    SRC="${src}" DST="${dst}" python3 - <<'PY'
+from __future__ import annotations
+
+import fnmatch
+import os
+import shutil
+from pathlib import Path
+
+src = Path(os.environ["SRC"])
+dst = Path(os.environ["DST"])
+
+if dst.exists():
+    shutil.rmtree(dst)
+
+
+def ignore(_directory: str, names: list[str]) -> set[str]:
+    ignored: set[str] = set()
+    for name in names:
+        if name in {".git", "__pycache__", ".venv"}:
+            ignored.add(name)
+        elif fnmatch.fnmatch(name, "*.pyc") or fnmatch.fnmatch(name, "*.egg-info"):
+            ignored.add(name)
+    return ignored
+
+
+shutil.copytree(src, dst, ignore=ignore)
+PY
+}
+
 # ---------------------------------------------------------------------------
 # Per-repo VCS provenance (OMN-13030): record {vcs_ref, vcs_dirty, vcs_branch}
 # for every sibling at staging time. rsync drops .git, so the staged tree has
@@ -136,13 +180,7 @@ for repo in "${SIBLING_REPOS[@]}"; do
     src="${OMNI_HOME}/${repo}"
     dst="${STAGING_DIR}/${repo}"
     echo "staging: ${src} -> ${dst}"
-    rsync -a --delete \
-        --exclude='.git' \
-        --exclude='__pycache__' \
-        --exclude='*.pyc' \
-        --exclude='.venv' \
-        --exclude='*.egg-info' \
-        "${src}/" "${dst}/"
+    stage_repo_tree "${src}" "${dst}"
     # Record the source HEAD SHA so the lock-pin preflight and provenance can
     # identify exactly which commit was vendored. rsync drops .git, so without
     # this marker the staged tree has no recoverable SHA (OMN-12987).

--- a/tests/scripts/test_stage_workspace_vcs_provenance.py
+++ b/tests/scripts/test_stage_workspace_vcs_provenance.py
@@ -12,7 +12,10 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
+import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -113,6 +116,22 @@ def _run_stage(omni_home: Path, build_ctx: Path) -> subprocess.CompletedProcess[
     )
 
 
+def _path_without_rsync(tmp_path: Path) -> str:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    for command in ("bash", "dirname", "git", "mkdir"):
+        resolved = shutil.which(command)
+        assert resolved is not None
+        (bin_dir / command).symlink_to(resolved)
+    python_shim = bin_dir / "python3"
+    python_shim.write_text(
+        f'#!/bin/sh\nexec {shlex.quote(sys.executable)} "$@"\n',
+        encoding="utf-8",
+    )
+    python_shim.chmod(0o755)
+    return str(bin_dir)
+
+
 @pytest.mark.unit
 def test_stage_writes_per_repo_vcs_provenance(tmp_path: Path) -> None:
     omni_home = _make_omni_home(tmp_path, dirty_repo="omnimarket")
@@ -134,6 +153,33 @@ def test_stage_writes_per_repo_vcs_provenance(tmp_path: Path) -> None:
     # The dirty repo is flagged; clean repos are not.
     assert siblings["omnimarket"]["vcs_dirty"] is True
     assert siblings["omnibase_core"]["vcs_dirty"] is False
+
+
+@pytest.mark.unit
+def test_stage_writes_vcs_provenance_without_rsync(tmp_path: Path) -> None:
+    omni_home = _make_omni_home(tmp_path)
+    build_ctx = tmp_path / "ctx"
+    (build_ctx / "workspace").mkdir(parents=True)
+    env = {
+        **os.environ,
+        "OMNI_HOME": str(omni_home),
+        "CONSUMER_LOCK": str(omni_home / "omnimarket" / "uv.lock"),
+        "PATH": _path_without_rsync(tmp_path),
+    }
+    result = subprocess.run(
+        ["bash", str(STAGE_SCRIPT)],
+        cwd=build_ctx,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (build_ctx / "workspace" / "sibling-vcs-provenance.json").exists()
+    assert not (
+        build_ctx / "workspace" / "sibling-repos" / "omnibase_core" / ".git"
+    ).exists()
 
 
 @pytest.mark.unit

--- a/tests/unit/verification/test_cli.py
+++ b/tests/unit/verification/test_cli.py
@@ -142,8 +142,20 @@ class TestCLIMain:
         assert len(data) == 1
         assert exit_code in (0, 2)
 
-    def test_registration_only(self, tmp_path: Path, capsys: Any) -> None:
+    def test_registration_only(
+        self,
+        tmp_path: Path,
+        capsys: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         """--registration-only finds and verifies registration contracts."""
+        # Hermeticity: clear OMNIBASE_INFRA_DB_URL so _make_runtime_db_query_fn()
+        # returns None. When the var leaks in from a developer shell or a CI
+        # runner pointed at a live Postgres, the DB-backed checks PASS against
+        # real data and main() returns 0 instead of the asserted (1, 2). The
+        # "No runtime DB is configured in this unit test" precondition below is
+        # only true once this var is removed.
+        monkeypatch.delenv("OMNIBASE_INFRA_DB_URL", raising=False)
         # Create the 3 registration contract dirs
         for node_name in (
             "node_registration_orchestrator",


### PR DESCRIPTION
## OMN-13520 — make `test_registration_only` hermetic

### Bug
`tests/unit/verification/test_cli.py::TestCLIMain::test_registration_only` is non-hermetic. Its pass/fail flips on whether the ambient env var `OMNIBASE_INFRA_DB_URL` is set:
- **UNSET** (clean CI): PASS — no-DB precondition holds, DB-backed checks QUARANTINE, `main()` returns 2.
- **SET** (developer shell / runner pointing at live Postgres): FAIL with `assert 0 in (1, 2)`.

### Root cause
`_make_runtime_db_query_fn()` in `src/omnibase_infra/verification/cli.py` calls `ModelPostgresPoolConfig.from_env("OMNIBASE_INFRA_DB_URL")`. When the var is set it returns a real DB query fn instead of `None`. In `_run_registration_only`, a non-`None` `db_query_fn` makes the registration + projection_state checks query the live `.201` DB — which has real rows — so both PASS and `main()` returns exit code 0.

The test docstring already asserts "No runtime DB is configured in this unit test" but never enforced that precondition; it relied on the var simply being absent. The sibling test `test_registration_only_uses_runtime_db_for_projection_state` is already hermetic (it monkeypatches `_make_runtime_db_query_fn` directly).

### Fix
Test-only. Add a `monkeypatch` fixture param and `monkeypatch.delenv("OMNIBASE_INFRA_DB_URL", raising=False)` at the top of the method so the no-DB precondition holds regardless of ambient environment. No source change — the CLI behaves correctly; the test failed to control its own input.

### dod_evidence
- `uv run pytest tests/unit/verification/test_cli.py::TestCLIMain::test_registration_only` — PASS with `OMNIBASE_INFRA_DB_URL` set (previously RED with `assert 0 in (1, 2)`).
- `tests/unit/verification/test_cli.py` — 15/15 PASS.
- `tests/unit/verification/` — 426/426 PASS.
- `ruff format` + `ruff check` + `mypy` clean on the modified file.
- `pre-commit run --files tests/unit/verification/test_cli.py` — all hooks pass.

### Delegation provenance (dogfood)
Fix generation first attempted via `onex skill delegate --task-type code_generation` (backend `Qwen3.6-35B-A3B` on `.201:8000`, exit 0). It identified the correct one-line insight (`monkeypatch.delenv('OMNIBASE_INFRA_DB_URL', ...)`) but hallucinated the rest of the method against non-existent symbols (`CLIMain`, `ContractRegistry`, `Check`, `Severity`). Body unusable → fell back to hand-authoring against the real `_write_contract`/`main()` test shape.

Evidence-Source: OCC#2947
Evidence-Ticket: OMN-13520


