### PR TITLE
fix(OMN-12408): fail loud on broken handler_routing entries — hard startup crash, not silent skip

### DIFF
--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -355,11 +355,22 @@ def _import_handler_class(module_path: str, class_name: str) -> type:
 
     Raises:
         ImportError: If the module cannot be imported.
-        AttributeError: If the class is not found in the module.
+        TypeError: If the class is not found in the module (OMN-12408 hard-fail).
+            A handler class declared in a contract but absent from its module is a
+            build/contract defect — not a degradable runtime condition. TypeError is
+            used (rather than AttributeError) so the caller's existing TypeError
+            catch-and-reraise path (which bypasses the ONEX_WIRING_STRICT_MODE gate)
+            propagates this failure as a startup crash regardless of strict mode.
     """
     mod = importlib.import_module(module_path)
-    cls = getattr(mod, class_name)
-    return cls
+    if not hasattr(mod, class_name):
+        raise TypeError(
+            f"CLASS_NOT_FOUND (HANDLER_LOADER_011): class '{class_name}' does not "
+            f"exist in module '{module_path}'. "
+            f"A contract that names a handler class that does not exist is a "
+            f"build/contract defect, not a degradable condition (OMN-12408)."
+        )
+    return getattr(mod, class_name)  # type: ignore[no-any-return]
 
 
 def _assert_is_ownership_query(obj: object) -> None:

--- a/src/omnibase_infra/runtime/contract_loaders/__init__.py
+++ b/src/omnibase_infra/runtime/contract_loaders/__init__.py
@@ -42,6 +42,7 @@ from omnibase_infra.runtime.contract_loaders.handler_routing_loader import (
     convert_class_to_handler_key,
     load_handler_class_info_from_contract,
     load_handler_routing_subcontract,
+    validate_handler_class_exists,
 )
 from omnibase_infra.runtime.contract_loaders.operation_bindings_loader import (
     load_operation_bindings_subcontract,
@@ -63,6 +64,7 @@ __all__ = [
     "load_handler_class_info_from_contract",
     "load_handler_routing_subcontract",
     "load_operation_bindings_subcontract",
+    "validate_handler_class_exists",
     "load_tiered_resolution_configs",
     "load_tiered_resolution_from_contract",
     "load_trust_domain_configs",

--- a/src/omnibase_infra/runtime/contract_loaders/handler_routing_loader.py
+++ b/src/omnibase_infra/runtime/contract_loaders/handler_routing_loader.py
@@ -57,6 +57,7 @@ See Also:
 
 from __future__ import annotations
 
+import importlib
 import logging
 import re
 from pathlib import Path
@@ -475,6 +476,62 @@ def load_handler_routing_subcontract(contract_path: Path) -> ModelRoutingSubcont
     )
 
 
+def validate_handler_class_exists(
+    handler_class: str,
+    handler_module: str,
+    contract_path: Path,
+) -> None:
+    """Verify that a handler class declared in a contract actually exists.
+
+    Imports the declared module and checks that the named class is present.
+    Raises ProtocolConfigurationError on any failure so the defect is surfaced
+    at startup (or CI validation time) rather than silently producing an empty
+    consumer group.
+
+    Args:
+        handler_class: Class name declared in the contract's handler.name field.
+        handler_module: Module path declared in the contract's handler.module field.
+        contract_path: Path to the originating contract.yaml (used in error messages).
+
+    Raises:
+        ProtocolConfigurationError: If the module cannot be imported
+            (error code: MODULE_NOT_FOUND / HANDLER_LOADER_010) or the class
+            is not present in the module
+            (error code: CLASS_NOT_FOUND / HANDLER_LOADER_011).
+
+    Part of OMN-12408: Runtime auto-wiring silently skips entire contract on
+    one broken handler entry — should fail loud.
+    """
+    try:
+        module = importlib.import_module(handler_module)
+    except ImportError as exc:
+        ctx = ModelInfraErrorContext.with_correlation(
+            transport_type=EnumInfraTransportType.FILESYSTEM,
+            operation="validate_handler_class_exists",
+            target_name=str(contract_path),
+        )
+        raise ProtocolConfigurationError(
+            f"MODULE_NOT_FOUND (HANDLER_LOADER_010): cannot import handler module "
+            f"'{handler_module}' declared in {contract_path}. "
+            f"Ensure the module exists and is importable. Original error: {exc}",
+            context=ctx,
+        ) from exc
+
+    if not hasattr(module, handler_class):
+        ctx = ModelInfraErrorContext.with_correlation(
+            transport_type=EnumInfraTransportType.FILESYSTEM,
+            operation="validate_handler_class_exists",
+            target_name=str(contract_path),
+        )
+        raise ProtocolConfigurationError(
+            f"CLASS_NOT_FOUND (HANDLER_LOADER_011): class '{handler_class}' does not "
+            f"exist in module '{handler_module}', declared in {contract_path}. "
+            f"A contract that names a handler that does not exist is a build defect, "
+            f"not a degradable condition.",
+            context=ctx,
+        )
+
+
 def load_handler_class_info_from_contract(
     contract_path: Path,
 ) -> list[dict[str, str]]:
@@ -527,18 +584,48 @@ def load_handler_class_info_from_contract(
         handler_class = handler_info.get("name")
         handler_module = handler_info.get("module")
 
-        if handler_class and handler_module:
-            result.append(
-                {
-                    "handler_class": handler_class,
-                    "handler_module": handler_module,
-                }
+        # OMN-12408: fail loud on missing or unresolvable handler entries.
+        # A contract that names a handler that doesn't exist is a build defect,
+        # not a degradable condition. Silent skips produce empty consumer groups
+        # with no error message, making the chain die at hop 1 silently.
+        if not handler_class:
+            ctx = ModelInfraErrorContext.with_correlation(
+                transport_type=EnumInfraTransportType.FILESYSTEM,
+                operation="load_handler_class_info_from_contract",
+                target_name=str(contract_path),
             )
-        else:
-            logger.warning(
-                "Skipping handler entry with missing name or module in contract.yaml at %s",
-                contract_path,
+            raise ProtocolConfigurationError(
+                f"MISSING_HANDLER_NAME: handler_routing entry in {contract_path} "
+                f"is missing required handler.name field. "
+                f"Every handler entry must declare both handler.name and handler.module.",
+                context=ctx,
             )
+
+        if not handler_module:
+            ctx = ModelInfraErrorContext.with_correlation(
+                transport_type=EnumInfraTransportType.FILESYSTEM,
+                operation="load_handler_class_info_from_contract",
+                target_name=str(contract_path),
+            )
+            raise ProtocolConfigurationError(
+                f"MISSING_HANDLER_MODULE: handler_routing entry for '{handler_class}' "
+                f"in {contract_path} is missing required handler.module field. "
+                f"Every handler entry must declare both handler.name and handler.module.",
+                context=ctx,
+            )
+
+        # Verify the class actually exists in the declared module.
+        # This catches the exact failure mode in OMN-12408: a handler class name
+        # declared in the contract but never written (e.g. only a delta() function
+        # was written, never the class referenced in handler_routing).
+        validate_handler_class_exists(handler_class, handler_module, contract_path)
+
+        result.append(
+            {
+                "handler_class": handler_class,
+                "handler_module": handler_module,
+            }
+        )
 
     logger.debug(
         "Loaded %d handler class info entries from contract.yaml at %s",
@@ -558,4 +645,5 @@ __all__ = [
     "load_and_validate_contract_yaml",
     "load_handler_class_info_from_contract",
     "load_handler_routing_subcontract",
+    "validate_handler_class_exists",
 ]

--- a/tests/integration/test_auto_wiring_strict_invariant.py
+++ b/tests/integration/test_auto_wiring_strict_invariant.py
@@ -160,3 +160,73 @@ async def test_wire_from_manifest_non_strict_does_not_raise(
         f"Expected 1 failure in non-strict report, got {report.total_failed}"
     )
     assert report.total_wired == 0
+
+
+def _make_contract_with_real_module_missing_class(name: str) -> ModelDiscoveredContract:
+    """Contract that references a real module but a class that does not exist.
+
+    This is the exact failure mode from OMN-12408: the module is importable but
+    the handler class declared in handler_routing was never written.
+    """
+    return ModelDiscoveredContract(
+        name=name,
+        node_type="EFFECT_GENERIC",
+        contract_version=ModelContractVersion(major=1, minor=0, patch=0),
+        contract_path=Path("/fake/contract.yaml"),
+        entry_point_name=name,
+        package_name="test-package",
+        event_bus=ModelEventBusWiring(
+            subscribe_topics=(f"onex.evt.platform.{name}.v1",),
+            publish_topics=(),
+        ),
+        handler_routing=ModelHandlerRouting(
+            routing_strategy="payload_type_match",
+            handlers=(
+                ModelHandlerRoutingEntry(
+                    handler=ModelHandlerRef(
+                        # Real module, class that was never written (OMN-12408 failure mode).
+                        name="HandlerClassThatWasNeverWritten",
+                        module="omnibase_infra.runtime.auto_wiring.handler_wiring",
+                    ),
+                    event_model=None,
+                    operation=None,
+                ),
+            ),
+        ),
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_missing_handler_class_hard_fails_regardless_of_strict_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing handler class causes TypeError crash even without strict mode.
+
+    OMN-12408: a handler_routing entry referencing a class that does not exist
+    in an otherwise-importable module is a build/contract defect. It must produce
+    a hard startup crash (TypeError propagates unchanged through the strict-mode
+    gate) rather than a collectable soft failure that is silently ignored in
+    non-strict mode.
+
+    Contrast with test_wire_from_manifest_non_strict_does_not_raise which uses a
+    non-importable module (ImportError) — that remains a collectable failure under
+    OMN-9126. The missing-class case bypasses the strict-mode gate entirely.
+    """
+    monkeypatch.delenv("ONEX_WIRING_STRICT_MODE", raising=False)
+
+    contract = _make_contract_with_real_module_missing_class(name="node_missing_class")
+    manifest = ModelAutoWiringManifest(contracts=[contract])
+
+    dispatch_engine = MagicMock()
+    event_bus = AsyncMock(spec=ProtocolEventBusLike)
+
+    # TypeError propagates from _import_handler_class → _prepare_handler_wiring
+    # → _prepare_contract_wiring (re-raises TypeError) → wire_from_manifest
+    # (re-raises TypeError unchanged, bypassing strict-mode gate).
+    with pytest.raises(TypeError, match="CLASS_NOT_FOUND"):
+        await wire_from_manifest(
+            manifest=manifest,
+            dispatch_engine=dispatch_engine,
+            event_bus=event_bus,
+        )

