### PR TITLE
feat(OMN-13109): runner-monitor silent-wedge + crash-loop detection

### DIFF
--- a/contracts/OMN-13109.yaml
+++ b/contracts/OMN-13109.yaml
@@ -1,0 +1,48 @@
+schema_version: '1.0.0'
+ticket_id: OMN-13109
+title: 'Runner-fleet monitor: silent-wedge + crash-loop detection'
+summary: >-
+  Upgrade runner-monitor.sh detection so it catches the two failure modes the legacy container+registration check missed: (a) SILENT-WEDGE — a runner that is Up (healthy) and online/registered but idle while jobs sit queued past a threshold (registered but not pulling work), and (b) CRASH-LOOP-ON-RESTART — a container with a climbing RestartCount or repeated config.sh re-registration markers. Both alert to Slack with the SAFE force-recreate remediation recipe (fresh registration token, named services only, detached). Auto-bounce is gated OFF by default; the script remains observe-and-alert.
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: tests
+    description: >-
+      Behavioral shell-driven tests prove the upgraded monitor flags a wedged runner the legacy logic passed, flags crash-loop, and never invokes docker restart / empty-filter bounce.
+    command: uv run pytest tests/unit/observability/runner_health/test_runner_monitor_wedge_detection.py -q
+  - kind: ci
+    description: CI pipeline green on PR
+    command: gh pr checks <PR> --repo OmniNode-ai/omnibase_infra
+emergency_bypass:
+  enabled: false
+  justification: ''
+  follow_up_ticket_id: ''
+dod_evidence:
+  - id: dod-001-wedge
+    description: >-
+      The upgraded monitor flags a SILENT-WEDGE (runner online + busy=0 while a self-hosted job has been queued past the threshold) — the exact state the legacy container+registration logic returned CLEAN. Test drives the real runner-monitor.sh end-to-end with mocked docker/curl/gh/date and asserts wedge_count >= 1.
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/unit/observability/runner_health/test_runner_monitor_wedge_detection.py::test_silent_wedge_is_flagged_where_legacy_logic_passed -q'
+  - id: dod-002-crashloop
+    description: >-
+      The upgraded monitor flags CRASH-LOOP via climbing RestartCount and via repeated config.sh re-registration log markers, even when the container momentarily reports Up (healthy).
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest "tests/unit/observability/runner_health/test_runner_monitor_wedge_detection.py::test_crashloop_flagged_on_high_restart_count" "tests/unit/observability/runner_health/test_runner_monitor_wedge_detection.py::test_crashloop_flagged_on_reregistration_log_markers" -q'
+  - id: dod-003-no-mutation
+    description: >-
+      Safety invariant: with auto-bounce OFF (default) the monitor never invokes docker restart or an empty-filter docker compose recreate against the fleet; the documented remediation is force-recreate of NAMED services only with a freshly minted registration token.
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest "tests/unit/observability/runner_health/test_runner_monitor_wedge_detection.py::test_monitor_never_runs_docker_restart_or_empty_bounce" "tests/unit/observability/runner_health/test_runner_monitor_wedge_detection.py::test_script_documents_safe_bounce_and_forbids_docker_restart" -q'
+  - id: dod-004-suite
+    description: Full runner_health unit suite stays green (no regression to existing monitor/collector/janitor tests).
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/unit/observability/runner_health/ -q'

--- a/docker/runners/runner-monitor.sh
+++ b/docker/runners/runner-monitor.sh
@@ -2,10 +2,43 @@
 # runner-monitor.sh — Self-hosted runner health monitor with Slack alerts
 # Deployed to: 192.168.86.201:~/.omnibase/runners/runner-monitor.sh
 # Cron: */3 * * * * (every 3 minutes)
+# Ticket: OMN-13109 (silent-wedge + crash-loop detection)
 #
 # Checks configured omninode-runner-* containers and their GitHub Actions
 # registrations. Fires a Slack alert on state transitions. Resolves silently
 # when all recover. Uses a state file to prevent alert spam.
+#
+# Detection layers (each catches a failure mode the previous layer misses):
+#
+#   1. CONTAINER + REGISTRATION (legacy): container is `Up (healthy)` AND the
+#      runner is `online` in the GitHub org pool. The OMN-12433 healthcheck
+#      additionally proves github.com egress.
+#
+#   2. SILENT-WEDGE (OMN-13109): a runner can be `Up (healthy)` and `online`
+#      while NOT pulling jobs — the Runner.Listener is alive and the long-poll
+#      registration looks connected, but the runner is not picking up queued
+#      work (last job days old). Container-only and registration-only checks
+#      both PASS this state. We detect it by cross-referencing the GitHub
+#      `busy` field against jobs that are QUEUED for our runner labels: if work
+#      has been queued longer than WEDGE_QUEUE_AGE_SECONDS while the fleet sits
+#      idle (online + not busy), the fleet is wedged.
+#
+#   3. CRASH-LOOP-ON-RESTART (OMN-13109): a blanket `docker restart` crash-loops
+#      these runners — the entrypoint re-runs config.sh, which reports "already
+#      configured", exits, and compose `restart: unless-stopped` immediately
+#      restarts it. This shows up as a climbing container RestartCount and/or
+#      repeated re-registration markers in `docker logs`. We detect both and
+#      alert with the explicit SAFE remediation (NOT `docker restart`).
+#
+# SAFE remediation recipe (documented; NOT auto-executed unless explicitly
+# enabled — see MONITOR_AUTO_BOUNCE below):
+#
+#   Bounce ONLY the specific wedged/crash-looping service via:
+#     docker compose -f <compose> up -d --force-recreate <service-1> <service-N>
+#   with a FRESHLY minted registration token, run DETACHED.
+#   NEVER `docker restart`           → crash-loops (cached creds + baked token expired)
+#   NEVER an empty service filter    → would recreate all 48 at once
+#   NEVER block on the bounce        → 2-minute hard limit, run in background
 
 set -euo pipefail
 
@@ -14,7 +47,33 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 STATE_FILE="/tmp/runner-monitor-state.json"
 COMPOSE_DIR="$HOME/.omnibase/runners/docker"
+COMPOSE_FILE="${COMPOSE_DIR}/docker-compose.runners.yml"
 RUNNER_FLEET_CONFIG_PATH="${RUNNER_FLEET_CONFIG_PATH:-$HOME/.omnibase/runners/config/runner_fleet.yaml}"
