### PR TITLE
chore(deps)(OMN-13523): batch infra Dependabot updates

### DIFF
--- a/.github/workflows/artifact-reconciliation-webhook.yml
+++ b/.github/workflows/artifact-reconciliation-webhook.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Get changed files
         id: changed-files

--- a/.github/workflows/artifact-reconciliation-webhook.yml
+++ b/.github/workflows/artifact-reconciliation-webhook.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Get changed files
         id: changed-files

--- a/.github/workflows/attest-source-hash.yml
+++ b/.github/workflows/attest-source-hash.yml
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
 

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -110,7 +110,7 @@ jobs:
             echo "skip=false"
           } >> "$GITHUB_OUTPUT"
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python 3.12
         if: steps.resolve.outputs.skip != 'true' && steps.resolve.outputs.actor == 'jonahgabriel'

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -110,7 +110,7 @@ jobs:
             echo "skip=false"
           } >> "$GITHUB_OUTPUT"
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Python 3.12
         if: steps.resolve.outputs.skip != 'true' && steps.resolve.outputs.actor == 'jonahgabriel'

--- a/.github/workflows/baselines-scheduler.yml
+++ b/.github/workflows/baselines-scheduler.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/baselines-scheduler.yml
+++ b/.github/workflows/baselines-scheduler.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/branch-protection-audit.yml
+++ b/.github/workflows/branch-protection-audit.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Check CROSS_REPO_PAT is configured
         id: pat_check

--- a/.github/workflows/branch-protection-audit.yml
+++ b/.github/workflows/branch-protection-audit.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Check CROSS_REPO_PAT is configured
         id: pat_check

--- a/.github/workflows/build-and-push-migrate-image.yml
+++ b/.github/workflows/build-and-push-migrate-image.yml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Python for AWS CLI
         uses: actions/setup-python@v6

--- a/.github/workflows/build-and-push-migrate-image.yml
+++ b/.github/workflows/build-and-push-migrate-image.yml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python for AWS CLI
         uses: actions/setup-python@v6

--- a/.github/workflows/build-and-push-runtime.yml
+++ b/.github/workflows/build-and-push-runtime.yml
@@ -81,7 +81,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Verify Docker socket access
         run: |

--- a/.github/workflows/build-and-push-runtime.yml
+++ b/.github/workflows/build-and-push-runtime.yml
@@ -81,7 +81,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Verify Docker socket access
         run: |

--- a/.github/workflows/canonical-inference-gate.yml
+++ b/.github/workflows/canonical-inference-gate.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/canonical-inference-gate.yml
+++ b/.github/workflows/canonical-inference-gate.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/check-handshake.yml
+++ b/.github/workflows/check-handshake.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Checkout omnibase_core
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: OmniNode-ai/omnibase_core
           # Pinned to omnibase_core main as of 2026-02-10.

--- a/.github/workflows/check-handshake.yml
+++ b/.github/workflows/check-handshake.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Checkout omnibase_core
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: OmniNode-ai/omnibase_core
           # Pinned to omnibase_core main as of 2026-02-10.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1289,7 +1289,7 @@ jobs:
 
       - name: Download all JUnit XML shards
         if: needs.test-parallel.result == 'success' || needs.test-parallel.result == 'failure'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: test-results-*
           path: junit-shards

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Python and uv
         uses: ./.github/actions/setup-python-uv
@@ -150,7 +150,7 @@ jobs:
       # Clone omnibase_core HEAD so the validator is available before the
       # OMN-13026 omnibase_core pin bump lands in the lockfile.
       - name: Checkout omnibase_core validator source
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: OmniNode-ai/omnibase_core
           ref: dev
@@ -182,7 +182,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Python and uv
         uses: ./.github/actions/setup-python-uv
@@ -290,7 +290,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Reject unallowlisted infra node handlers
         run: bash scripts/ci/reject-node-implementations.sh --all
@@ -311,7 +311,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Python and uv
         uses: ./.github/actions/setup-python-uv
@@ -343,7 +343,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Python and uv
         uses: ./.github/actions/setup-python-uv
@@ -380,7 +380,7 @@ jobs:
     steps:
       - name: Checkout code
         timeout-minutes: 10
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 2
           fetch-tags: false
@@ -404,7 +404,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Python and uv
         uses: ./.github/actions/setup-python-uv
@@ -437,7 +437,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Python and uv
         uses: ./.github/actions/setup-python-uv
@@ -483,26 +483,26 @@ jobs:
 
     steps:
       - name: Checkout omnibase_infra
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: omnibase_infra
 
       - name: Checkout omniintelligence (sibling contracts)
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: OmniNode-ai/omniintelligence
           path: omniintelligence
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout omnimemory (sibling contracts)
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: OmniNode-ai/omnimemory
           path: omnimemory
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout omniclaude (sibling contracts)
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: OmniNode-ai/omniclaude
           path: omniclaude