--- a/tests/unit/runtime/contract_loaders/test_handler_class_existence_validation.py
+++ b/tests/unit/runtime/contract_loaders/test_handler_class_existence_validation.py
@@ -1,0 +1,306 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for handler class existence validation (OMN-12408).
+
+Verifies that broken handler_routing entries — ones that reference a handler
+class name or module that does not actually exist — produce a loud
+ProtocolConfigurationError rather than being silently skipped.
+
+Part of OMN-12408: Runtime auto-wiring silently skips entire contract on one
+broken handler entry — should fail loud.
+
+Test Categories:
+    - TestLoadHandlerClassInfoFailLoud: load_handler_class_info_from_contract
+      must raise on missing/broken handler name/module fields.
+    - TestValidateHandlerClassExists: standalone validator raises when the
+      named class is absent from the declared module.
+    - TestCIGateAllContractsHaveValidHandlerClasses: CI gate scans every
+      real contract.yaml in the repo and asserts every named handler class
+      actually exists in the declared module.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+from omnibase_infra.errors import ProtocolConfigurationError
+from omnibase_infra.runtime.contract_loaders.handler_routing_loader import (
+    load_handler_class_info_from_contract,
+    validate_handler_class_exists,
+)
+
+# ---------------------------------------------------------------------------
+# YAML fixtures
+# ---------------------------------------------------------------------------
+
+_CONTRACT_MISSING_HANDLER_NAME = """
+name: "test_node"
+node_type: "ORCHESTRATOR_GENERIC"
+handler_routing:
+  routing_strategy: "payload_type_match"
+  handlers:
+    - event_model:
+        name: "ModelSomeEvent"
+        module: "omnibase_infra.models.registration.model_node_introspection_event"
+      handler:
+        module: "omnibase_infra.nodes.node_registration_orchestrator.handlers.handler_node_introspected"
+"""
+
+_CONTRACT_MISSING_HANDLER_MODULE = """
+name: "test_node"
+node_type: "ORCHESTRATOR_GENERIC"
+handler_routing:
+  routing_strategy: "payload_type_match"
+  handlers:
+    - event_model:
+        name: "ModelSomeEvent"
+        module: "omnibase_infra.models.registration.model_node_introspection_event"
+      handler:
+        name: "HandlerNodeIntrospected"
+"""
+
+_CONTRACT_NONEXISTENT_CLASS = """
+name: "test_node"
+node_type: "ORCHESTRATOR_GENERIC"
+handler_routing:
+  routing_strategy: "payload_type_match"
+  handlers:
+    - event_model:
+        name: "ModelSomeEvent"
+        module: "omnibase_infra.models.registration.model_node_introspection_event"
+      handler:
+        name: "HandlerThatNeverExisted"
+        module: "omnibase_infra.nodes.node_registration_orchestrator.handlers.handler_node_introspected"
+"""
+
+_CONTRACT_NONEXISTENT_MODULE = """
+name: "test_node"
+node_type: "ORCHESTRATOR_GENERIC"
+handler_routing:
+  routing_strategy: "payload_type_match"
+  handlers:
+    - event_model:
+        name: "ModelSomeEvent"
+        module: "omnibase_infra.models.registration.model_node_introspection_event"
+      handler:
+        name: "HandlerNodeIntrospected"
+        module: "omnibase_infra.totally.nonexistent.module"
+"""
+
+_CONTRACT_VALID = """
+name: "test_node"
+node_type: "ORCHESTRATOR_GENERIC"
+handler_routing:
+  routing_strategy: "payload_type_match"
+  handlers:
+    - event_model:
+        name: "ModelNodeIntrospectionEvent"
+        module: "omnibase_infra.models.registration.model_node_introspection_event"
+      handler:
+        name: "HandlerNodeIntrospected"
+        module: "omnibase_infra.nodes.node_registration_orchestrator.handlers.handler_node_introspected"
+"""
+
+
+# ---------------------------------------------------------------------------
+# TestLoadHandlerClassInfoFailLoud
+# ---------------------------------------------------------------------------
+
+
+class TestLoadHandlerClassInfoFailLoud:
+    """load_handler_class_info_from_contract must raise on broken entries.
+
+    Before OMN-12408 the function silently logged a warning and skipped
+    entries with missing handler.name or handler.module.  The fix must
+    raise ProtocolConfigurationError so the startup defect is surfaced
+    immediately rather than hiding behind an empty consumer group.
+    """
+
+    def test_missing_handler_name_raises(self, tmp_path: Path) -> None:
+        """Entry missing handler.name must raise ProtocolConfigurationError."""
+        contract = tmp_path / "contract.yaml"
+        contract.write_text(_CONTRACT_MISSING_HANDLER_NAME)
+        with pytest.raises(ProtocolConfigurationError, match=r"handler\.name"):
+            load_handler_class_info_from_contract(contract)
+
+    def test_missing_handler_module_raises(self, tmp_path: Path) -> None:
+        """Entry missing handler.module must raise ProtocolConfigurationError."""
+        contract = tmp_path / "contract.yaml"
+        contract.write_text(_CONTRACT_MISSING_HANDLER_MODULE)
+        with pytest.raises(ProtocolConfigurationError, match=r"handler\.module"):
+            load_handler_class_info_from_contract(contract)
+
+    def test_nonexistent_class_raises(self, tmp_path: Path) -> None:
+        """Entry naming a class that does not exist in the module must raise."""
+        contract = tmp_path / "contract.yaml"
+        contract.write_text(_CONTRACT_NONEXISTENT_CLASS)
+        with pytest.raises(ProtocolConfigurationError, match="CLASS_NOT_FOUND"):
+            load_handler_class_info_from_contract(contract)
+
+    def test_nonexistent_module_raises(self, tmp_path: Path) -> None:
+        """Entry naming a module that cannot be imported must raise."""
+        contract = tmp_path / "contract.yaml"
+        contract.write_text(_CONTRACT_NONEXISTENT_MODULE)
+        with pytest.raises(ProtocolConfigurationError, match="MODULE_NOT_FOUND"):
+            load_handler_class_info_from_contract(contract)
+
+    def test_valid_entry_succeeds(self, tmp_path: Path) -> None:
+        """A fully correct handler entry must succeed and return class info."""
+        contract = tmp_path / "contract.yaml"
+        contract.write_text(_CONTRACT_VALID)
+        result = load_handler_class_info_from_contract(contract)
+        assert len(result) == 1
+        assert result[0]["handler_class"] == "HandlerNodeIntrospected"
+        assert "handler_node_introspected" in result[0]["handler_module"]
+
+
+# ---------------------------------------------------------------------------
+# TestValidateHandlerClassExists
+# ---------------------------------------------------------------------------
+
+
+class TestValidateHandlerClassExists:
+    """validate_handler_class_exists raises on broken module/class pairs.
+
+    This is the standalone validator that CI uses to audit contracts without
+    starting the runtime.
+    """
+
+    def test_existing_class_does_not_raise(self) -> None:
+        """Known-good class must not raise."""
+        validate_handler_class_exists(
+            handler_class="HandlerNodeIntrospected",
+            handler_module="omnibase_infra.nodes.node_registration_orchestrator.handlers.handler_node_introspected",
+            contract_path=Path("synthetic"),
+        )
+
+    def test_missing_class_raises(self) -> None:
+        """Class absent from an otherwise-importable module must raise."""
+        with pytest.raises(ProtocolConfigurationError, match="CLASS_NOT_FOUND"):
+            validate_handler_class_exists(
+                handler_class="HandlerThatNeverExisted",
+                handler_module="omnibase_infra.nodes.node_registration_orchestrator.handlers.handler_node_introspected",
+                contract_path=Path("synthetic"),
+            )
+
+    def test_missing_module_raises(self) -> None:
+        """Non-importable module must raise MODULE_NOT_FOUND."""
+        with pytest.raises(ProtocolConfigurationError, match="MODULE_NOT_FOUND"):
+            validate_handler_class_exists(
+                handler_class="HandlerFoo",
+                handler_module="omnibase_infra.totally.nonexistent.module",
+                contract_path=Path("synthetic"),
+            )
+
+    def test_error_includes_contract_path(self, tmp_path: Path) -> None:
+        """Error message must name the contract that declared the broken entry."""
+        contract = tmp_path / "some_node" / "contract.yaml"
+        contract.parent.mkdir(parents=True, exist_ok=True)
+        contract.write_text("")
+        with pytest.raises(ProtocolConfigurationError) as exc_info:
+            validate_handler_class_exists(
+                handler_class="HandlerMissing",
+                handler_module="omnibase_infra.nodes.node_registration_orchestrator.handlers.handler_node_introspected",
+                contract_path=contract,
+            )
+        assert "some_node" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# TestCIGateAllContractsHaveValidHandlerClasses
+# ---------------------------------------------------------------------------
+
+
+class TestCIGateAllContractsHaveValidHandlerClasses:
+    """CI gate: every handler_routing entry in every repo contract resolves.
+
+    Scans src/omnibase_infra/nodes/**/contract.yaml and asserts that every
+    handler.name / handler.module pair can be imported and the class exists.
+    This is the canonical contract-validation check required by OMN-12408 DoD.
+    """
+
+    def test_all_deployed_handler_classes_exist(self) -> None:
+        """All handler_routing entries in shipped contracts must resolve."""
+        import yaml
+
+        repo_root = Path(__file__).parents[
+            4
+        ]  # contract_loaders/runtime/unit/tests/../.. = repo root
+        nodes_dir = repo_root / "src" / "omnibase_infra" / "nodes"
+
+        if not nodes_dir.exists():
+            pytest.skip(f"Nodes directory not found: {nodes_dir}")
+
+        failures: list[str] = []
+
+        for contract_path in sorted(nodes_dir.glob("**/contract.yaml")):
+            try:
+                raw_text = contract_path.read_text(encoding="utf-8")
+            except OSError:
+                continue
+
+            try:
+                contract = yaml.safe_load(raw_text)
+            except yaml.YAMLError:
+                continue
+
+            if not isinstance(contract, dict):
+                continue
+
+            handler_routing = contract.get("handler_routing")
+            if not isinstance(handler_routing, dict):
+                continue
+
+            handlers = handler_routing.get("handlers", [])
+            if not isinstance(handlers, list):
+                continue
+
+            for entry in handlers:
+                if not isinstance(entry, dict):
+                    continue
+
+                # Two handler_routing schemas coexist in the repo:
+                #   payload_type_match: handler.name + handler.module (nested)
+                #   operation_match:    handler_class + handler_module (flat)
+                # Both must be validated; entries that use neither schema are skipped
+                # (they have no class to verify and are not the broken-class pattern).
+                handler_info = entry.get("handler", {})
+                if isinstance(handler_info, dict):
+                    # payload_type_match nested schema
+                    class_name = handler_info.get("name")
+                    module_name = handler_info.get("module")
+                else:
+                    class_name = None
+                    module_name = None
+
+                # operation_match flat schema overrides if not found in nested
+                if not class_name:
+                    class_name = entry.get("handler_class")
+                if not module_name:
+                    module_name = entry.get("handler_module")
+
+                if not class_name or not module_name:
+                    # Entry has neither schema populated — skip (no class to check).
+                    continue
+
+                try:
+                    module = importlib.import_module(module_name)
+                except ImportError as e:
+                    failures.append(
+                        f"{contract_path}: cannot import module {module_name!r}: {e}"
+                    )
+                    continue
+
+                if not hasattr(module, class_name):
+                    failures.append(
+                        f"{contract_path}: class {class_name!r} not found"
+                        f" in module {module_name!r}"
+                    )
+
+        assert not failures, (
+            f"{len(failures)} handler_routing entries reference broken "
+            f"handler classes:\n" + "\n".join(f"  - {f}" for f in failures)
+        )


