### PR TITLE
fix(OMN-12409): scan manifest and wire result_applier for all contracts with published_events

### DIFF
--- a/src/omnibase_infra/runtime/service_kernel.py
+++ b/src/omnibase_infra/runtime/service_kernel.py
@@ -2614,6 +2614,9 @@ async def bootstrap() -> int:
                 # from the contract's own discovered contract_path — this resolves the
                 # actual package-installed YAML, not a guessed path.
                 if event_bus is not None:
+                    from omnibase_infra.runtime.auto_wiring.handler_wiring import (
+                        _contract_declares_db_io,
+                    )
                     from omnibase_infra.runtime.event_bus_subcontract_wiring import (
                         load_published_events_map,
                     )
@@ -2625,7 +2628,12 @@ async def bootstrap() -> int:
                         if _contract.name in auto_wiring_result_appliers:
                             # Explicit registration takes precedence.
                             continue
-                        if _contract.event_bus is None:
+                        if (
+                            _contract.event_bus is None
+                            or not _contract.event_bus.publish_topics
+                        ):
+                            continue
+                        if _contract_declares_db_io(_contract):
                             continue
                         _pe_map = load_published_events_map(
                             Path(_contract.contract_path),
@@ -2633,7 +2641,7 @@ async def bootstrap() -> int:
                         )
                         if not _pe_map:
                             continue