+
+# Silent-wedge thresholds (OMN-13109). A fleet that is online + idle while jobs
+# have been queued for longer than WEDGE_QUEUE_AGE_SECONDS is wedged. Default
+# 10 minutes — long enough to ignore normal scheduling latency, short enough to
+# catch the all-night wedge that starved the merge queue.
+WEDGE_QUEUE_AGE_SECONDS="${WEDGE_QUEUE_AGE_SECONDS:-600}"
+# Repos whose Actions queues are serviced by this self-hosted fleet. Queued-job
+# age is sampled across these. Override via WEDGE_WATCH_REPOS (space-separated
+# "owner/name" entries).
+WEDGE_WATCH_REPOS="${WEDGE_WATCH_REPOS:-OmniNode-ai/omnibase_infra OmniNode-ai/omnibase_core OmniNode-ai/omniclaude OmniNode-ai/omnimarket}"
+
+# Crash-loop thresholds (OMN-13109). A container whose RestartCount exceeds
+# CRASHLOOP_RESTART_THRESHOLD, or whose recent logs show repeated re-registration
+# markers, is crash-looping and must NOT be `docker restart`-ed.
+CRASHLOOP_RESTART_THRESHOLD="${CRASHLOOP_RESTART_THRESHOLD:-5}"
+CRASHLOOP_LOG_TAIL_LINES="${CRASHLOOP_LOG_TAIL_LINES:-200}"
+CRASHLOOP_REREGISTER_MARKER_THRESHOLD="${CRASHLOOP_REREGISTER_MARKER_THRESHOLD:-3}"
+
+# Auto-bounce is OFF by default: this monitor DETECTS and ALERTS. It does NOT
+# mutate the live fleet unless an operator deliberately sets MONITOR_AUTO_BOUNCE=1
+# in the monitor env. Even then it force-recreates only the named services with
+# a fresh token, detached, with a 2-minute hard limit — never `docker restart`,
+# never an empty filter. Steady state is observe-and-alert.
+MONITOR_AUTO_BOUNCE="${MONITOR_AUTO_BOUNCE:-0}"
+AUTO_BOUNCE_HARD_LIMIT_SECONDS="${AUTO_BOUNCE_HARD_LIMIT_SECONDS:-120}"
 
 config_field() {
     local field="${1}"
@@ -78,16 +137,114 @@ slack_post() {
         )" > /dev/null 2>&1
 }
 