@@ -551,27 +551,27 @@ jobs:
 
     steps:
       - name: Checkout omnibase_infra
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           path: omnibase_infra
 
       - name: Checkout omniintelligence (sibling)
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: OmniNode-ai/omniintelligence
           path: omniintelligence
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout omnimemory (sibling)
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: OmniNode-ai/omnimemory
           path: omnimemory
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout omnibase_compat (sibling)
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: OmniNode-ai/omnibase_compat
           path: omnibase_compat
@@ -663,7 +663,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Python and uv
         uses: ./.github/actions/setup-python-uv
@@ -695,7 +695,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Python and uv
         uses: ./.github/actions/setup-python-uv
@@ -727,7 +727,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Python and uv
         uses: ./.github/actions/setup-python-uv
@@ -756,7 +756,7 @@ jobs:
         || fromJSON((github.event_name == 'merge_group' && vars.OMNI_REQUIRED_CI_RUNS_ON_JSON) || vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Verify all referenced contract paths exist
         run: |
@@ -803,7 +803,7 @@ jobs:
       }}
     if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install gh CLI
         run: |
@@ -849,7 +849,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
@@ -932,7 +932,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
@@ -1010,10 +1010,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Checkout onex_change_control standards
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         continue-on-error: true
         with:
           repository: OmniNode-ai/onex_change_control
@@ -1079,7 +1079,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Python and uv
         uses: ./.github/actions/setup-python-uv
@@ -1189,9 +1189,9 @@ jobs:
     timeout-minutes: 20
     if: github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'push'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Checkout onex_change_control
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: OmniNode-ai/onex_change_control
           path: onex_change_control
@@ -1261,7 +1261,7 @@ jobs:
 
     steps:
       - name: Checkout code (dev branch baseline)
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: dev
           sparse-checkout: |
@@ -1270,7 +1270,7 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Checkout PR HEAD (for scripts)
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           clean: false
           path: pr-head
@@ -1498,26 +1498,26 @@ jobs:
 
     steps:
       - name: Checkout omnibase_infra
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: omnibase_infra
 
       - name: Checkout omniintelligence (sibling)
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: OmniNode-ai/omniintelligence
           path: omniintelligence
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout omnimemory (sibling)
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: OmniNode-ai/omnimemory
           path: omnimemory
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout omnibase_compat (sibling)
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: OmniNode-ai/omnibase_compat
           path: omnibase_compat