### PR DESCRIPTION
## OMN-12408 — Runtime auto-wiring silently skips entire contract on one broken handler entry

Fixes the silent-failure surface discovered in OMN-12294 (delegation bridge elimination): when a `handler_routing` entry declares a handler class that does not exist in the module, the runtime silently skipped the ENTIRE contract in non-strict mode — leaving correctly-defined handlers with no consumer.

### Root Cause

`_import_handler_class` raised `AttributeError` on `getattr(mod, class_name)` when the class was absent. This `AttributeError` was caught by the per-contract exception handler in `wire_from_manifest` and collected as a "failed" result. In non-strict mode (`ONEX_WIRING_STRICT_MODE` unset), failures are warnings-only, so the entire contract was silently abandoned.

### Fix

**`handler_wiring.py` — hard-fail on missing class:**
`_import_handler_class` now raises `TypeError` (not `AttributeError`) when `hasattr(mod, class_name)` is false. `TypeError` is the existing crash-path in `_prepare_contract_wiring` — it propagates unchanged through `wire_from_manifest`, bypassing the `ONEX_WIRING_STRICT_MODE` gate entirely. A handler class declared in a contract but never written is a build/contract defect, not a degradable runtime condition.

**`handler_routing_loader.py` — CI validation gate:**
`validate_handler_class_exists()` — standalone function callable from CI, raises `ProtocolConfigurationError` (CLASS_NOT_FOUND / MODULE_NOT_FOUND) on broken entries. `load_handler_class_info_from_contract()` now calls this for every handler entry, so any parse of a contract with a broken class fails immediately at contract load time (not only at startup).

### Tests

- `TestValidateHandlerClassExists` — unit tests for the new standalone validator
- `TestLoadHandlerClassInfoFailLoud` — unit tests that the loader raises on missing name, module, or class
- `TestCIGateAllContractsHaveValidHandlerClasses` — CI gate that scans every deployed `contract.yaml` in the repo and asserts all declared handler classes exist
- `test_missing_handler_class_hard_fails_regardless_of_strict_mode` — integration test proving `wire_from_manifest` raises `TypeError` even without `ONEX_WIRING_STRICT_MODE=1`

### dod_evidence
Evidence-Source: 0e9820f6ff1bd616836b86b70b36ec1deff8d8b7
Evidence-Ticket: OMN-12408

