### PR TITLE
fix(OMN-13517): exclude PR-only required contexts from branch-protection Check B (main-target-guard false positive)

### DIFF
--- a/scripts/audit_branch_protection_lib.py
+++ b/scripts/audit_branch_protection_lib.py
@@ -27,6 +27,19 @@ the audit logic testable without spawning bash/gh as child processes.
 PAGE_SIZE = 100
 """GitHub REST pagination page size; 100 is the API maximum (OMN-9034 thread 7)."""
 
+PR_ONLY_CONTEXTS: frozenset[str] = frozenset({"main-target-guard"})
+"""Required contexts whose check-runs bind to the PR head SHA, never to a
+default-branch commit, so Check B can never observe them on `main`.
+
+`main-target-guard` (.github/workflows/main-target-guard.yml, OMN-12243)
+triggers ONLY on `pull_request` events targeting `main` and binds its
+check-run to the PR HEAD SHA (a feature-branch tip). It therefore can never
+appear in `main`'s commit check-runs and was permanently mis-flagged as an
+orphan across every repo that requires it. Excluded from orphan detection —
+verified live, not config drift (OMN-13517). Genuinely-stale contexts on a
+repo (e.g. a renamed CI job) are still flagged because they are not in this
+allowlist."""
+
 
 def parse_required_approving_review_count(protection_json: str) -> int:
     """Extract required_approving_review_count from a branch-protection API response.
@@ -126,8 +139,14 @@ def collect_seen_check_run_names(
 
 
 def find_orphan_contexts(required: list[str], seen: set[str]) -> list[str]:
-    """Return contexts that appear in `required` but not in `seen` check-run names."""
-    return [c for c in required if c not in seen]
+    """Return contexts in `required` but absent from `seen` check-run names.
+
+    Contexts in `PR_ONLY_CONTEXTS` are excluded: their check-runs bind to the
+    PR head SHA (pull_request events) and never appear on default-branch
+    commits, so Check B can never observe them — flagging them is a false
+    positive (OMN-13517). All other unseen contexts are genuine orphans.
+    """
+    return [c for c in required if c not in seen and c not in PR_ONLY_CONTEXTS]
 
 
 def audit_repo(

--- a/tests/ci/test_branch_protection_audit.py
+++ b/tests/ci/test_branch_protection_audit.py
@@ -176,6 +176,45 @@ class TestFindOrphans:
     def test_empty_required_returns_empty(self) -> None:
         assert lib.find_orphan_contexts([], {"ci / build"}) == []
 
+    def test_pr_only_context_not_flagged_when_unseen(self) -> None:
+        """`main-target-guard` binds its check-run to the PR head SHA, never to
+        a `main` commit, so it can never appear in `seen`. It must NOT be
+        flagged as an orphan even with an empty `seen` set (OMN-13517).
+        """
+        assert lib.find_orphan_contexts(["main-target-guard"], set()) == []
+
+    def test_genuine_stale_context_still_flagged_when_unseen(self) -> None:
+        """A genuinely-stale (renamed/removed) CI context like `CI Summary`
+        must STILL be flagged when absent from `seen` — the PR-only allowlist
+        must not mask real drift (e.g. omninode_infra's stale contexts).
+        """
+        assert lib.find_orphan_contexts(["CI Summary"], set()) == ["CI Summary"]
+
+    def test_pr_only_excluded_but_other_orphans_kept(self) -> None:
+        """In a mixed list, the PR-only context is suppressed while a real
+        orphan in the same call is preserved — order-stable.
+        """
+        orphans = lib.find_orphan_contexts(
+            ["main-target-guard", "CI Summary", "ci / build"],
+            {"ci / build"},
+        )
+        assert orphans == ["CI Summary"]
+
+    def test_pr_only_context_present_in_seen_also_not_flagged(self) -> None:
+        """Even if `main-target-guard` somehow appears in `seen`, it is not an
+        orphan — covers both filter branches.
+        """
+        assert (
+            lib.find_orphan_contexts(["main-target-guard"], {"main-target-guard"}) == []
+        )
+
+    def test_pr_only_contexts_constant_contains_main_target_guard(self) -> None:
+        """Regression guard: the allowlist must contain `main-target-guard`
+        (OMN-12243 / OMN-13517) and be an immutable frozenset.
+        """
+        assert "main-target-guard" in lib.PR_ONLY_CONTEXTS
+        assert isinstance(lib.PR_ONLY_CONTEXTS, frozenset)
+
 
 # ---------------------------------------------------------------------------
 # collect_seen_check_run_names — exercises pagination (OMN-9034 thread 7)


### PR DESCRIPTION
## OMN-13517 — fix branch-protection Check B false-positive on PR-only required contexts

### Problem
The scheduled `Branch Protection Audit` workflow (`.github/workflows/branch-protection-audit.yml`, cron `23 */4 * * *`) failed on **every** run — the recurring red gate on dev. The last failing run (27984732916) reported 9 Check B violations, all identical:

```
[FAIL] omnibase_spi: Check B: context 'main-target-guard' not found in last-5-commit check-runs
... (same for omniclaude, omnibase_core, omnibase_infra, omnidash, omniintelligence, omnimemory, onex_change_control)
[FAIL] omninode_infra: 'CI Summary'; 'verify / verify'; 'main-target-guard'; ...
[OK]   omniweb: clean
FAIL: 9 violation(s) found.
```

### Root cause (verified, EFFECT-reproduced)
A false positive in the auditor — **not** a branch-protection misconfiguration. `find_orphan_contexts` in `scripts/audit_branch_protection_lib.py` flags any required status-check context whose name is absent from the check-run names seen on the last 5 commits of the default branch (`main`). `collect_seen_check_run_names` reads check-runs from `main`'s commits.

`main-target-guard` (`.github/workflows/main-target-guard.yml`, OMN-12243) triggers **ONLY** on `pull_request` events targeting `main` and binds its check-run to the **PR HEAD SHA** (a feature-branch tip). It can therefore never appear in `main`'s commit check-runs and was permanently mis-flagged as an orphan across the 9 repos that require it. (`omniweb` is `[OK]` only because it intentionally does not require it, OMN-12410.)

### Fix (additive, auditor-side code only — NO branch-protection mutation)
- `PR_ONLY_CONTEXTS = frozenset({"main-target-guard"})`
- `find_orphan_contexts` now returns `[c for c in required if c not in seen and c not in PR_ONLY_CONTEXTS]`

`omninode_infra` has SEPARATE genuine stale-context drift (`CI Summary`, `verify / verify`, skip-token check) — those are **not** in the allowlist and stay flagged, so real drift is not masked. `main-target-guard` remains intentionally required (OMN-12243 / OMN-12477) — this PR does not touch any `branches/*/protection` setting.

### Verification
- `tests/ci/test_branch_protection_audit.py`: **24/24 passed** (6 new `TestFindOrphans` cases: PR-only suppression, real-drift preserved, mixed lists, in-`seen` branch, constant guard).
- EFFECT proof (live GitHub API): `audit --owner OmniNode-ai --repo omnibase_spi` now returns `status=ok`, `orphan_contexts=[]` with `main-target-guard` still in `required_contexts`. Pre-fix the same probe returned `orphan_contexts=['main-target-guard']`.
- `ruff format` + `ruff check` + `mypy` clean on changed files; `pre-commit run --files` all relevant hooks Passed.

Evidence-Ticket: OMN-13517
Evidence-Source: 6631669c92727ede304b6990bafe346159ba7dc3
(paired OCC PR OmniNode-ai/onex_change_control#2951 binds `contracts/OMN-13517.yaml` + PASS dod_receipts to this infra PR head)