@@ -1598,7 +1598,7 @@ jobs:
         || fromJSON((github.event_name == 'merge_group' && vars.OMNI_REQUIRED_CI_RUNS_ON_JSON) || vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
@@ -1643,7 +1643,7 @@ jobs:
           --health-retries 10
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Python and uv
         uses: ./.github/actions/setup-python-uv
@@ -1795,7 +1795,7 @@ jobs:
         || fromJSON((github.event_name == 'merge_group' && vars.OMNI_REQUIRED_CI_RUNS_ON_JSON) || vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - name: Setup Python and uv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Python and uv
         uses: ./.github/actions/setup-python-uv
@@ -150,7 +150,7 @@ jobs:
       # Clone omnibase_core HEAD so the validator is available before the
       # OMN-13026 omnibase_core pin bump lands in the lockfile.
       - name: Checkout omnibase_core validator source
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: OmniNode-ai/omnibase_core
           ref: dev
@@ -182,7 +182,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Python and uv
         uses: ./.github/actions/setup-python-uv
@@ -290,7 +290,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Reject unallowlisted infra node handlers
         run: bash scripts/ci/reject-node-implementations.sh --all
@@ -311,7 +311,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Python and uv
         uses: ./.github/actions/setup-python-uv
@@ -343,7 +343,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Python and uv
         uses: ./.github/actions/setup-python-uv
@@ -380,7 +380,7 @@ jobs:
     steps:
       - name: Checkout code
         timeout-minutes: 10
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 2
           fetch-tags: false
@@ -404,7 +404,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Python and uv
         uses: ./.github/actions/setup-python-uv
@@ -437,7 +437,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Python and uv
         uses: ./.github/actions/setup-python-uv
@@ -483,26 +483,26 @@ jobs:
 
     steps:
       - name: Checkout omnibase_infra
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           path: omnibase_infra
 
       - name: Checkout omniintelligence (sibling contracts)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: OmniNode-ai/omniintelligence
           path: omniintelligence
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout omnimemory (sibling contracts)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: OmniNode-ai/omnimemory
           path: omnimemory
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout omniclaude (sibling contracts)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: OmniNode-ai/omniclaude
           path: omniclaude
@@ -551,27 +551,27 @@ jobs:
 
     steps:
       - name: Checkout omnibase_infra
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           path: omnibase_infra
 
       - name: Checkout omniintelligence (sibling)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: OmniNode-ai/omniintelligence
           path: omniintelligence
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout omnimemory (sibling)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: OmniNode-ai/omnimemory
           path: omnimemory
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout omnibase_compat (sibling)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: OmniNode-ai/omnibase_compat
           path: omnibase_compat
@@ -663,7 +663,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Python and uv
         uses: ./.github/actions/setup-python-uv
@@ -695,7 +695,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Python and uv
         uses: ./.github/actions/setup-python-uv
@@ -727,7 +727,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Python and uv
         uses: ./.github/actions/setup-python-uv
@@ -756,7 +756,7 @@ jobs:
         || fromJSON((github.event_name == 'merge_group' && vars.OMNI_REQUIRED_CI_RUNS_ON_JSON) || vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Verify all referenced contract paths exist
         run: |
@@ -803,7 +803,7 @@ jobs:
       }}
     if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install gh CLI
         run: |
@@ -849,7 +849,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -932,7 +932,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -1010,10 +1010,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Checkout onex_change_control standards
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         continue-on-error: true
         with:
           repository: OmniNode-ai/onex_change_control
@@ -1079,7 +1079,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Python and uv
         uses: ./.github/actions/setup-python-uv
@@ -1189,9 +1189,9 @@ jobs:
     timeout-minutes: 20
     if: github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'push'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Checkout onex_change_control
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: OmniNode-ai/onex_change_control
           path: onex_change_control
@@ -1261,7 +1261,7 @@ jobs:
 
     steps:
       - name: Checkout code (dev branch baseline)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: dev
           sparse-checkout: |
@@ -1270,7 +1270,7 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Checkout PR HEAD (for scripts)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           clean: false
           path: pr-head
@@ -1498,26 +1498,26 @@ jobs:
 
     steps:
       - name: Checkout omnibase_infra
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           path: omnibase_infra
 
       - name: Checkout omniintelligence (sibling)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: OmniNode-ai/omniintelligence
           path: omniintelligence
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout omnimemory (sibling)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: OmniNode-ai/omnimemory
           path: omnimemory
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout omnibase_compat (sibling)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: OmniNode-ai/omnibase_compat
           path: omnibase_compat
@@ -1598,7 +1598,7 @@ jobs:
         || fromJSON((github.event_name == 'merge_group' && vars.OMNI_REQUIRED_CI_RUNS_ON_JSON) || vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -1643,7 +1643,7 @@ jobs:
           --health-retries 10
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Python and uv
         uses: ./.github/actions/setup-python-uv
@@ -1795,7 +1795,7 @@ jobs:
         || fromJSON((github.event_name == 'merge_group' && vars.OMNI_REQUIRED_CI_RUNS_ON_JSON) || vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Setup Python and uv

--- a/.github/workflows/cr-thread-gate.yml
+++ b/.github/workflows/cr-thread-gate.yml
@@ -36,7 +36,7 @@ jobs:
       }}
     steps:
       - name: Checkout omniclaude scripts
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: OmniNode-ai/omniclaude
           ref: main

--- a/.github/workflows/cr-thread-gate.yml
+++ b/.github/workflows/cr-thread-gate.yml
@@ -36,7 +36,7 @@ jobs:
       }}
     steps:
       - name: Checkout omniclaude scripts
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: OmniNode-ai/omniclaude
           ref: main

--- a/.github/workflows/dependency-cascade.yml
+++ b/.github/workflows/dependency-cascade.yml
@@ -119,7 +119,7 @@ jobs:
 
       - name: Checkout downstream repo
         if: steps.token_check.outputs.has_token == 'true'
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: OmniNode-ai/${{ matrix.repo }}
           token: ${{ secrets.cross-repo-pat || secrets.CROSS_REPO_PAT }}

--- a/.github/workflows/dependency-cascade.yml
+++ b/.github/workflows/dependency-cascade.yml
@@ -119,7 +119,7 @@ jobs:
 
       - name: Checkout downstream repo
         if: steps.token_check.outputs.has_token == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: OmniNode-ai/${{ matrix.repo }}
           token: ${{ secrets.cross-repo-pat || secrets.CROSS_REPO_PAT }}

--- a/.github/workflows/dev-baseline-publisher.yml
+++ b/.github/workflows/dev-baseline-publisher.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout dev branch
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: dev
           fetch-depth: 0

--- a/.github/workflows/dev-baseline-publisher.yml
+++ b/.github/workflows/dev-baseline-publisher.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout dev branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: dev
           fetch-depth: 0