-                        _topics = list(_pe_map.values())
+                        _topics = tuple(_contract.event_bus.publish_topics)
                         auto_wiring_result_appliers[_contract.name] = (
                             DispatchResultApplier(
                                 event_bus=event_bus,

--- a/src/omnibase_infra/runtime/service_kernel.py
+++ b/src/omnibase_infra/runtime/service_kernel.py
@@ -2602,6 +2602,55 @@ async def bootstrap() -> int:
                 )
                 auto_wiring_manifest_for_subscriptions = filtered_manifest
 
+                # OMN-12409: Wire result appliers for all manifest contracts that
+                # declare published_events but are not yet in auto_wiring_result_appliers.
+                #
+                # ORCHESTRATOR contracts were already registered above (build_loop,
+                # delegate_skill, registration).  EFFECT/REDUCER/COMPUTE contracts that
+                # return a model destined for a declared topic would have their handler
+                # output silently dropped without an applier.  Scan every contract in the
+                # filtered manifest; for each one with a non-empty published_events map
+                # that has not been explicitly registered, build a DispatchResultApplier
+                # from the contract's own discovered contract_path — this resolves the
+                # actual package-installed YAML, not a guessed path.
+                if event_bus is not None:
+                    from omnibase_infra.runtime.event_bus_subcontract_wiring import (
+                        load_published_events_map,
+                    )
+                    from omnibase_infra.runtime.service_dispatch_result_applier import (
+                        DispatchResultApplier,
+                    )
+
+                    for _contract in filtered_manifest.contracts:
+                        if _contract.name in auto_wiring_result_appliers:
+                            # Explicit registration takes precedence.
+                            continue
+                        if _contract.event_bus is None:
+                            continue
+                        _pe_map = load_published_events_map(
+                            Path(_contract.contract_path),
+                            logger,
+                        )
+                        if not _pe_map:
+                            continue
+                        _topics = list(_pe_map.values())
+                        auto_wiring_result_appliers[_contract.name] = (
+                            DispatchResultApplier(
+                                event_bus=event_bus,
+                                output_topic=_topics[0],
+                                output_topic_map=_pe_map,
+                                allowed_output_topics=_topics,
+                            )
+                        )
+                        logger.info(
+                            "Auto-wiring result applier registered from published_events "
+                            "(contract=%s, node_type=%s, topics=%s, correlation_id=%s)",
+                            _contract.name,
+                            _contract.node_type,
+                            _topics,
+                            correlation_id,
+                        )
+
                 runtime_handler_dependencies = _build_runtime_handler_dependencies(
                     registration_service.postgres_pool,
                     kafka_bootstrap_servers if use_kafka else None,

--- a/tests/unit/runtime/test_effect_result_applier_wiring.py
+++ b/tests/unit/runtime/test_effect_result_applier_wiring.py
@@ -40,7 +40,10 @@ from omnibase_infra.event_bus.event_bus_inmemory import EventBusInmemory
 from omnibase_infra.event_bus.models.model_event_message import ModelEventMessage
 from omnibase_infra.models.dispatch.model_dispatch_result import ModelDispatchResult
 from omnibase_infra.protocols import ProtocolEventBusLike
-from omnibase_infra.runtime.auto_wiring.handler_wiring import wire_from_manifest
+from omnibase_infra.runtime.auto_wiring.handler_wiring import (
+    _contract_declares_db_io,
+    wire_from_manifest,
+)
 from omnibase_infra.runtime.auto_wiring.models import (
     ModelAutoWiringManifest,
     ModelContractVersion,
@@ -290,12 +293,14 @@ def test_manifest_scan_builds_applier_for_effect_contract(tmp_path: Path) -> Non
     for _contract in manifest.contracts:
         if _contract.name in auto_wiring_result_appliers:
             continue
-        if _contract.event_bus is None:
+        if _contract.event_bus is None or not _contract.event_bus.publish_topics:
+            continue
+        if _contract_declares_db_io(_contract):
             continue
         pe_map = load_published_events_map(Path(_contract.contract_path))
         if not pe_map:
             continue
-        topics = list(pe_map.values())
+        topics = tuple(_contract.event_bus.publish_topics)
         auto_wiring_result_appliers[_contract.name] = DispatchResultApplier(
             event_bus=event_bus_mock,
             output_topic=topics[0],
@@ -351,12 +356,14 @@ def test_manifest_scan_skips_already_registered_contracts(tmp_path: Path) -> Non
     for _contract in manifest.contracts:
         if _contract.name in auto_wiring_result_appliers:
             continue  # skip already-registered
-        if _contract.event_bus is None:
+        if _contract.event_bus is None or not _contract.event_bus.publish_topics:
+            continue
+        if _contract_declares_db_io(_contract):
             continue
         pe_map = load_published_events_map(Path(_contract.contract_path))
         if not pe_map:
             continue
-        topics = list(pe_map.values())
+        topics = tuple(_contract.event_bus.publish_topics)
         auto_wiring_result_appliers[_contract.name] = DispatchResultApplier(
             event_bus=AsyncMock(spec=ProtocolEventBusLike),
             output_topic=topics[0],
@@ -373,7 +380,6 @@ def test_manifest_scan_skips_already_registered_contracts(tmp_path: Path) -> Non
 
 
 @pytest.mark.asyncio
-@pytest.mark.integration
 async def test_effect_contract_handler_result_published_via_auto_wiring(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/runtime/test_effect_result_applier_wiring.py
+++ b/tests/unit/runtime/test_effect_result_applier_wiring.py
@@ -39,6 +39,7 @@ from omnibase_infra.enums import EnumDispatchStatus
 from omnibase_infra.event_bus.event_bus_inmemory import EventBusInmemory
 from omnibase_infra.event_bus.models.model_event_message import ModelEventMessage
 from omnibase_infra.models.dispatch.model_dispatch_result import ModelDispatchResult
+from omnibase_infra.protocols import ProtocolEventBusLike
 from omnibase_infra.runtime.auto_wiring.handler_wiring import wire_from_manifest
 from omnibase_infra.runtime.auto_wiring.models import (
     ModelAutoWiringManifest,
@@ -177,7 +178,7 @@ async def test_applier_routes_effect_returned_model_to_correct_topic(
     pe_map = load_published_events_map(contract_path)
     topics = list(pe_map.values())
 
-    event_bus = AsyncMock()
+    event_bus = AsyncMock(spec=ProtocolEventBusLike)
     applier = DispatchResultApplier(
         event_bus=event_bus,
         output_topic=topics[0],
@@ -213,7 +214,7 @@ async def test_applier_routes_alternate_effect_output_to_correct_topic(
     pe_map = load_published_events_map(contract_path)
     topics = list(pe_map.values())
 
-    event_bus = AsyncMock()
+    event_bus = AsyncMock(spec=ProtocolEventBusLike)
     applier = DispatchResultApplier(
         event_bus=event_bus,
         output_topic=topics[0],
@@ -283,7 +284,7 @@ def test_manifest_scan_builds_applier_for_effect_contract(tmp_path: Path) -> Non
     manifest = ModelAutoWiringManifest(contracts=contracts, errors=())
 
     # Kernel logic: scan manifest.contracts for published_events.
-    event_bus_mock = AsyncMock()
+    event_bus_mock = AsyncMock(spec=ProtocolEventBusLike)
     auto_wiring_result_appliers: dict[str, object] = {}
 
     for _contract in manifest.contracts:
@@ -357,7 +358,7 @@ def test_manifest_scan_skips_already_registered_contracts(tmp_path: Path) -> Non
             continue
         topics = list(pe_map.values())
         auto_wiring_result_appliers[_contract.name] = DispatchResultApplier(
-            event_bus=AsyncMock(),
+            event_bus=AsyncMock(spec=ProtocolEventBusLike),
             output_topic=topics[0],
             output_topic_map=pe_map,
             allowed_output_topics=topics,

--- a/tests/unit/runtime/test_effect_result_applier_wiring.py
+++ b/tests/unit/runtime/test_effect_result_applier_wiring.py
@@ -1,0 +1,472 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for OMN-12409: EFFECT node result_applier wiring.
+
+Verifies that the runtime wires a DispatchResultApplier for EFFECT and REDUCER
+contracts that declare published_events, so handler-returned models are
+published to the correct bus topic rather than being silently dropped.
+
+Root cause: the kernel registered result appliers only for a small set of
+hard-coded ORCHESTRATOR contracts.  Any contract that (a) goes through the
+auto-wiring manifest scanner and (b) has published_events but is NOT in the
+hard-coded set had its handler results dropped — the auto-wiring callback's
+``if result_applier is not None and result is not None:`` branch was never taken.
+
+The fix scans the filtered manifest after discovery and pre-registers a
+DispatchResultApplier for every contract that has published_events and is not
+already registered in auto_wiring_result_appliers.  The applier reads topics
+from the contract's own discovered contract_path, not from a guessed path.
+
+Related:
+    - OMN-12409: EFFECT/REDUCER result_applier gap
+    - service_kernel.py auto_wiring_result_appliers discovery block
+    - handler_wiring.py _subscribe_contract_topics
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from pydantic import BaseModel
+
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+from omnibase_infra.enums import EnumDispatchStatus
+from omnibase_infra.event_bus.event_bus_inmemory import EventBusInmemory
+from omnibase_infra.event_bus.models.model_event_message import ModelEventMessage
+from omnibase_infra.models.dispatch.model_dispatch_result import ModelDispatchResult
+from omnibase_infra.runtime.auto_wiring.handler_wiring import wire_from_manifest
+from omnibase_infra.runtime.auto_wiring.models import (
+    ModelAutoWiringManifest,
+    ModelContractVersion,
+    ModelDiscoveredContract,
+    ModelEventBusWiring,
+    ModelHandlerRef,
+    ModelHandlerRouting,
+    ModelHandlerRoutingEntry,
+)
+from omnibase_infra.runtime.event_bus_subcontract_wiring import (
+    load_published_events_map,
+)
+from omnibase_infra.runtime.message_dispatch_engine import MessageDispatchEngine
+from omnibase_infra.runtime.service_dispatch_result_applier import (
+    DispatchResultApplier,
+)
+
+pytestmark = pytest.mark.unit
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_EFFECT_CONTRACT_YAML = """\
+name: node_llm_delegation_call_effect
+node_type: EFFECT_GENERIC
+event_bus:
+  subscribe_topics:
+    - "onex.cmd.omnibase-infra.delegation-call-request.v1"
+  publish_topics:
+    - "onex.evt.omnibase-infra.inference-response.v1"
+    - "onex.evt.omnibase-infra.delegation-all-tiers-failed.v1"
+published_events:
+  - event_type: "InferenceResponse"
+    topic: "onex.evt.omnibase-infra.inference-response.v1"
+  - event_type: "DelegationAllTiersFailed"
+    topic: "onex.evt.omnibase-infra.delegation-all-tiers-failed.v1"
+"""
+
+_REDUCER_CONTRACT_YAML = """\
+name: node_delegation_routing_reducer
+node_type: REDUCER_GENERIC
+event_bus:
+  subscribe_topics:
+    - "onex.cmd.omnibase-infra.delegation-routing-request.v1"
+  publish_topics:
+    - "onex.evt.omnibase-infra.routing-decision.v1"
+published_events:
+  - event_type: "RoutingDecision"
+    topic: "onex.evt.omnibase-infra.routing-decision.v1"
+"""
+
+
+class ModelInferenceResponse(BaseModel):
+    """Stub returned by an EFFECT handler (short-name = InferenceResponse)."""
+
+    correlation_id: str = "c-1"
+
+
+class ModelDelegationAllTiersFailed(BaseModel):
+    """Alternate EFFECT output (short-name = DelegationAllTiersFailed)."""
+
+    correlation_id: str = "c-2"
+
+
+class ModelRoutingDecision(BaseModel):
+    """Stub returned by a REDUCER handler (short-name = RoutingDecision)."""
+
+    correlation_id: str = "c-3"
+
+
+class HandlerEffectReturnsInferenceResponse:
+    """Minimal EFFECT handler that returns ModelInferenceResponse.
+
+    Propagates correlation_id from the received envelope so the integration
+    test can confirm the correct message was delivered.
+    """
+
+    async def handle(self, envelope: object) -> ModelInferenceResponse:
+        corr = getattr(envelope, "correlation_id", None)
+        if corr is not None:
+            return ModelInferenceResponse(correlation_id=str(corr))
+        # envelope.payload might carry correlation_id (raw-dict fallback)
+        payload = getattr(envelope, "payload", None)
+        if isinstance(payload, dict):
+            dict_corr = payload.get("correlation_id")
+            if dict_corr is not None:
+                return ModelInferenceResponse(correlation_id=str(dict_corr))
+        return ModelInferenceResponse(correlation_id="c-1")
+
+
+# ---------------------------------------------------------------------------
+# Unit: load_published_events_map
+# ---------------------------------------------------------------------------
+
+
+def test_load_published_events_map_effect_contract(tmp_path: Path) -> None:
+    """published_events map loads correctly for an EFFECT contract."""
+    contract_path = tmp_path / "contract.yaml"
+    contract_path.write_text(_EFFECT_CONTRACT_YAML, encoding="utf-8")
+
+    pe_map = load_published_events_map(contract_path)
+
+    assert pe_map == {
+        "InferenceResponse": "onex.evt.omnibase-infra.inference-response.v1",
+        "DelegationAllTiersFailed": "onex.evt.omnibase-infra.delegation-all-tiers-failed.v1",
+    }
+
+
+def test_load_published_events_map_reducer_contract(tmp_path: Path) -> None:
+    """published_events map loads correctly for a REDUCER contract."""
+    contract_path = tmp_path / "contract.yaml"
+    contract_path.write_text(_REDUCER_CONTRACT_YAML, encoding="utf-8")
+
+    pe_map = load_published_events_map(contract_path)
+
+    assert pe_map == {
+        "RoutingDecision": "onex.evt.omnibase-infra.routing-decision.v1",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Unit: DispatchResultApplier built from published_events map routes correctly
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_applier_routes_effect_returned_model_to_correct_topic(
+    tmp_path: Path,
+) -> None:
+    """DispatchResultApplier built from published_events map routes InferenceResponse."""
+    contract_path = tmp_path / "contract.yaml"
+    contract_path.write_text(_EFFECT_CONTRACT_YAML, encoding="utf-8")
+
+    pe_map = load_published_events_map(contract_path)
+    topics = list(pe_map.values())
+
+    event_bus = AsyncMock()
+    applier = DispatchResultApplier(
+        event_bus=event_bus,
+        output_topic=topics[0],
+        output_topic_map=pe_map,
+        allowed_output_topics=topics,
+    )
+
+    result = ModelDispatchResult(
+        status=EnumDispatchStatus.SUCCESS,
+        topic="onex.cmd.omnibase-infra.delegation-call-request.v1",
+        started_at=datetime.now(UTC),
+        completed_at=datetime.now(UTC),
+        output_count=1,
+        output_events=[ModelInferenceResponse()],
+        correlation_id=uuid4(),
+    )
+
+    await applier.apply(result, uuid4())
+
+    assert event_bus.publish_envelope.await_count == 1
+    _, kwargs = event_bus.publish_envelope.await_args
+    assert kwargs["topic"] == "onex.evt.omnibase-infra.inference-response.v1"
+
+
+@pytest.mark.asyncio
+async def test_applier_routes_alternate_effect_output_to_correct_topic(
+    tmp_path: Path,
+) -> None:
+    """DispatchResultApplier routes DelegationAllTiersFailed to its own topic."""
+    contract_path = tmp_path / "contract.yaml"
+    contract_path.write_text(_EFFECT_CONTRACT_YAML, encoding="utf-8")
+
+    pe_map = load_published_events_map(contract_path)
+    topics = list(pe_map.values())
+
+    event_bus = AsyncMock()
+    applier = DispatchResultApplier(
+        event_bus=event_bus,
+        output_topic=topics[0],
+        output_topic_map=pe_map,
+        allowed_output_topics=topics,
+    )
+
+    result = ModelDispatchResult(
+        status=EnumDispatchStatus.SUCCESS,
+        topic="onex.cmd.omnibase-infra.delegation-call-request.v1",
+        started_at=datetime.now(UTC),
+        completed_at=datetime.now(UTC),
+        output_count=1,
+        output_events=[ModelDelegationAllTiersFailed()],
+        correlation_id=uuid4(),
+    )
+
+    await applier.apply(result, uuid4())
+
+    assert event_bus.publish_envelope.await_count == 1
+    _, kwargs = event_bus.publish_envelope.await_args
+    assert kwargs["topic"] == "onex.evt.omnibase-infra.delegation-all-tiers-failed.v1"
+
+
+# ---------------------------------------------------------------------------
+# Unit: kernel-level manifest scan (OMN-12409 fix)
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_scan_builds_applier_for_effect_contract(tmp_path: Path) -> None:
+    """Kernel scan builds DispatchResultApplier from published_events for EFFECT.
+
+    Reproduces the kernel logic: iterate filtered_manifest.contracts, skip
+    already-registered entries, load published_events map from contract_path,
+    and register an applier.  Contracts without published_events are skipped.
+    """
+    contract_path = tmp_path / "contract.yaml"
+    contract_path.write_text(_EFFECT_CONTRACT_YAML, encoding="utf-8")
+
+    # Simulate the filtered manifest with one EFFECT contract.
+    from omnibase_infra.runtime.auto_wiring.models import (
+        ModelAutoWiringManifest,
+        ModelContractVersion,
+        ModelDiscoveredContract,
+        ModelEventBusWiring,
+    )
+
+    contracts = (
+        ModelDiscoveredContract(
+            name="node_llm_delegation_call_effect",
+            node_type="EFFECT_GENERIC",
+            contract_version=ModelContractVersion(major=1, minor=0, patch=0),
+            contract_path=contract_path,
+            entry_point_name="node_llm_delegation_call_effect",
+            package_name="omnimarket",
+            event_bus=ModelEventBusWiring(
+                subscribe_topics=(
+                    "onex.cmd.omnibase-infra.delegation-call-request.v1",
+                ),
+                publish_topics=(
+                    "onex.evt.omnibase-infra.inference-response.v1",
+                    "onex.evt.omnibase-infra.delegation-all-tiers-failed.v1",
+                ),
+            ),
+        ),
+    )
+    manifest = ModelAutoWiringManifest(contracts=contracts, errors=())
+
+    # Kernel logic: scan manifest.contracts for published_events.
+    event_bus_mock = AsyncMock()
+    auto_wiring_result_appliers: dict[str, object] = {}
+
+    for _contract in manifest.contracts:
+        if _contract.name in auto_wiring_result_appliers:
+            continue
+        if _contract.event_bus is None:
+            continue
+        pe_map = load_published_events_map(Path(_contract.contract_path))
+        if not pe_map:
+            continue
+        topics = list(pe_map.values())
+        auto_wiring_result_appliers[_contract.name] = DispatchResultApplier(
+            event_bus=event_bus_mock,
+            output_topic=topics[0],
+            output_topic_map=pe_map,
+            allowed_output_topics=topics,
+        )
+
+    assert "node_llm_delegation_call_effect" in auto_wiring_result_appliers
+    applier = auto_wiring_result_appliers["node_llm_delegation_call_effect"]
+    assert isinstance(applier, DispatchResultApplier)
+    assert applier.published_events_map == {
+        "InferenceResponse": "onex.evt.omnibase-infra.inference-response.v1",
+        "DelegationAllTiersFailed": "onex.evt.omnibase-infra.delegation-all-tiers-failed.v1",
+    }
+
+
+def test_manifest_scan_skips_already_registered_contracts(tmp_path: Path) -> None:
+    """Kernel scan does not overwrite explicitly pre-registered appliers."""
+    contract_path = tmp_path / "contract.yaml"
+    contract_path.write_text(_EFFECT_CONTRACT_YAML, encoding="utf-8")
+
+    from omnibase_infra.runtime.auto_wiring.models import (
+        ModelAutoWiringManifest,
+        ModelContractVersion,
+        ModelDiscoveredContract,
+        ModelEventBusWiring,
+    )
+
+    contracts = (
+        ModelDiscoveredContract(
+            name="node_llm_delegation_call_effect",
+            node_type="EFFECT_GENERIC",
+            contract_version=ModelContractVersion(major=1, minor=0, patch=0),
+            contract_path=contract_path,
+            entry_point_name="node_llm_delegation_call_effect",
+            package_name="omnimarket",
+            event_bus=ModelEventBusWiring(
+                subscribe_topics=(
+                    "onex.cmd.omnibase-infra.delegation-call-request.v1",
+                ),
+                publish_topics=("onex.evt.omnibase-infra.inference-response.v1",),
+            ),
+        ),
+    )
+    manifest = ModelAutoWiringManifest(contracts=contracts, errors=())
+
+    # Pre-register a sentinel applier to verify it is NOT overwritten.
+    sentinel = object()
+    auto_wiring_result_appliers: dict[str, object] = {
+        "node_llm_delegation_call_effect": sentinel,
+    }
+
+    for _contract in manifest.contracts:
+        if _contract.name in auto_wiring_result_appliers:
+            continue  # skip already-registered
+        if _contract.event_bus is None:
+            continue
+        pe_map = load_published_events_map(Path(_contract.contract_path))
+        if not pe_map:
+            continue
+        topics = list(pe_map.values())
+        auto_wiring_result_appliers[_contract.name] = DispatchResultApplier(
+            event_bus=AsyncMock(),
+            output_topic=topics[0],
+            output_topic_map=pe_map,
+            allowed_output_topics=topics,
+        )
+
+    assert auto_wiring_result_appliers["node_llm_delegation_call_effect"] is sentinel
+
+
+# ---------------------------------------------------------------------------
+# Integration: wire_from_manifest auto-builds result_applier for EFFECT
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_effect_contract_handler_result_published_via_auto_wiring(
+    tmp_path: Path,
+) -> None:
+    """EFFECT handler's returned model is published when wired via wire_from_manifest.
+
+    This reproduces the OMN-12409 scenario: an EFFECT contract with publish_topics
+    and published_events gets an auto-built DispatchResultApplier in
+    _subscribe_contract_topics, so the handler's returned model is published to
+    the declared topic.
+    """
+    subscribe_topic = "onex.cmd.omnibase-infra.delegation-call-request.v1"
+    publish_topic = "onex.evt.omnibase-infra.inference-response.v1"
+    contract_yaml_path = tmp_path / "contract.yaml"
+    contract_yaml_path.write_text(_EFFECT_CONTRACT_YAML, encoding="utf-8")
+    correlation_id = uuid4()
+
+    contract = ModelDiscoveredContract(
+        name="node_llm_delegation_call_effect",
+        node_type="EFFECT_GENERIC",
+        contract_version=ModelContractVersion(major=1, minor=0, patch=0),
+        contract_path=contract_yaml_path,
+        entry_point_name="node_llm_delegation_call_effect",
+        package_name="omnimarket",
+        terminal_event=publish_topic,
+        event_bus=ModelEventBusWiring(
+            subscribe_topics=(subscribe_topic,),
+            publish_topics=(
+                publish_topic,
+                "onex.evt.omnibase-infra.delegation-all-tiers-failed.v1",
+            ),
+        ),
+        handler_routing=ModelHandlerRouting(
+            routing_strategy="payload_type_match",
+            handlers=(
+                ModelHandlerRoutingEntry(
+                    handler=ModelHandlerRef(
+                        name="HandlerEffectReturnsInferenceResponse",
+                        module=__name__,
+                    ),
+                    event_model=None,
+                ),
+            ),
+        ),
+    )
+
+    bus = EventBusInmemory(environment="test", group="omn-12409-effect-result")
+    await bus.start()
+    try:
+        published_results: asyncio.Queue[ModelInferenceResponse] = asyncio.Queue()
+
+        async def collect_result(message: ModelEventMessage) -> None:
+            envelope = ModelEventEnvelope[ModelInferenceResponse].model_validate_json(
+                message.value
+            )
+            if envelope.correlation_id == correlation_id:
+                await published_results.put(envelope.payload)
+
+        await bus.subscribe(
+            publish_topic,
+            group_id="result-collector",
+            on_message=collect_result,
+        )
+
+        engine = MessageDispatchEngine()
+        with patch(
+            "omnibase_infra.runtime.auto_wiring.handler_wiring._import_handler_class",
+            return_value=HandlerEffectReturnsInferenceResponse,
+        ):
+            await wire_from_manifest(
+                ModelAutoWiringManifest(contracts=(contract,)),
+                engine,
+                event_bus=bus,
+                environment="local",
+            )
+        engine.freeze()
+
+        command = ModelEventEnvelope[object](
+            payload={"status": "ready"},
+            correlation_id=correlation_id,
+            event_type="omnibase-infra.delegation-call-request",
+        )
+        await bus.publish(
+            subscribe_topic,
+            None,
+            command.model_dump_json().encode("utf-8"),
+            None,
+        )
+
+        result = await asyncio.wait_for(published_results.get(), timeout=2)
+
+        # The key assertion: result was published (not silently dropped).
+        # correlation_id propagation depends on the handler implementation;
+        # what matters here is that the EFFECT handler's returned model was
+        # published to the declared publish_topic (not dropped).
+        assert isinstance(result, ModelInferenceResponse)
+    finally:
+        await bus.close()


### PR DESCRIPTION
## OMN-12409 — EFFECT/REDUCER result_applier gap

EFFECT and REDUCER nodes whose handlers return a model destined for a published_events topic had their output silently dropped on the auto-wiring path.

### Root cause

_make_event_bus_callback (handler_wiring.py) only publishes handler results when result_applier is not None. ORCHESTRATOR contracts had appliers explicitly wired in the kernel. EFFECT/REDUCER contracts did not — they relied on the _subscribe_contract_topics auto-build, which resolves the contract_path from the discovered manifest. An earlier attempt to pre-register delegation worker appliers loaded from _get_contracts_dir() — which points at omnibase_infra's own nodes directory, not the omnimarket package install path — so the map came back empty and the applier was never registered.

### Fix

After discovery builds filtered_manifest, scan every contract. For each contract with a non-empty published_events map that is not already in auto_wiring_result_appliers, build a DispatchResultApplier from the contract's own contract_path (the manifest scanner already resolved this to the installed package location). Explicit pre-registrations for ORCHESTRATOR contracts are not overwritten.

This covers all EFFECT, REDUCER, and COMPUTE contracts that declare published_events — not just 3 hard-coded delegation worker names.

### Files changed

- src/omnibase_infra/runtime/service_kernel.py: add manifest scan after filtered_manifest is built; pre-register DispatchResultApplier for each contract with published_events not already in auto_wiring_result_appliers
- tests/unit/runtime/test_effect_result_applier_wiring.py (new): 7 unit+integration tests

### Tests

```
uv run pytest tests/unit/runtime/test_effect_result_applier_wiring.py \
  tests/unit/runtime/auto_wiring/ \
  tests/integration/test_pattern_b_terminal_result_applier.py -q
295 passed in 8.27s

uv run mypy src/ --strict
Success: no issues found in 2490 source files

ruff format + check --fix: All checks passed

pre-commit run (changed files): All hooks Passed
```

New test coverage:
- test_load_published_events_map_effect_contract — EFFECT contract map loads
- test_load_published_events_map_reducer_contract — REDUCER contract map loads
- test_applier_routes_effect_returned_model_to_correct_topic — correct topic routing
- test_applier_routes_alternate_effect_output_to_correct_topic — multi-topic EFFECT output
- test_manifest_scan_builds_applier_for_effect_contract — kernel scan logic
- test_manifest_scan_skips_already_registered_contracts — no overwrite of explicit pre-registrations
- test_effect_contract_handler_result_published_via_auto_wiring — e2e: EFFECT handler result published


Evidence-Source: 8a9b43b558e385078f13b3a65447f46cb74abf4a


Evidence-Ticket: OMN-12409

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed auto-registration of event appliers for contracts that declare published events, ensuring proper event routing to configured topics.

* **Tests**
  * Added comprehensive unit and integration test coverage for event routing and auto-wiring behavior of effect and reducer contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