+# gh_api_runners — fetch the org self-hosted runner list as JSON. Empty string
+# on failure (caller treats empty as github_api_failed).
+gh_api_runners() {
+    curl -fsS \
+        -H "Authorization: Bearer ${RUNNER_GITHUB_TOKEN}" \
+        -H "Accept: application/vnd.github+json" \
+        "https://api.github.com/orgs/${RUNNER_ORG}/actions/runners?per_page=100" 2>/dev/null || true
+}
+
+# oldest_queued_job_age_seconds — across WEDGE_WATCH_REPOS, find the OLDEST
+# job whose status is "queued" and that targets a self-hosted label, then return
+# its age in seconds. Returns 0 when nothing is queued (no wedge possible).
+#
+# This is the discriminator the legacy monitor lacked: a runner being "online"
+# tells you the listener long-poll is connected, NOT that work is flowing.
+# Queued work that ages out while the fleet is idle is the wedge signal.
+oldest_queued_job_age_seconds() {
+    local now_epoch oldest_epoch="" repo runs_json run_ids jobs_json job_created
+    now_epoch=$(date -u +%s)
+
+    for repo in ${WEDGE_WATCH_REPOS}; do
+        runs_json=$(curl -fsS \
+            -H "Authorization: Bearer ${RUNNER_GITHUB_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${repo}/actions/runs?status=queued&per_page=20" 2>/dev/null || true)
+        [[ -z "${runs_json}" ]] && continue
+
+        run_ids=$(jq -r '.workflow_runs[]?.id // empty' <<< "${runs_json}" 2>/dev/null || true)
+        [[ -z "${run_ids}" ]] && continue
+
+        while IFS= read -r run_id; do
+            [[ -z "${run_id}" ]] && continue
+            jobs_json=$(curl -fsS \
+                -H "Authorization: Bearer ${RUNNER_GITHUB_TOKEN}" \
+                -H "Accept: application/vnd.github+json" \
+                "https://api.github.com/repos/${repo}/actions/runs/${run_id}/jobs?per_page=50" 2>/dev/null || true)
+            [[ -z "${jobs_json}" ]] && continue
+
+            # Only count queued jobs that target a self-hosted label. Hosted
+            # jobs (ubuntu-latest) are not serviced by this fleet and must not
+            # trigger a wedge alert.
+            while IFS= read -r job_created; do
+                [[ -z "${job_created}" ]] && continue
+                local job_epoch
+                # GNU date (Linux .201 host) parses the ISO-8601 created_at.
+                job_epoch=$(date -u -d "${job_created}" +%s 2>/dev/null || echo "")
+                [[ -z "${job_epoch}" ]] && continue
+                if [[ -z "${oldest_epoch}" ]] || [[ "${job_epoch}" -lt "${oldest_epoch}" ]]; then
+                    oldest_epoch="${job_epoch}"
+                fi
+            done < <(jq -r --arg group "${RUNNER_GROUP}" '
+                .jobs[]?
+                | select(.status == "queued")
+                | select(any(.labels[]?; . == "self-hosted" or . == $group))
+                | .created_at
+            ' <<< "${jobs_json}" 2>/dev/null || true)
+        done <<< "${run_ids}"
+    done
+
+    if [[ -z "${oldest_epoch}" ]]; then
+        echo 0
+        return 0
+    fi
+    echo $(( now_epoch - oldest_epoch ))
+}
+
+# container_is_crashlooping — given a container name, return 0 (true) when it is
+# crash-looping: RestartCount exceeds threshold OR recent logs show repeated
+# re-registration markers (config.sh re-run loop). Echoes a human reason on the
+# first matched signal.
+container_is_crashlooping() {
+    local name="${1}"
+    local restart_count marker_count
+
+    restart_count=$(docker inspect --format '{{.RestartCount}}' "${name}" 2>/dev/null || echo 0)
+    if [[ "${restart_count}" =~ ^[0-9]+$ ]] && [[ "${restart_count}" -gt "${CRASHLOOP_RESTART_THRESHOLD}" ]]; then
+        echo "RestartCount=${restart_count} > ${CRASHLOOP_RESTART_THRESHOLD}"
+        return 0
+    fi
+
+    # Re-registration markers in the recent log tail. The entrypoint emits these
+    # exact strings when it is stuck re-running config.sh / hitting max retries.
+    marker_count=$(docker logs --tail "${CRASHLOOP_LOG_TAIL_LINES}" "${name}" 2>&1 \
+        | grep -ciE 'already configured|Re-registering|Max retries .* reached|Registration error detected|Runner removed' \
+        || true)
+    if [[ "${marker_count}" =~ ^[0-9]+$ ]] && [[ "${marker_count}" -ge "${CRASHLOOP_REREGISTER_MARKER_THRESHOLD}" ]]; then
+        echo "re-registration markers=${marker_count} >= ${CRASHLOOP_REREGISTER_MARKER_THRESHOLD} in last ${CRASHLOOP_LOG_TAIL_LINES} log lines"
+        return 0
+    fi
+
+    return 1
+}
+
 # ---------------------------------------------------------------------------
 # Collect current state
 # ---------------------------------------------------------------------------
 declare -A current_status
 declare -A docker_oom_killed
 declare -A github_status
+declare -A github_busy
 
 total_found=0
 healthy=0
+online_count=0
+busy_count=0
 unhealthy_list=()
+wedge_list=()
+crashloop_list=()
 github_api_failed=false
 
 while IFS=$'\t' read -r name status; do
@@ -100,23 +257,23 @@ for name in "${!current_status[@]}"; do
     docker_oom_killed["$name"]="$oom_killed"
 done
 
-github_json=$(curl -fsS \
-    -H "Authorization: Bearer ${RUNNER_GITHUB_TOKEN}" \
-    -H "Accept: application/vnd.github+json" \
-    "https://api.github.com/orgs/${RUNNER_ORG}/actions/runners?per_page=100" 2>/dev/null || true)
+github_json=$(gh_api_runners)
 
 if [[ -z "${github_json}" ]]; then
     github_api_failed=true
     unhealthy_list+=("GITHUB_API: failed to fetch org runner status")
 else
-    while IFS=$'\t' read -r name status; do
+    # Capture both status (online/offline) AND busy (executing a job). The busy
+    # field is the silent-wedge discriminator the legacy monitor ignored.
+    while IFS=$'\t' read -r name status busy; do
         [[ -z "${name}" ]] && continue
         github_status["$name"]="$status"
+        github_busy["$name"]="$busy"
     done < <(jq -r --arg prefix "${RUNNER_NAME_PREFIX}" --arg group "${RUNNER_GROUP}" '
         .runners[]
         | select(.name | startswith($prefix))
         | select(any(.labels[]; .name == $group))
-        | [.name, .status]
+        | [.name, .status, (.busy | tostring)]
         | @tsv
     ' <<< "${github_json}")
 fi
@@ -144,6 +301,16 @@ for i in $(seq 1 "$EXPECTED_RUNNERS"); do
         continue
     fi
 
+    # Crash-loop check runs even on "healthy" containers: a container can be
+    # "Up (healthy)" in the brief window between restart and the next config.sh
+    # exit. RestartCount and the log markers expose the loop the status string
+    # hides. Do NOT `docker restart` these.
+    if crashloop_reason=$(container_is_crashlooping "${name}"); then
+        crashloop_list+=("${name}: CRASH-LOOP (${crashloop_reason})")
+        unhealthy_list+=("${name}: CRASH-LOOP (${crashloop_reason})")
+        continue
+    fi
+
     if [[ "${github_api_failed}" == true ]]; then
         healthy=$((healthy + 1))
         continue
@@ -155,8 +322,28 @@ for i in $(seq 1 "$EXPECTED_RUNNERS"); do
         continue
     fi
 
+    online_count=$((online_count + 1))
+    if [[ "${github_busy[$name]:-false}" == "true" ]]; then
+        busy_count=$((busy_count + 1))
+    fi
     healthy=$((healthy + 1))
 done
+
+# ---------------------------------------------------------------------------
+# Silent-wedge detection (OMN-13109)
+# ---------------------------------------------------------------------------
+# A wedged fleet PASSES every check above: containers Up (healthy), runners
+# online. The tell is jobs queued for our labels aging out while NO runner is
+# busy. Only evaluate when the GitHub API succeeded (we need the busy field) and
+# at least one runner is online (otherwise the offline path already alerted).
+queued_age=0
+if [[ "${github_api_failed}" != true ]] && [[ "${online_count}" -gt 0 ]]; then
+    queued_age=$(oldest_queued_job_age_seconds)
+    if [[ "${queued_age}" -ge "${WEDGE_QUEUE_AGE_SECONDS}" ]] && [[ "${busy_count}" -eq 0 ]]; then
+        wedge_list+=("SILENT-WEDGE: ${online_count} runners online + ${busy_count} busy, but a self-hosted job has been queued ${queued_age}s (>= ${WEDGE_QUEUE_AGE_SECONDS}s). Fleet is registered but not pulling jobs.")
+        unhealthy_list+=("SILENT-WEDGE: online=${online_count} busy=0, queued-job-age=${queued_age}s")
+    fi
+fi
 
 # Also check Docker socket accessibility from a healthy runner
 docker_ok=true
@@ -197,6 +384,77 @@ if [[ "${github_api_failed}" != true ]]; then
 fi
 
 # ---------------------------------------------------------------------------
+# SAFE remediation recipe (OMN-13109)
+# ---------------------------------------------------------------------------
+# Render the exact, copy-pasteable safe-bounce command for the affected
+# services. By default this is ONLY rendered into the Slack alert (operator runs
+# it). When MONITOR_AUTO_BOUNCE=1 it is executed — force-recreate of the named
+# services only, fresh token, detached, 2-minute hard limit.
+#
+# remediation_targets: space-separated service names extracted from the
+# wedge/crash-loop findings. Empty when the issue is something else (offline,
+# OOM, socket) where the bounce recipe does not apply.
+collect_remediation_targets() {
+    local targets=()
+    local entry svc
+    if [[ "${#crashloop_list[@]}" -gt 0 ]]; then
+        for entry in "${crashloop_list[@]}"; do
+            svc="${entry%%:*}"
+            [[ "${svc}" =~ ^${RUNNER_NAME_PREFIX}-[0-9]+$ ]] && targets+=("${svc}")
+        done
+    fi
+    # A silent wedge is fleet-wide: the safe recipe bounces the whole configured
+    # fleet, but STILL one explicit service list (never an empty filter).
+    if [[ "${#wedge_list[@]}" -gt 0 ]]; then
+        local j
+        for j in $(seq 1 "${EXPECTED_RUNNERS}"); do
+            targets+=("${RUNNER_NAME_PREFIX}-${j}")
+        done
+    fi
+    # De-dupe while preserving order. Guard against empty array under set -u.
+    if [[ "${#targets[@]}" -gt 0 ]]; then
+        printf '%s\n' "${targets[@]}" | awk '!seen[$0]++' | tr '\n' ' '
+    fi
+}
+
+render_safe_bounce_cmd() {
+    local target_list="$1"
+    [[ -z "${target_list// /}" ]] && { echo ""; return 0; }
+    cat <<RECIPE
+# SAFE BOUNCE — force-recreate ONLY these services with a FRESH token, detached.
+# NEVER 'docker restart' (crash-loops: cached creds + expired baked token).
+# NEVER an empty service filter (would recreate all 48 at once).
+TOKEN=\$(gh api --method POST /orgs/${RUNNER_ORG}/actions/runners/registration-token --jq .token)
+RUNNER_TOKEN="\$TOKEN" timeout ${AUTO_BOUNCE_HARD_LIMIT_SECONDS} \\
+  docker compose -f ${COMPOSE_FILE} up -d --force-recreate --no-deps ${target_list}
+RECIPE
+}
+
+# auto_bounce — execute the safe recipe IFF MONITOR_AUTO_BOUNCE=1. Detached,
+# fresh token, named services only, 2-minute hard limit. This is the documented
+# remediation; it is gated OFF by default so this script stays observe-and-alert.
+auto_bounce() {
+    local target_list="$1"
+    [[ "${MONITOR_AUTO_BOUNCE}" != "1" ]] && return 0
+    [[ -z "${target_list// /}" ]] && return 0
+
+    log "AUTO-BOUNCE enabled (MONITOR_AUTO_BOUNCE=1). Force-recreating: ${target_list}"
+    local token
+    token=$(gh api --method POST "/orgs/${RUNNER_ORG}/actions/runners/registration-token" --jq .token 2>/dev/null || true)
+    if [[ -z "${token}" ]]; then
+        log "AUTO-BOUNCE aborted: could not mint a fresh registration token."
+        slack_post "*[RUNNER AUTO-BOUNCE ABORTED]* could not mint registration token. Manual bounce required for: ${target_list}" "danger"
+        return 0
+    fi
+    # Detached, named services only, hard 2-minute limit, never blocking.
+    # shellcheck disable=SC2086
+    RUNNER_TOKEN="${token}" timeout "${AUTO_BOUNCE_HARD_LIMIT_SECONDS}" \
+        docker compose -f "${COMPOSE_FILE}" up -d --force-recreate --no-deps ${target_list} \
+        >> /tmp/runner-monitor-bounce.log 2>&1 &
+    log "AUTO-BOUNCE dispatched in background (limit ${AUTO_BOUNCE_HARD_LIMIT_SECONDS}s)."
+}
+
+# ---------------------------------------------------------------------------
 # Compare with previous state and alert on transitions
 # ---------------------------------------------------------------------------
 prev_unhealthy_count=0
@@ -205,11 +463,18 @@ if [[ -f "$STATE_FILE" ]]; then
 fi
 
 current_unhealthy_count=${#unhealthy_list[@]}
+wedge_count=${#wedge_list[@]}
+crashloop_count=${#crashloop_list[@]}
 
 # Write current state
 jq -n \
     --argjson healthy "$healthy" \
     --argjson unhealthy_count "$current_unhealthy_count" \
+    --argjson wedge_count "$wedge_count" \
+    --argjson crashloop_count "$crashloop_count" \
+    --argjson online "$online_count" \
+    --argjson busy "$busy_count" \
+    --argjson queued_age "$queued_age" \
     --argjson total "$total_found" \
     --argjson docker_ok "$docker_ok" \
     --arg timestamp "$(date -Iseconds)" \
@@ -217,6 +482,11 @@ jq -n \
     '{
         healthy: $healthy,
         unhealthy_count: $unhealthy_count,
+        wedge_count: $wedge_count,
+        crashloop_count: $crashloop_count,
+        online: $online,
+        busy: $busy,
+        oldest_queued_job_age_seconds: $queued_age,
         total: $total,
         docker_ok: $docker_ok,
         timestamp: $timestamp,
@@ -227,41 +497,91 @@ jq -n \
 # Alert logic — only on state transitions
 # ---------------------------------------------------------------------------
 
+remediation_targets="$(collect_remediation_targets)"
+safe_bounce_block=""
+if [[ -n "${remediation_targets// /}" ]]; then
+    safe_bounce_block="$(render_safe_bounce_cmd "${remediation_targets}")"
+fi
+
+# Build the special-finding banner (wedge / crash-loop) appended to alerts.
+special_findings=""
+if [[ "${wedge_count}" -gt 0 ]]; then
+    special_findings+="$(printf '%s\n' "${wedge_list[@]}")"$'\n'
+fi
+if [[ "${crashloop_count}" -gt 0 ]]; then
+    special_findings+="$(printf '%s\n' "${crashloop_list[@]}")"$'\n'
+fi
+
 if [[ $current_unhealthy_count -gt 0 ]] && [[ $prev_unhealthy_count -eq 0 ]]; then
     # Transition: all-good → something broken
     detail=$(printf '%s\n' "${unhealthy_list[@]}")
-    slack_post "*[RUNNER ALERT]* ${current_unhealthy_count}/${EXPECTED_RUNNERS} runners unhealthy
+    msg="*[RUNNER ALERT]* ${current_unhealthy_count}/${EXPECTED_RUNNERS} runners unhealthy
 
 \`\`\`
 ${detail}
 \`\`\`
 
-Healthy: ${healthy}/${EXPECTED_RUNNERS}
+Healthy: ${healthy}/${EXPECTED_RUNNERS} | Online: ${online_count} | Busy: ${busy_count}
 Docker socket: $([ "$docker_ok" = true ] && echo 'OK' || echo 'FAILED')
-Host: ${RUNNER_HOST}" "danger"
-    log "ALERT: ${current_unhealthy_count} runners unhealthy (was 0). Slack notified."
+Host: ${RUNNER_HOST}"
+    if [[ -n "${special_findings}" ]]; then
+        msg+="
+
+*Detected failure modes (OMN-13109):*
+\`\`\`
+${special_findings}\`\`\`"
+    fi
+    if [[ -n "${safe_bounce_block}" ]]; then
+        msg+="
+
+*Safe remediation (force-recreate named services only — NEVER docker restart):*
+\`\`\`
+${safe_bounce_block}
+\`\`\`"
+    fi
+    slack_post "${msg}" "danger"
+    log "ALERT: ${current_unhealthy_count} runners unhealthy (was 0). wedge=${wedge_count} crashloop=${crashloop_count}. Slack notified."
+    auto_bounce "${remediation_targets}"
 
 elif [[ $current_unhealthy_count -gt 0 ]] && [[ $prev_unhealthy_count -gt 0 ]] && [[ $current_unhealthy_count -ne $prev_unhealthy_count ]]; then
     # Transition: bad → worse or bad → partially recovered
     detail=$(printf '%s\n' "${unhealthy_list[@]}")
-    slack_post "*[RUNNER UPDATE]* ${current_unhealthy_count}/${EXPECTED_RUNNERS} runners unhealthy (was ${prev_unhealthy_count})
+    msg="*[RUNNER UPDATE]* ${current_unhealthy_count}/${EXPECTED_RUNNERS} runners unhealthy (was ${prev_unhealthy_count})
 
 \`\`\`
 ${detail}
 \`\`\`
 
-Healthy: ${healthy}/${EXPECTED_RUNNERS}" "warning"
-    log "UPDATE: ${current_unhealthy_count} unhealthy (was ${prev_unhealthy_count}). Slack notified."
+Healthy: ${healthy}/${EXPECTED_RUNNERS} | Online: ${online_count} | Busy: ${busy_count}"
+    if [[ -n "${special_findings}" ]]; then
+        msg+="
+
+*Detected failure modes (OMN-13109):*
+\`\`\`
+${special_findings}\`\`\`"
+    fi
+    if [[ -n "${safe_bounce_block}" ]]; then
+        msg+="
+
+*Safe remediation (force-recreate named services only — NEVER docker restart):*
+\`\`\`
+${safe_bounce_block}
+\`\`\`"
+    fi
+    slack_post "${msg}" "warning"
+    log "UPDATE: ${current_unhealthy_count} unhealthy (was ${prev_unhealthy_count}). wedge=${wedge_count} crashloop=${crashloop_count}. Slack notified."
+    auto_bounce "${remediation_targets}"
 
 elif [[ $current_unhealthy_count -eq 0 ]] && [[ $prev_unhealthy_count -gt 0 ]]; then
     # Transition: broken → all recovered
     slack_post "*[RUNNER RECOVERED]* All ${EXPECTED_RUNNERS} runners healthy
 
+Online: ${online_count} | Busy: ${busy_count}
 Docker socket: $([ "$docker_ok" = true ] && echo 'OK' || echo 'FAILED')
 Host: ${RUNNER_HOST}" "good"
     log "RECOVERED: All ${EXPECTED_RUNNERS} runners healthy. Slack notified."
 
 else
     # No state change — silent
-    log "OK: ${healthy}/${EXPECTED_RUNNERS} healthy, ${current_unhealthy_count} unhealthy (no change)."
+    log "OK: ${healthy}/${EXPECTED_RUNNERS} healthy, ${current_unhealthy_count} unhealthy (wedge=${wedge_count} crashloop=${crashloop_count}, no change)."
 fi

--- a/tests/unit/observability/runner_health/test_runner_monitor_wedge_detection.py
+++ b/tests/unit/observability/runner_health/test_runner_monitor_wedge_detection.py
@@ -1,0 +1,525 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Behavioral tests for runner-monitor.sh silent-wedge + crash-loop detection.
+
+OMN-13109. The legacy monitor only checked "container Up (healthy) + runner
+online", which PASSES a silently-wedged runner (online, registered, but not
+pulling jobs) and a crash-looping runner (Up healthy in the window between
+restart and the next config.sh exit). These tests drive the REAL shell script
+end-to-end against PATH-injected mock binaries (docker / curl / gh / date) and
+assert on the JSON state file the script writes, proving:
+
+  * a wedged fleet (online, busy=0, job queued past threshold) is flagged
+    (``wedge_count >= 1``) where the legacy container+registration logic was
+    clean,
+  * a crash-looping container (RestartCount past threshold OR repeated
+    re-registration log markers) is flagged (``crashloop_count >= 1``),
+  * a genuinely healthy fleet stays clean (``unhealthy_count == 0``),
+  * the script never emits a ``docker restart`` or empty-filter bounce; the
+    documented remediation is force-recreate of NAMED services only.
+
+The script is exercised verbatim — no re-implementation of the detection logic
+in Python — so a regression in the bash predicates fails these tests.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import stat
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parents[4]
+MONITOR_SCRIPT = REPO_ROOT / "docker" / "runners" / "runner-monitor.sh"
+FLEET_CONFIG = REPO_ROOT / "config" / "runner_fleet.yaml"
+
+# Small fleet for fast, deterministic tests. The script reads expected_count
+# from a config file we generate per-test (NOT the live 48-runner config), so
+# the loop is short.
+TEST_FLEET_COUNT = 3
+PREFIX = "omninode-runner"
+
+
+pytestmark = pytest.mark.unit
+
+
+def _require_tools() -> None:
+    for tool in ("bash", "jq"):
+        if shutil.which(tool) is None:
+            pytest.skip(f"{tool} not available; shell detection test requires it")
+
+
+def _write_exec(path: Path, body: str) -> None:
+    path.write_text("#!/usr/bin/env bash\n" + textwrap.dedent(body), encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _write_fleet_config(path: Path) -> None:
+    path.write_text(
+        textwrap.dedent(
+            f"""\
+            version: "1.0"
+            github_org: OmniNode-ai
+            runner_host: 192.168.86.201
+            runner_group: omnibase-ci
+            runner_name_prefix: {PREFIX}
+            expected_count: {TEST_FLEET_COUNT}
+            burst_count: {TEST_FLEET_COUNT}
+            """
+        ),
+        encoding="utf-8",
+    )
+
+
+def _runners_json(*, status: str, busy: bool, count: int) -> str:
+    runners = [
+        {
+            "name": f"{PREFIX}-{i}",
+            "status": status,
+            "busy": busy,
+            "labels": [{"name": "self-hosted"}, {"name": "omnibase-ci"}],
+        }
+        for i in range(1, count + 1)
+    ]
+    return json.dumps({"total_count": count, "runners": runners})
+
+
+def _queued_runs_json(run_id: int | None) -> str:
+    if run_id is None:
+        return json.dumps({"total_count": 0, "workflow_runs": []})
+    return json.dumps({"total_count": 1, "workflow_runs": [{"id": run_id}]})
+
+
+def _queued_jobs_json(*, created_at: str) -> str:
+    return json.dumps(
+        {
+            "total_count": 1,
+            "jobs": [
+                {
+                    "status": "queued",
+                    "labels": ["self-hosted", "omnibase-ci"],
+                    "runner_name": "",
+                    "created_at": created_at,
+                    "started_at": created_at,
+                }
+            ],
+        }
+    )
+
+
+def _make_mock_bin(
+    bindir: Path,
+    *,
+    docker_status: str,
+    docker_restart_count: int,
+    docker_logs: str,
+    runners_json: str,
+    queued_run_id: int | None,
+    queued_job_created_at: str,
+    now_epoch: int,
+    job_created_epoch: int,
+) -> None:
+    """Create mock docker / curl / gh / date executables for one scenario."""
+    bindir.mkdir(parents=True, exist_ok=True)
+
+    # --- docker mock: ps, inspect (.State.OOMKilled, .RestartCount), logs, exec
+    _write_exec(
+        bindir / "docker",
+        f"""\
+        set -euo pipefail
+        cmd="${{1:-}}"
+        case "${{cmd}}" in
+          ps)
+            # Emit one line per test runner with the configured status string.
+            for i in $(seq 1 {TEST_FLEET_COUNT}); do
+              printf '%s\\t%s\\n' "{PREFIX}-${{i}}" "{docker_status}"
+            done
+            ;;
+          inspect)
+            fmt="$*"
+            if [[ "${{fmt}}" == *OOMKilled* ]]; then
+              echo "false"
+            elif [[ "${{fmt}}" == *RestartCount* ]]; then
+              echo "{docker_restart_count}"
+            else
+              echo "false"
+            fi
+            ;;
+          logs)
+            cat <<'LOGS'
+{docker_logs}
+LOGS
+            ;;
+          exec)
+            # `docker exec <name> docker info ...` socket probe — succeed.
+            echo "27.0.0"
+            ;;
+          compose)
+            # Record any compose invocation so the test can assert no unsafe
+            # bounce ever ran (auto-bounce is OFF by default).
+            echo "compose $*" >> "${{MOCK_DOCKER_CALLLOG:-/dev/null}}"
+            ;;
+          restart)
+            # A `docker restart` against the fleet is the forbidden action.
+            echo "restart $*" >> "${{MOCK_DOCKER_CALLLOG:-/dev/null}}"
+            ;;
+          *)
+            : ;;
+        esac
+        """,
+    )
+
+    # --- curl mock: org runners API + per-repo queued runs/jobs API
+    _write_exec(
+        bindir / "curl",
+        f"""\
+        set -euo pipefail
+        url=""
+        for a in "$@"; do url="${{a}}"; done  # last arg is the URL
+        if [[ "${{url}}" == *"/actions/runners?"* ]]; then
+          cat <<'JSON'
+{runners_json}
+JSON
+        elif [[ "${{url}}" == *"/actions/runs?status=queued"* ]]; then
+          cat <<'JSON'
+{_queued_runs_json(queued_run_id)}
+JSON
+        elif [[ "${{url}}" == *"/actions/runs/"*"/jobs"* ]]; then
+          cat <<'JSON'
+{_queued_jobs_json(created_at=queued_job_created_at)}
+JSON
+        elif [[ "${{url}}" == *"slack.com"* ]]; then
+          echo '{{"ok":true}}'
+        else
+          echo ""
+        fi
+        """,
+    )
+
+    # --- gh mock: token mint (only used by auto-bounce, which stays OFF here)
+    _write_exec(
+        bindir / "gh",
+        """\
+        set -euo pipefail
+        echo "mock-registration-token"
+        """,
+    )
+
+    # --- date mock: deterministic clock + GNU-style `-d <iso>` parsing so the
+    # test is portable to BSD date (macOS) while the .201 host uses GNU date.
+    _write_exec(
+        bindir / "date",
+        f"""\
+        set -euo pipefail
+        args="$*"
+        if [[ "${{args}}" == *"-d "* ]]; then
+          # Parsing the queued job's created_at -> fixed epoch.
+          echo "{job_created_epoch}"
+        elif [[ "${{args}}" == *"+%s"* ]]; then
+          echo "{now_epoch}"
+        elif [[ "${{args}}" == *"-Iseconds"* ]]; then
+          echo "2026-06-23T00:00:00+00:00"
+        else
+          # date '+%H:%M:%S' for log lines
+          echo "00:00:00"
+        fi
+        """,
+    )
+
+
+def _run_monitor(
+    tmp_path: Path,
+    bindir: Path,
+    *,
+    extra_env: dict[str, str] | None = None,
+) -> dict[str, object]:
+    """Run the real monitor script with the mock PATH; return parsed state file."""
+    state_file = tmp_path / "runner-monitor-state.json"
+    fleet_config = tmp_path / "runner_fleet.yaml"
+    _write_fleet_config(fleet_config)
+    call_log = tmp_path / "docker-calls.log"
+
+    env = {
+        # Keep jq + bash real; everything else comes from the mock bindir first.
+        "PATH": f"{bindir}:{os.environ.get('PATH', '')}",
+        "HOME": str(tmp_path),
+        "STATE_FILE": str(state_file),
+        "RUNNER_FLEET_CONFIG_PATH": str(fleet_config),
+        "SLACK_BOT_TOKEN": "xoxb-test",
+        "SLACK_CHANNEL_ID": "C-test",
+        "RUNNER_GITHUB_TOKEN": "ghp-test",
+        "MOCK_DOCKER_CALLLOG": str(call_log),
+        # Wedge threshold low enough that the controlled queued-age trips it.
+        "WEDGE_QUEUE_AGE_SECONDS": "600",
+        "WEDGE_WATCH_REPOS": "OmniNode-ai/omnibase_infra",
+        "CRASHLOOP_RESTART_THRESHOLD": "5",
+        "CRASHLOOP_REREGISTER_MARKER_THRESHOLD": "3",
+        # Auto-bounce MUST stay off — these tests prove detection only and must
+        # never mutate anything.
+        "MONITOR_AUTO_BOUNCE": "0",
+    }
+    if extra_env:
+        env.update(extra_env)
+
+    # The script reads STATE_FILE via a hardcoded default; override by editing
+    # the env the script honors. The script defines STATE_FILE internally, so we
+    # pass it through a wrapper that exports our value first.
+    wrapper = tmp_path / "run.sh"
+    wrapper.write_text(
+        textwrap.dedent(
+            f"""\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            # The script hardcodes STATE_FILE; rewrite that one line on the fly
+            # into a temp copy so the test controls the output path.
+            sed 's#^STATE_FILE=.*#STATE_FILE="{state_file}"#' "{MONITOR_SCRIPT}" > "{tmp_path}/monitor.sh"
+            bash "{tmp_path}/monitor.sh"
+            """
+        ),
+        encoding="utf-8",
+    )
+    wrapper.chmod(wrapper.stat().st_mode | stat.S_IEXEC)
+
+    result = subprocess.run(
+        ["bash", str(wrapper)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"monitor exited {result.returncode}\nSTDOUT:\n{result.stdout}\n"
+        f"STDERR:\n{result.stderr}"
+    )
+    assert state_file.exists(), f"state file not written\nSTDOUT:\n{result.stdout}"
+    state: dict[str, object] = json.loads(state_file.read_text(encoding="utf-8"))
+    # Attach the call log so callers can assert on bounce behavior.
+    state["_docker_calls"] = (
+        call_log.read_text(encoding="utf-8") if call_log.exists() else ""
+    )
+    return state
+
+
+def _int(state: dict[str, object], key: str) -> int:
+    """Extract an integer counter from the parsed state file (mypy-friendly)."""
+    value = state[key]
+    assert isinstance(value, int), f"{key} is not an int: {value!r}"
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Scenario fixtures
+# ---------------------------------------------------------------------------
+
+NOW = 1_750_000_000
+
+
+def _scenario_bin(
+    bindir: Path,
+    *,
+    status: str = "online",
+    busy: bool = False,
+    docker_status: str = "Up 6 hours (healthy)",
+    restart_count: int = 0,
+    docker_logs: str = "[entrypoint] Starting runner (attempt 1)",
+    queued: bool = False,
+    queued_age_seconds: int = 0,
+) -> None:
+    queued_run_id = 555 if queued else None
+    job_created_epoch = NOW - queued_age_seconds
+    _make_mock_bin(
+        bindir,
+        docker_status=docker_status,
+        docker_restart_count=restart_count,
+        docker_logs=docker_logs,
+        runners_json=_runners_json(status=status, busy=busy, count=TEST_FLEET_COUNT),
+        queued_run_id=queued_run_id,
+        queued_job_created_at="2026-06-22T00:00:00Z",
+        now_epoch=NOW,
+        job_created_epoch=job_created_epoch,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_healthy_fleet_is_clean(tmp_path: Path) -> None:
+    """All online, no queued work, restart 0 -> nothing flagged."""
+    _require_tools()
+    bindir = tmp_path / "bin"
+    _scenario_bin(bindir, status="online", busy=False, queued=False)
+    state = _run_monitor(tmp_path, bindir)
+
+    assert state["unhealthy_count"] == 0, state
+    assert state["wedge_count"] == 0, state
+    assert state["crashloop_count"] == 0, state
+    assert state["online"] == TEST_FLEET_COUNT, state
+
+
+def test_silent_wedge_is_flagged_where_legacy_logic_passed(tmp_path: Path) -> None:
+    """THE core proof: online + healthy + registered, but idle while a job has
+    been queued past the threshold. Legacy container+registration logic sees
+    only ``status=online`` and passes; the upgraded logic flags the wedge."""
+    _require_tools()
+    bindir = tmp_path / "bin"
+    _scenario_bin(
+        bindir,
+        status="online",  # registration looks healthy — legacy logic's only signal
+        busy=False,  # fleet is idle
+        docker_status="Up 6 hours (healthy)",  # container looks healthy
+        restart_count=0,
+        queued=True,
+        queued_age_seconds=3600,  # job queued an hour, well past 600s threshold
+    )
+    state = _run_monitor(tmp_path, bindir)
+
+    # Legacy-equivalent assertion: container up + online would have been clean.
+    # Upgraded assertion: the wedge is caught.
+    assert _int(state, "wedge_count") >= 1, (
+        "silent wedge (online+idle while job queued) not detected — this is the "
+        f"exact state the legacy monitor missed. State: {state}"
+    )
+    assert _int(state, "unhealthy_count") >= 1, state
+    assert state["busy"] == 0, state
+    assert _int(state, "oldest_queued_job_age_seconds") >= 600, state
+
+
+def test_wedge_not_flagged_when_a_runner_is_busy(tmp_path: Path) -> None:
+    """Jobs queued but a runner IS busy -> work is flowing, not a wedge."""
+    _require_tools()
+    bindir = tmp_path / "bin"
+    _scenario_bin(
+        bindir,
+        status="online",
+        busy=True,  # at least one runner pulling work
+        queued=True,
+        queued_age_seconds=3600,
+    )
+    state = _run_monitor(tmp_path, bindir)
+    assert state["wedge_count"] == 0, (
+        f"busy fleet with queued backlog is draining, not wedged: {state}"
+    )
+
+
+def test_wedge_not_flagged_when_queue_is_young(tmp_path: Path) -> None:
+    """Idle fleet but the queued job is younger than the threshold -> normal
+    scheduling latency, not a wedge."""
+    _require_tools()
+    bindir = tmp_path / "bin"
+    _scenario_bin(
+        bindir,
+        status="online",
+        busy=False,
+        queued=True,
+        queued_age_seconds=60,  # < 600s threshold
+    )
+    state = _run_monitor(tmp_path, bindir)
+    assert state["wedge_count"] == 0, state
+
+
+def test_crashloop_flagged_on_high_restart_count(tmp_path: Path) -> None:
+    """RestartCount past threshold -> crash-loop flagged even though the
+    container momentarily reports Up (healthy)."""
+    _require_tools()
+    bindir = tmp_path / "bin"
+    _scenario_bin(
+        bindir,
+        status="online",
+        busy=False,
+        docker_status="Up 10 seconds (healthy)",
+        restart_count=42,  # > CRASHLOOP_RESTART_THRESHOLD=5
+        queued=False,
+    )
+    state = _run_monitor(tmp_path, bindir)
+    assert _int(state, "crashloop_count") >= 1, (
+        f"climbing RestartCount not detected as crash-loop: {state}"
+    )
+    assert _int(state, "unhealthy_count") >= 1, state
+
+
+def test_crashloop_flagged_on_reregistration_log_markers(tmp_path: Path) -> None:
+    """Repeated re-registration markers in logs -> crash-loop flagged even with
+    a low RestartCount (the config.sh 'already configured' loop)."""
+    _require_tools()
+    bindir = tmp_path / "bin"
+    loop_logs = "\n".join(
+        [
+            "[entrypoint] Registration error detected.",
+            "[entrypoint] Re-registering in 20s (retry 1/3)...",
+            "[entrypoint] Re-registering in 40s (retry 2/3)...",
+            "[entrypoint] Max retries (3) reached. Sleeping 5m before exit 1.",
+        ]
+    )
+    _scenario_bin(
+        bindir,
+        status="online",
+        busy=False,
+        docker_status="Up 30 seconds (healthy)",
+        restart_count=1,  # below the RestartCount threshold on purpose
+        docker_logs=loop_logs,
+        queued=False,
+    )
+    state = _run_monitor(tmp_path, bindir)
+    assert _int(state, "crashloop_count") >= 1, (
+        f"repeated re-registration markers not detected as crash-loop: {state}"
+    )
+
+
+def test_monitor_never_runs_docker_restart_or_empty_bounce(tmp_path: Path) -> None:
+    """Safety invariant: with auto-bounce OFF (default) the monitor must never
+    invoke `docker restart` or `docker compose up` against the fleet — it only
+    DETECTS and renders the recipe into the alert."""
+    _require_tools()
+    bindir = tmp_path / "bin"
+    _scenario_bin(
+        bindir,
+        status="online",
+        busy=False,
+        restart_count=99,  # crash-loop
+        queued=True,
+        queued_age_seconds=3600,  # wedge too
+    )
+    state = _run_monitor(tmp_path, bindir)
+    calls = str(state["_docker_calls"])
+    assert "restart" not in calls, f"forbidden `docker restart` invoked: {calls}"
+    assert "compose" not in calls, (
+        f"auto-bounce ran a compose recreate while MONITOR_AUTO_BOUNCE=0: {calls}"
+    )
+
+
+def test_script_documents_safe_bounce_and_forbids_docker_restart() -> None:
+    """Static guarantee on the script text: the safe-bounce recipe uses
+    force-recreate of NAMED services with a fresh token, and the script never
+    bounces via `docker restart` or an empty service filter."""
+    content = MONITOR_SCRIPT.read_text(encoding="utf-8")
+    assert "--force-recreate" in content
+    assert "registration-token" in content, "fresh-token mint recipe absent"
+    assert "--no-deps" in content, "bounce must scope to named services only"
+    # The recipe and prose must call out the forbidden action explicitly.
+    assert "NEVER 'docker restart'" in content or "NEVER `docker restart`" in content
+    # No actual `docker restart <container>` invocation anywhere in the script.
+    # Every legitimate mention of the string is either a prohibition ("NEVER
+    # ...docker restart...") in a comment or alert banner; none is an executed
+    # command. Assert that there is no line whose first command token sequence
+    # is `docker restart`.
+    invocation_lines = [
+        line
+        for line in content.splitlines()
+        if "docker restart" in line
+        and "NEVER" not in line
+        and "'docker restart'" not in line
+        and "`docker restart`" not in line
+        and not line.lstrip().startswith("#")
+    ]
+    assert not invocation_lines, (
+        "script appears to invoke `docker restart` against the fleet: "
+        f"{invocation_lines}"
+    )


### PR DESCRIPTION
## OMN-13109 — Runner-fleet monitor: silent-wedge + crash-loop detection

Friction ticket OMN-13109: *"26/48 self-hosted runners silently OFFLINE (live Runner.Listener, dropped GitHub long-poll); no auto-recovery fired — monitor is alert-only."*

### Problem
The cron `runner-monitor.sh` (`*/3`, Slack-wired) only checked **container Up (healthy) + runner online** — both of which are TRUE for a silently-wedged runner. A wedged runner has a live `Runner.Listener` and a connected long-poll registration, but is **not pulling queued jobs** (last job days old). The legacy logic passed it. A blanket `docker restart` makes it worse: the entrypoint re-runs `config.sh` → `already configured` → exit → compose `restart: unless-stopped` loop (cached creds empty, baked token expired).

### Detection added (`docker/runners/runner-monitor.sh`)
1. **SILENT-WEDGE** — cross-references the GitHub runner `busy` field against jobs queued for our self-hosted labels (`oldest_queued_job_age_seconds` across the watched repos). `online + busy=0` while a job has been queued past `WEDGE_QUEUE_AGE_SECONDS` (default 600s) ⇒ wedged. `busy` is the discriminator the legacy monitor ignored — `online` proves the long-poll is connected, not that work is flowing.
2. **CRASH-LOOP-ON-RESTART** — `container_is_crashlooping()` flags a climbing `RestartCount` (> `CRASHLOOP_RESTART_THRESHOLD`, default 5) OR repeated entrypoint re-registration markers (`already configured` / `Re-registering` / `Max retries reached`) in the recent `docker logs` tail, even while the container momentarily reports `Up (healthy)`.

Both fire Slack alerts with the special-finding banner and a copy-pasteable **SAFE remediation recipe**: force-recreate of **named services only** with a **freshly minted registration token**, detached, 2-minute hard limit. **NEVER `docker restart`, NEVER an empty service filter.** Auto-bounce is **gated OFF** (`MONITOR_AUTO_BOUNCE=0`) by default — the script stays observe-and-alert. The new state file additionally records `wedge_count`, `crashloop_count`, `online`, `busy`, and `oldest_queued_job_age_seconds`.

### dod_evidence
Contract: `contracts/OMN-13109.yaml`. Behavioral tests (`tests/unit/observability/runner_health/test_runner_monitor_wedge_detection.py`) drive the **real** `runner-monitor.sh` end-to-end against PATH-injected mock `docker`/`curl`/`gh`/`date` and assert on the JSON state file — no Python re-implementation of the detection logic.

```
8 passed in 3.8s
  test_healthy_fleet_is_clean
  test_silent_wedge_is_flagged_where_legacy_logic_passed   <-- core proof
  test_wedge_not_flagged_when_a_runner_is_busy
  test_wedge_not_flagged_when_queue_is_young
  test_crashloop_flagged_on_high_restart_count
  test_crashloop_flagged_on_reregistration_log_markers
  test_monitor_never_runs_docker_restart_or_empty_bounce
  test_script_documents_safe_bounce_and_forbids_docker_restart
```

**Legacy-vs-fix proof:** running the pre-upgrade canonical script against the identical wedge scenario (online, busy=0, job queued 1h) returns `unhealthy_count=0` (CLEAN — misses the wedge); the upgraded script returns `wedge_count=1`.

Full `tests/unit/observability/runner_health/` suite: 88 passed (no regression). shellcheck clean; ruff + mypy clean.

### Live fleet NOT touched
SSH to `.201` was **read-only** (`docker ps`, `docker inspect RestartCount`, read the live script + compose + config). No `docker restart` / `docker compose up` / `--force-recreate` / token-mint was run against the fleet, and the new script was **not** deployed to the live monitor. This is a write + test + PR-only change.

### Follow-up (not in this PR)
The repo's shellcheck pre-commit hook is scoped to `scripts/(deploy-runtime|runtime_build)` and does not cover `docker/runners/runner-monitor.sh`. Widening that scope pulls in pre-existing scripts (red baseline the hook comment explicitly warns against), so it is left as a separate gate-hardening follow-up; this PR's script is verified shellcheck-clean manually.



Evidence-Source: OCC#2973


Evidence-Ticket: OMN-13109