--- a/.github/workflows/dispatcher-route-coverage.yml
+++ b/.github/workflows/dispatcher-route-coverage.yml
@@ -62,12 +62,12 @@ jobs:
 
     steps:
       - name: Checkout omnibase_infra
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Checkout omnimarket (sibling)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: OmniNode-ai/omnimarket
           ref: dev

--- a/.github/workflows/dispatcher-route-coverage.yml
+++ b/.github/workflows/dispatcher-route-coverage.yml
@@ -62,12 +62,12 @@ jobs:
 
     steps:
       - name: Checkout omnibase_infra
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Checkout omnimarket (sibling)
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: OmniNode-ai/omnimarket
           ref: dev

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Python and uv
         uses: ./.github/actions/setup-python-uv
@@ -101,7 +101,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # Pre-flight: verify Docker daemon is accessible (catches socket permission issues early)
       - name: Verify Docker socket access
@@ -239,7 +239,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Verify Docker socket access
         run: |
@@ -333,7 +333,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set lowercase repository owner
         id: repo

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Python and uv
         uses: ./.github/actions/setup-python-uv
@@ -101,7 +101,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       # Pre-flight: verify Docker daemon is accessible (catches socket permission issues early)
       - name: Verify Docker socket access
@@ -239,7 +239,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Verify Docker socket access
         run: |
@@ -333,7 +333,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set lowercase repository owner
         id: repo

--- a/.github/workflows/env-parity.yml
+++ b/.github/workflows/env-parity.yml
@@ -42,14 +42,14 @@ jobs:
 
     steps:
       - name: Checkout omnibase_infra
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           path: omnibase_infra
 
       - name: Checkout omninode_infra (sibling — provides k8s ConfigMap)
         # GITHUB_TOKEN is scoped to omnibase_infra and cannot access the private
         # omninode_infra repo. Use CROSS_REPO_PAT (same pattern as dependency-cascade.yml).
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: OmniNode-ai/omninode_infra
           path: omninode_infra

--- a/.github/workflows/env-parity.yml
+++ b/.github/workflows/env-parity.yml
@@ -42,14 +42,14 @@ jobs:
 
     steps:
       - name: Checkout omnibase_infra
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: omnibase_infra
 
       - name: Checkout omninode_infra (sibling — provides k8s ConfigMap)
         # GITHUB_TOKEN is scoped to omnibase_infra and cannot access the private
         # omninode_infra repo. Use CROSS_REPO_PAT (same pattern as dependency-cascade.yml).
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: OmniNode-ai/omninode_infra
           path: omninode_infra

--- a/.github/workflows/fresh-deploy-fitness.yml
+++ b/.github/workflows/fresh-deploy-fitness.yml
@@ -134,6 +134,7 @@ jobs:
         uses: ./.github/actions/setup-python-uv
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+          cache-enabled: "false"
       - name: Sibling-pin recurrence ratchet — logic regression gate
         run: |
           uv run --frozen pytest tests/scripts/test_check_sibling_lock_pins.py -q -p no:cacheprovider

--- a/.github/workflows/fresh-deploy-fitness.yml
+++ b/.github/workflows/fresh-deploy-fitness.yml
@@ -50,7 +50,7 @@ jobs:
       }}
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Set up Python
@@ -77,7 +77,7 @@ jobs:
       }}
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
@@ -96,7 +96,7 @@ jobs:
       }}
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
@@ -129,7 +129,7 @@ jobs:
     timeout-minutes: 8
     steps:
       - name: Checkout omnibase_infra
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Setup Python and uv
         uses: ./.github/actions/setup-python-uv
         with:
@@ -164,7 +164,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.OMNI_GITHUB_TOKEN || github.token }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:

--- a/.github/workflows/fresh-deploy-fitness.yml
+++ b/.github/workflows/fresh-deploy-fitness.yml
@@ -50,7 +50,7 @@ jobs:
       }}
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - name: Set up Python
@@ -77,7 +77,7 @@ jobs:
       }}
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
@@ -96,7 +96,7 @@ jobs:
       }}
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
@@ -129,7 +129,7 @@ jobs:
     timeout-minutes: 8
     steps:
       - name: Checkout omnibase_infra
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Python and uv
         uses: ./.github/actions/setup-python-uv
         with:
@@ -165,7 +165,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.OMNI_GITHUB_TOKEN || github.token }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:

--- a/.github/workflows/integration-test-check.yml
+++ b/.github/workflows/integration-test-check.yml
@@ -39,7 +39,7 @@ jobs:
       }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -120,7 +120,7 @@ jobs:
       }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/integration-test-check.yml
+++ b/.github/workflows/integration-test-check.yml
@@ -39,7 +39,7 @@ jobs:
       }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
@@ -120,7 +120,7 @@ jobs:
       }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/lane-census-staleness.yml
