### PR TITLE
fix(OMN-13537): default ONEX_ARTIFACT_STORE_ROOT under state_root so CLI receipt capture stops failing open

### DIFF
--- a/scripts/check-env-reads.sh
+++ b/scripts/check-env-reads.sh
@@ -24,6 +24,12 @@ APPROVED_INFIX_PATTERNS=(
     "/runtime/config_discovery/config_prefetcher.py"
     "/runtime/runtime_profile.py"
     "/services/registry_api/registry_discovery.py"
+    # OMN-13537: receipt-mode CLI is the config-resolution boundary between the
+    # --state-root flag and the ArtifactStore's sole env-var contract
+    # (ONEX_ARTIFACT_STORE_ROOT). The pinned omnibase_core store exposes no
+    # injection seam, so the boundary must publish the resolved default to the
+    # environment — same class of boundary as service_kernel/config_prefetcher.
+    "/cli/receipt_mode.py"
 )
 
 ENV_READ_PATTERNS='os\.environ\[|os\.environ\.get|os\.getenv|from os import environ|from os import getenv'

--- a/src/omnibase_infra/cli/receipt_mode.py
+++ b/src/omnibase_infra/cli/receipt_mode.py
@@ -16,9 +16,19 @@ Layer A of the skill-output-suppression slice
   :class:`~omnibase_core.models.dispatch.model_skill_result.ModelSkillResult`
   JSON object carrying the FULL result.
 
+Artifact store root resolution (OMN-13537):
+
+- The artifact store root defaults to ``<state_root>/artifacts`` when
+  ``ONEX_ARTIFACT_STORE_ROOT`` is unset, so durable capture succeeds for the
+  CLI surface (``onex node/skill/delegate --output receipt``) without the
+  operator pre-exporting the env var. An explicit override always wins.
+  Before this, the unset env var raised ``KeyError`` in the store constructor
+  and the path **failed open** — receipts were silently never captured.
+
 Failure asymmetry (capture vs telemetry):
 
-- Artifact write failure ⇒ the FULL output is printed instead of the receipt
+- Artifact write failure (a genuine OSError/quota/etc., NOT a missing-env
+  default) ⇒ the FULL output is printed instead of the receipt
   (no hidden loss — parent invariant 1; no silent fallback).
 - Artifact write success but event emission failure ⇒ the receipt still
   prints; the event is spooled to a local outbox under the state root for
@@ -26,12 +36,16 @@ Failure asymmetry (capture vs telemetry):
   when the artifact exists.
 
 .. versionadded:: OMN-13094
+.. versionchanged:: OMN-13537
+   Artifact store root defaults to ``<state_root>/artifacts`` when unset
+   (was: KeyError → fail-open, receipts silently dropped).
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import os
 import socket
 import time
 import traceback
@@ -43,7 +57,10 @@ from typing import cast
 import click
 from pydantic import JsonValue, ValidationError
 
-from omnibase_core.artifacts.artifact_store import ArtifactStore
+from omnibase_core.artifacts.artifact_store import (
+    ARTIFACT_STORE_ROOT_ENV,
+    ArtifactStore,
+)
 from omnibase_core.enums.enum_skill_result_status import EnumSkillResultStatus
 from omnibase_core.enums.enum_workflow_result import EnumWorkflowResult
 from omnibase_core.models.artifacts.model_artifact_ref import ModelArtifactRef
@@ -64,6 +81,12 @@ logger = logging.getLogger(__name__)
 # (matching the workflow_result.json convention — plan Open Question 4).
 CAPTURE_DIR_NAME = "captures"
 SPOOL_DIR_NAME = "emit_spool"
+
+# Artifact store root is a sub-directory of the node's state root by default.
+# The receipt's durable captures (capture log + handler result) belong with the
+# run's other state, so the artifact store shares the state root rather than
+# living in an unrelated location.
+ARTIFACT_STORE_DIR_NAME = "artifacts"
 
 # Socket timeout for emit-daemon calls. Emission is telemetry, never the
 # critical path — a slow daemon must not stall the dispatch.