+++ b/.github/workflows/lane-census-staleness.yml
@@ -73,7 +73,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Python and uv
         uses: ./.github/actions/setup-python-uv

--- a/.github/workflows/lane-census-staleness.yml
+++ b/.github/workflows/lane-census-staleness.yml
@@ -73,7 +73,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Python and uv
         uses: ./.github/actions/setup-python-uv

--- a/.github/workflows/merge-queue-bypass-audit.yml
+++ b/.github/workflows/merge-queue-bypass-audit.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Check CROSS_REPO_PAT is configured
         id: pat_check

--- a/.github/workflows/merge-queue-bypass-audit.yml
+++ b/.github/workflows/merge-queue-bypass-audit.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Check CROSS_REPO_PAT is configured
         id: pat_check

--- a/.github/workflows/nightly-integration.yml
+++ b/.github/workflows/nightly-integration.yml
@@ -98,7 +98,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/nightly-integration.yml
+++ b/.github/workflows/nightly-integration.yml
@@ -98,7 +98,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/node-migration-sync.yml
+++ b/.github/workflows/node-migration-sync.yml
@@ -43,12 +43,12 @@ jobs:
 
     steps:
       - name: Checkout omnibase_infra
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Checkout omnimarket (sibling — node migration source of truth)
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: OmniNode-ai/omnimarket
           ref: dev

--- a/.github/workflows/node-migration-sync.yml
+++ b/.github/workflows/node-migration-sync.yml
@@ -43,12 +43,12 @@ jobs:
 
     steps:
       - name: Checkout omnibase_infra
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Checkout omnimarket (sibling — node migration source of truth)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: OmniNode-ai/omnimarket
           ref: dev

--- a/.github/workflows/omni-standards-compliance.yml
+++ b/.github/workflows/omni-standards-compliance.yml
@@ -40,7 +40,7 @@ jobs:
       }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Python and uv
         uses: ./.github/actions/setup-python-uv
@@ -74,7 +74,7 @@ jobs:
       }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Python and uv
         uses: ./.github/actions/setup-python-uv
@@ -102,7 +102,7 @@ jobs:
       }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -236,7 +236,7 @@ jobs:
       }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Verify CI workflow naming convention
         run: |

--- a/.github/workflows/omni-standards-compliance.yml
+++ b/.github/workflows/omni-standards-compliance.yml
@@ -40,7 +40,7 @@ jobs:
       }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Python and uv
         uses: ./.github/actions/setup-python-uv
@@ -74,7 +74,7 @@ jobs:
       }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Python and uv
         uses: ./.github/actions/setup-python-uv
@@ -102,7 +102,7 @@ jobs:
       }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -236,7 +236,7 @@ jobs:
       }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Verify CI workflow naming convention
         run: |

--- a/.github/workflows/omnigate.yml
+++ b/.github/workflows/omnigate.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.event.pull_request.head.repo.fork == true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/omnigate.yml
+++ b/.github/workflows/omnigate.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.event.pull_request.head.repo.fork == true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/plugin-pin-cascade.yml
+++ b/.github/workflows/plugin-pin-cascade.yml
@@ -55,7 +55,7 @@ jobs:
           fi
 
       - name: Checkout omnibase_infra
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/plugin-pin-cascade.yml
+++ b/.github/workflows/plugin-pin-cascade.yml
@@ -55,7 +55,7 @@ jobs:
           fi
 
       - name: Checkout omnibase_infra
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/pr-merged-event.yml
+++ b/.github/workflows/pr-merged-event.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Get changed files
         id: changed-files

--- a/.github/workflows/pr-merged-event.yml
+++ b/.github/workflows/pr-merged-event.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Get changed files
         id: changed-files

--- a/.github/workflows/prod-promotion-lineage.yml
+++ b/.github/workflows/prod-promotion-lineage.yml
@@ -72,7 +72,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Python and uv
         uses: ./.github/actions/setup-python-uv
@@ -100,7 +100,7 @@ jobs:
 
     steps:
       - name: Checkout (full history for ancestry check)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/prod-promotion-lineage.yml
+++ b/.github/workflows/prod-promotion-lineage.yml
@@ -72,7 +72,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Python and uv
         uses: ./.github/actions/setup-python-uv
@@ -100,7 +100,7 @@ jobs:
 
     steps:
       - name: Checkout (full history for ancestry check)
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/receipt-honesty.yml
+++ b/.github/workflows/receipt-honesty.yml
@@ -35,7 +35,7 @@ jobs:
   receipt-honesty:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Clone omnibase_core (provides the receipt-honesty validator)

--- a/.github/workflows/receipt-honesty.yml
+++ b/.github/workflows/receipt-honesty.yml
@@ -35,7 +35,7 @@ jobs:
   receipt-honesty:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - name: Clone omnibase_core (provides the receipt-honesty validator)