@@ -252,6 +275,40 @@ def _print_full_output_on_capture_failure(
         click.echo(json.dumps(workflow_data, indent=2))
 
 
+def _resolve_artifact_store_root(state_root: Path) -> Path:
+    """Resolve the artifact store root for receipt-mode capture (boundary).
+
+    The artifact store (omnibase_core) resolves its root *only* from
+    ``ONEX_ARTIFACT_STORE_ROOT`` and ``KeyError``\\s when unset — fail-fast by
+    design (Operating Rule 8). But the receipt-mode CLI is invoked from operator
+    shells that set ``ONEX_STATE_DIR`` but NOT ``ONEX_ARTIFACT_STORE_ROOT``
+    (only the hook backstop exports it, OMN-13095). Without a default here, the
+    unset env var caught the KeyError and the path **failed open** — receipts
+    were silently never captured (OMN-13537).
+
+    This function is the config-resolution boundary between the CLI's
+    ``--state-root`` flag and the store's env-var contract (the same class of
+    boundary as ``runtime/config_discovery`` / ``service_kernel``): an explicit
+    operator-set ``ONEX_ARTIFACT_STORE_ROOT`` always wins; otherwise the store
+    root defaults to ``<state_root>/artifacts``, the convention the hook backstop
+    already encodes. This is NOT a silent fallback to a wrong path — it is the
+    documented home for this run's durable captures, co-located with the run's
+    other state. The resolved default is published to the environment so the
+    pinned ``ArtifactStore`` constructor reads it through its sole resolution
+    path (one source of truth for the store root; no second resolution surface).
+
+    Returns:
+        The resolved artifact store root (absolute path under ``state_root`` when
+        no explicit override is set).
+    """
+    # Explicit operator override wins; only default when truly unset/empty.
+    if os.environ.get(ARTIFACT_STORE_ROOT_ENV):
+        return Path(os.environ[ARTIFACT_STORE_ROOT_ENV])
+    resolved = (state_root / ARTIFACT_STORE_DIR_NAME).resolve()
+    os.environ[ARTIFACT_STORE_ROOT_ENV] = str(resolved)
+    return resolved
+
+
 def run_receipt_mode(
     *,
     node_name: str,
@@ -315,6 +372,11 @@ def run_receipt_mode(
         ]
 
     # --- Layer B: durable capture (parent invariant 1) -------------------
+    # Resolve the artifact store root BEFORE constructing the store: default it
+    # to <state_root>/artifacts when unset so durable capture succeeds instead
+    # of failing open on a missing ONEX_ARTIFACT_STORE_ROOT (OMN-13537). An
+    # explicit operator override still wins.
+    _resolve_artifact_store_root(state_root)
     handler_result_json = workflow_data.get("handler_result")
     artifact_payloads: list[dict[str, JsonValue]] = []
     artifact_refs: list[ModelArtifactRef] = []

--- a/tests/unit/cli/test_cli_node_receipt.py
+++ b/tests/unit/cli/test_cli_node_receipt.py
@@ -12,8 +12,10 @@ Acceptance is STRUCTURAL, not size-based (plan Open Question 3 resolution):
   artifact store and hash-verified on retrieval;
 - ``artifact.captured`` + ``tool.output.captured`` are emitted via the emit
   daemon socket, or spooled locally when the daemon is unreachable;
-- artifact-write failure prints the FULL output instead of a receipt
-  (no hidden loss);
+- ONEX_ARTIFACT_STORE_ROOT defaults to ``<state_root>/artifacts`` when unset
+  so durable capture succeeds without a pre-exported env var (OMN-13537);
+- a genuine (non-env) artifact-write failure prints the FULL output instead of
+  a receipt (no hidden loss);
 - node failure produces ``status=failed`` with the full error output inline.
 
 These tests run the REAL dispatch path: the actual click command through the
@@ -280,14 +282,73 @@ class TestReceiptModeSuccess:
         assert not spool_dir.exists() or not list(spool_dir.iterdir())
 
 
-class TestReceiptModeFailureAsymmetry:
-    def test_artifact_write_failure_prints_full_output_not_receipt(
+class TestArtifactStoreRootDefault:
+    """OMN-13537: ONEX_ARTIFACT_STORE_ROOT defaults to <state_root>/artifacts.
+
+    Before this fix the unset env var raised KeyError in the store constructor
+    and the receipt path failed OPEN — receipts were silently never captured.
+    """
+
+    def test_unset_env_captures_under_state_root_default(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Missing ONEX_ARTIFACT_STORE_ROOT ⇒ FULL output, no receipt."""
-        result, _ = _invoke_receipt(tmp_path, monkeypatch, store_root=None)
-        # The run itself succeeded; capture failed; nothing may be hidden.
+        """Unset ONEX_ARTIFACT_STORE_ROOT ⇒ default-resolve, receipt captured."""
+        result, state_root = _invoke_receipt(tmp_path, monkeypatch, store_root=None)
+        assert result.exit_code == 0, result.output
+        # No fail-open: the KeyError line must NOT appear.
+        assert "artifact capture failed" not in result.stderr
+        assert "no hidden loss" not in result.stderr
+        # Exactly one receipt JSON on stdout (capture succeeded).
+        payload = _parse_single_receipt(result.stdout)
+        receipt = ModelSkillResult.model_validate(payload)
+        assert receipt.status.is_success_like
+        assert receipt.artifact_refs, "capture must be artifact-backed via default"
+
+        # Artifacts physically landed under the defaulted <state_root>/artifacts.
+        default_store_root = state_root / "artifacts"
+        assert default_store_root.is_dir()
+        store = ArtifactStore()  # reads the env var the CLI just defaulted
+        assert store.root == default_store_root.resolve()
+        for raw_ref in payload["artifact_refs"]:  # type: ignore[union-attr]
+            assert isinstance(raw_ref, dict)
+            ref = ModelArtifactRef.model_validate(raw_ref)
+            store.read_blob(ref)  # re-hashes; raises on mismatch
+            assert store.read_meta(ref).source_system == "onex_cli"
+
+    def test_explicit_env_override_wins_over_default(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An explicit ONEX_ARTIFACT_STORE_ROOT is honored, not the default."""
+        explicit_root = tmp_path / "operator-chosen-artifacts"
+        result, state_root = _invoke_receipt(
+            tmp_path, monkeypatch, store_root=explicit_root
+        )
+        assert result.exit_code == 0, result.output
+        _parse_single_receipt(result.stdout)
+        # Artifacts went to the operator path, NOT the state-root default.
+        assert explicit_root.is_dir()
+        assert list(explicit_root.iterdir()), "explicit store root must hold blobs"
+        default_store_root = state_root / "artifacts"
+        assert not default_store_root.exists(), "default must not be used on override"
+
+
+class TestReceiptModeFailureAsymmetry:
+    def test_genuine_write_failure_prints_full_output_not_receipt(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A real (non-env) artifact write failure ⇒ FULL output, no receipt.
+
+        Fail-loud is preserved for genuine write errors: pointing the store
+        root at an existing regular FILE makes the store's shard ``mkdir`` raise
+        ``NotADirectoryError`` (an ``OSError``), which must surface the full
+        output (no hidden loss) rather than a receipt.
+        """
+        store_file = tmp_path / "store-is-a-file"
+        store_file.write_text("not a directory", encoding="utf-8")
+        result, _ = _invoke_receipt(tmp_path, monkeypatch, store_root=store_file)
+        # The run itself succeeded; capture failed for a real reason.
         assert result.exit_code == 0
+        assert "artifact capture failed" in result.stderr
         assert "no hidden loss" in result.stderr
         # Full capture stream passes through instead of a receipt.
         assert "RuntimeLocal" in result.stdout


### PR DESCRIPTION
## OMN-13537 — fix receipt-mode `ONEX_ARTIFACT_STORE_ROOT` fail-open

Follow-up defect from epic OMN-13089 (Skill Output Suppression). The epic's children (OMN-13093/13094/13095/13096) are all Done — this is a NEW env-resolution / fail-open gap in the CLI receipt path, not covered by any of them.

### Problem (verified live)
Every `onex node|skill|delegate --output receipt` dispatch from the operator shell printed:
```
receipt mode: artifact capture failed (KeyError: 'ONEX_ARTIFACT_STORE_ROOT'); printing full output instead of a receipt (no hidden loss).
```
`ArtifactStore` resolves its root only from `os.environ[ONEX_ARTIFACT_STORE_ROOT]` (KeyError when unset, by design — fail-fast Rule 8). The receipt-mode CLI never defaulted it. The operator shell sets `ONEX_STATE_DIR` but **not** `ONEX_ARTIFACT_STORE_ROOT` (only the hook backstop OMN-13095 exported it). The KeyError was caught and the path **failed open** — Layer B durable capture (epic AC 5+6) was silently never reached for the whole CLI surface.

### Fix (default-resolve, not fail-loud)
`receipt_mode._resolve_artifact_store_root` resolves the store root at the config boundary: defaults to `<state_root>/artifacts` when unset (the same convention the hook encodes), explicit operator override always wins, and publishes the resolved default to the env so the pinned core store reads it through its sole resolution path. Receipts are now **captured** instead of dropped. Genuine (non-env) write failures still **fail loud** via the existing full-output path — no fail-open introduced for real errors.

`scripts/check-env-reads.sh`: the receipt-mode CLI is allowlisted as a config-resolution boundary (same class as `service_kernel`/`config_prefetcher`; the pinned `omnibase_core` `ArtifactStore` exposes no DI seam, so the env var is the only contract).

### dod_evidence

**Live end-to-end proof — operator scenario, `ONEX_ARTIFACT_STORE_ROOT` UNSET:**
```
$ env -u ONEX_ARTIFACT_STORE_ROOT uv run onex node proof_noop --output receipt --state-root <root> ...
{"skill_name":"proof_noop","node_name":"proof_noop","status":"success",...,
 "artifact_refs":[{"ref":"sha256:7ce1e186..."},{"ref":"sha256:2265d01d..."}], ...}
exit_code=0
# stderr: EMPTY (no "artifact capture failed" line)
# blobs + meta sidecars physically landed under <state_root>/artifacts/{7c,22}/...
```
Before the fix this same invocation printed the KeyError fail-open line + full output and captured nothing.

**Tests (real CLI dispatch path, no mocked runtime):**
- `tests/unit/cli/test_cli_node_receipt.py::TestArtifactStoreRootDefault::test_unset_env_captures_under_state_root_default` — unset env ⇒ receipt captured under defaulted store, no KeyError.
- `...::test_explicit_env_override_wins_over_default` — explicit override honored, default NOT used.
- `...::TestReceiptModeFailureAsymmetry::test_genuine_write_failure_prints_full_output_not_receipt` — store-root-is-a-file (NotADirectoryError) ⇒ fail-loud full output preserved.

```
tests/unit/cli/test_cli_node_receipt.py ... 10 passed
tests/unit/cli/test_cli_delegate.py + test_cli_skill.py ... 43 passed, 1 skipped (no regression)
uv run pytest tests/ -m unit ... 21293 passed, 18 skipped, 0 failed
mypy src/omnibase_infra/cli/receipt_mode.py ... Success
ruff check + format ... clean
pre-commit run (changed files) ... all pass (incl. env-reads gate)
```

Dedup: searched Linear for ONEX_ARTIFACT_STORE_ROOT / receipt artifact capture; epic OMN-13089 children all Done; this env-resolution/fail-open gap is new. Filed as OMN-13537 under OMN-13089.



Evidence-Source: OCC#2973


Evidence-Ticket: OMN-13537