--- a/.github/workflows/release-python-dry-run.yml
+++ b/.github/workflows/release-python-dry-run.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/release-python-dry-run.yml
+++ b/.github/workflows/release-python-dry-run.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/release-python-reusable.yml
+++ b/.github/workflows/release-python-reusable.yml
@@ -32,7 +32,7 @@ jobs:
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release-python-reusable.yml
+++ b/.github/workflows/release-python-reusable.yml
@@ -32,7 +32,7 @@ jobs:
         || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
       }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
     outputs:
       version: ${{ steps.tag.outputs.tag }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
@@ -128,7 +128,7 @@ jobs:
     runs-on: >-
       ${{ fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]') }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
     outputs:
       version: ${{ steps.tag.outputs.tag }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
@@ -128,7 +128,7 @@ jobs:
     runs-on: >-
       ${{ fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]') }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}

--- a/.github/workflows/reusable-runtime-boot.yml
+++ b/.github/workflows/reusable-runtime-boot.yml
@@ -111,7 +111,7 @@ jobs:
           echo "effective pg_port for mode=${{ inputs.mode }} -> ${effective}"
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Python and uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/reusable-runtime-boot.yml
+++ b/.github/workflows/reusable-runtime-boot.yml
@@ -111,7 +111,7 @@ jobs:
           echo "effective pg_port for mode=${{ inputs.mode }} -> ${effective}"
 
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Python and uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/runner-image-build-smoke.yml
+++ b/.github/workflows/runner-image-build-smoke.yml
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Verify Docker socket access
         run: |

--- a/.github/workflows/runner-image-build-smoke.yml
+++ b/.github/workflows/runner-image-build-smoke.yml
@@ -128,7 +128,7 @@ jobs:
           echo "Runner image build smoke PASSED: identity bound + prebuilt env baked."
 
       # OMN-12585: assert the baked runner can execute node24 actions
-      # (actions/checkout@v6, used 73x across workflows). The OMN-12567 image
+      # (actions/checkout@v7, used across workflows). The OMN-12567 image
       # pinned RUNNER_VERSION=2.323.0, which predates node24 execution support
       # (landed in actions/runner 2.327.0); rolling it to the live fleet (2.334.0)
       # downgraded the runner and broke "Set up job" with `'using: node24' is not
@@ -144,7 +144,7 @@ jobs:
             set -euo pipefail
             node24="${RUNNER_HOME}/externals/node24/bin/node"
             if [[ ! -x "${node24}" ]]; then
-              echo "::error::baked runner has no executable node24 at ${node24}; it cannot run node24 actions (actions/checkout@v6). RUNNER_VERSION is too old (< 2.327.0)."
+              echo "::error::baked runner has no executable node24 at ${node24}; it cannot run node24 actions (actions/checkout@v7). RUNNER_VERSION is too old (< 2.327.0)."
               echo "externals dir contents:"
               ls -la "${RUNNER_HOME}/externals" 2>/dev/null || echo "no externals dir"
               exit 1

--- a/.github/workflows/runner-image-build-smoke.yml
+++ b/.github/workflows/runner-image-build-smoke.yml
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Verify Docker socket access
         run: |

--- a/.github/workflows/runtime-rebuild-trigger.yml
+++ b/.github/workflows/runtime-rebuild-trigger.yml
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Get changed files
         id: changed-files

--- a/.github/workflows/runtime-rebuild-trigger.yml
+++ b/.github/workflows/runtime-rebuild-trigger.yml
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Get changed files
         id: changed-files

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -32,7 +32,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/seed-provenance-check.yml
+++ b/.github/workflows/seed-provenance-check.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405

--- a/.github/workflows/seed-provenance-check.yml
+++ b/.github/workflows/seed-provenance-check.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405

--- a/.github/workflows/stale-todo-gate.yml
+++ b/.github/workflows/stale-todo-gate.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/stale-todo-gate.yml
+++ b/.github/workflows/stale-todo-gate.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/todo-audit-on-merge.yml
+++ b/.github/workflows/todo-audit-on-merge.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Extract ticket ID from branch name
         id: extract

--- a/.github/workflows/todo-audit-on-merge.yml
+++ b/.github/workflows/todo-audit-on-merge.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Extract ticket ID from branch name
         id: extract

--- a/.github/workflows/url-authority-gate.yml
+++ b/.github/workflows/url-authority-gate.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/url-authority-gate.yml
+++ b/.github/workflows/url-authority-gate.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/validate-validator-requirements.yml
+++ b/.github/workflows/validate-validator-requirements.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Checkout omnibase_core
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: OmniNode-ai/omnibase_core
           # Pinned to the commit that exports the validate-validator-requirements hook (OMN-13291).

--- a/.github/workflows/validate-validator-requirements.yml
+++ b/.github/workflows/validate-validator-requirements.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Checkout omnibase_core
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: OmniNode-ai/omnibase_core
           # Pinned to the commit that exports the validate-validator-requirements hook (OMN-13291).

--- a/.github/workflows/validator-runtime-profiles.yml
+++ b/.github/workflows/validator-runtime-profiles.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Checkout omnibase_infra
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/validator-runtime-profiles.yml
+++ b/.github/workflows/validator-runtime-profiles.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Checkout omnibase_infra
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/docker/runners/runner-image.lock.json
+++ b/docker/runners/runner-image.lock.json
@@ -1,12 +1,12 @@
 {
   "base_image_digest": "sha256:3ba65aa20f86a0fad9df2b2c259c613df006b2e6d0bfcc8a146afb8c525a9751",
   "gh_version": "2.67.0",
-  "identity_digest": "6276c51d98f177780c62787405e416c9",
+  "identity_digest": "da0dc5140fae53e84399503a0e5f8eb3",
   "image_version": 5,
   "kubectl_version": "1.32.1",
   "python_version": "3.12",
   "runner_version": "2.334.0",
-  "shared_env_digest": "2d761320b0fe185d656b4d63",
+  "shared_env_digest": "8238ed24bfdfc3816dde8016",
   "shared_env_install_args": "--frozen --all-extras --all-groups --no-install-project",
   "uv_version": "0.6.14"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     #   - SHAs provide audit trail and tamper-evidence
     # Core dependencies
     "pydantic>=2.11.7,<3.0.0",
-    "fastapi>=0.120.1,<0.138.0",
+    "fastapi>=0.120.1,<0.139.0",
     "uvicorn>=0.32.0,<0.50.0",
     "pyyaml>=6.0.2,<7.0.0",
     "aiohttp>=3.9.0,<4.0.0",

--- a/tests/ci/test_ci_workflow_resilience.py
+++ b/tests/ci/test_ci_workflow_resilience.py
@@ -37,7 +37,7 @@ CODEQL_CONFIG = REPO_ROOT / ".github" / "codeql" / "codeql-config.yml"
 SETUP_PYTHON_UV_ACTION = (
     REPO_ROOT / ".github" / "actions" / "setup-python-uv" / "action.yml"
 )
-CHECKOUT_V6_SHA = "df4cb1c069e1874edd31b4311f1884172cec0e10"
+CHECKOUT_V7_SHA = "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
 CODEQL_V4_SHA = "dc73d59c2d7bd4f8194098a91219eeee6d8a1719"
 
 
@@ -63,9 +63,8 @@ def test_migration_freeze_checkout_is_bounded_for_merge_group() -> None:
 
     assert job["timeout-minutes"] == 15
 
-    checkout_step = next(
-        step for step in steps if step.get("uses") == "actions/checkout@v6"
-    )
+    checkout_step = next(step for step in steps if step.get("name") == "Checkout code")
+    assert checkout_step["uses"] == "actions/checkout@v7"
     assert checkout_step["timeout-minutes"] == 10
     assert checkout_step["with"]["fetch-depth"] == 2
     assert checkout_step["with"]["fetch-tags"] is False
@@ -811,7 +810,7 @@ def test_codeql_uses_repo_config_that_ignores_github_metadata() -> None:
         for step in workflow["jobs"]["codeql"]["steps"]
         if step.get("name") == "Checkout repository"
     )
-    assert checkout_step["uses"] == f"actions/checkout@{CHECKOUT_V6_SHA}"
+    assert checkout_step["uses"] == f"actions/checkout@{CHECKOUT_V7_SHA}"
     assert checkout_step["with"]["persist-credentials"] is False
 
     init_step = next(

--- a/tests/ci/test_ci_workflow_resilience.py
+++ b/tests/ci/test_ci_workflow_resilience.py
@@ -64,7 +64,7 @@ def test_migration_freeze_checkout_is_bounded_for_merge_group() -> None:
     assert job["timeout-minutes"] == 15
 
     checkout_step = next(step for step in steps if step.get("name") == "Checkout code")
-    assert checkout_step["uses"] == "actions/checkout@v7"
+    assert checkout_step["uses"] == f"actions/checkout@{CHECKOUT_V7_SHA}"
     assert checkout_step["timeout-minutes"] == 10
     assert checkout_step["with"]["fetch-depth"] == 2
     assert checkout_step["with"]["fetch-tags"] is False

--- a/tests/ci/test_runner_image_node24_floor.py
+++ b/tests/ci/test_runner_image_node24_floor.py
@@ -6,7 +6,7 @@ not downgrade the live fleet (OMN-12585).
 Background. The OMN-12567 versioned runner image pinned
 ``ARG RUNNER_VERSION=2.323.0`` while the live fleet ran ``2.334.0``. Rolling that
 image to the fleet *downgraded* the GitHub Actions runner, and ``2.323.0`` cannot
-execute ``node24`` actions (``actions/checkout@v6``, used 73x across workflows).
+execute ``node24`` actions (``actions/checkout@v7``, used across workflows).
 It fails at "Set up job" with ``'using: node24' is not supported``. node24
 execution support landed in actions/runner ``2.327.0`` (actions/runner#3940).
 
@@ -44,7 +44,7 @@ RUNNER_DOCKERFILE = REPO_ROOT / "docker" / "runners" / "Dockerfile"
 LOCK_FILE = REPO_ROOT / "docker" / "runners" / "runner-image.lock.json"
 
 # node24 *execution* support landed in actions/runner 2.327.0 (actions/runner
-# #3940). Below this, `actions/checkout@v6` (using: node24) fails at "Set up job".
+# #3940). Below this, `actions/checkout@v7` (using: node24) fails at "Set up job".
 NODE24_FLOOR = (2, 327, 0)
 
 # The live self-hosted fleet runs 2.334.0 (verified 2026-06-02, OMN-12585). The
@@ -85,7 +85,7 @@ def test_dockerfile_runner_version_is_node24_capable() -> None:
     version = _parse(_dockerfile_runner_version())
     assert version >= NODE24_FLOOR, (
         f"RUNNER_VERSION {_fmt(version)} predates node24 execution support "
-        f"({_fmt(NODE24_FLOOR)}); actions/checkout@v6 (using: node24) would fail "
+        f"({_fmt(NODE24_FLOOR)}); actions/checkout@v7 (using: node24) would fail "
         "at 'Set up job' with \"'using: node24' is not supported\""
     )
 

--- a/tests/integration/infra/test_omn_12765_release_backmerge_identity.py
+++ b/tests/integration/infra/test_omn_12765_release_backmerge_identity.py
@@ -33,5 +33,5 @@ def test_release_backmerge_preserves_runner_identity_lock() -> None:
     )
 
     # OMN-13486: identity regenerated for the current dev/runtime proof inputs.
-    assert lock["identity_digest"] == "6276c51d98f177780c62787405e416c9"
-    assert lock["shared_env_digest"] == "2d761320b0fe185d656b4d63"
+    assert lock["identity_digest"] == "da0dc5140fae53e84399503a0e5f8eb3"
+    assert lock["shared_env_digest"] == "8238ed24bfdfc3816dde8016"

--- a/uv.lock
+++ b/uv.lock
@@ -2189,7 +2189,7 @@ requires-dist = [
     { name = "confluent-kafka", specifier = ">=2.12.0,<3.0.0" },
     { name = "cryptography", specifier = ">=46.0.3,<50.0.0" },
     { name = "dependency-injector", specifier = ">=4.48.1,<5.0.0" },
-    { name = "fastapi", specifier = ">=0.120.1,<0.138.0" },
+    { name = "fastapi", specifier = ">=0.120.1,<0.139.0" },
     { name = "grpcio", specifier = ">=1.62.0,<2.0.0" },
     { name = "httpx", specifier = ">=0.28.1,<0.29.0" },
     { name = "infisicalsdk", specifier = ">=1.0.15,<2.0.0" },


### PR DESCRIPTION
Evidence-Source: 97108cc318531acee82410b99c8f53e6d0c4263f
Evidence-Ticket: OMN-13523
Resolves: OMN-13523

Batch replacement for infra Dependabot PRs #2074, #2075, and #2076.

Preserves the original Dependabot commits in branch history while using an OMN-named branch so Receipt Gate can bind central OCC evidence.

Local verification:
- uv run python scripts/ci/runner_image_identity.py --mode verify
- uv run python scripts/check_release_identity.py --base origin/dev
- uv run python scripts/check_dispatcher_route_coverage.py --contracts-dir src/omnibase_infra/nodes --extra-contracts-dir $OMNI_HOME/omnimarket/src/omnimarket/nodes
- uv run pytest tests/ci/test_ci_workflow_resilience.py tests/ci/test_runner_image_node24_floor.py tests/integration/infra/test_omn_12765_release_backmerge_identity.py tests/scripts/test_check_sibling_lock_pins.py -q -p no:cacheprovider


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to use the newer `actions/checkout` version consistently, improving workflow compatibility and keeping action pinning aligned.
  * Updated artifact download action usage in CI and refreshed runner image guidance/messages where applicable.
* **Dependencies**
  * Widened the FastAPI version range to allow additional compatible releases.
* **Tests**
  * Updated CI resilience and integration test expectations for the new checkout pin and updated runner image digest values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


