### PR TITLE
fix(OMN-13546): add handle() dispatch entrypoints to HandlerForwardOutbound + HandlerConsumeInbound

### DIFF
--- a/contracts/OMN-13546.yaml
+++ b/contracts/OMN-13546.yaml
@@ -1,0 +1,43 @@
+# OMN-13546 contract file for omnibase_infra deploy-gate.
+# The canonical ticket contract and PASS receipts live in onex_change_control.
+schema_version: "1.0.0"
+ticket_id: "OMN-13546"
+title: "fix(OMN-13546): add handle() dispatch entrypoints to HandlerForwardOutbound + HandlerConsumeInbound"
+summary: >-
+  HandlerForwardOutbound and HandlerConsumeInbound in node_bus_forwarder_effect implemented domain-named transform methods but not the canonical handle() dispatch entrypoint checked by runtime auto-wiring. The fix adds async handle() methods that return ModelHandlerOutput.for_compute() with transformed gateway envelopes while preserving the existing pure transform methods.
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: "tests"
+    description: "Unit tests cover handle() dispatch entrypoints on both gateway forwarder handlers."
+    command: "uv run pytest tests/unit/nodes/node_bus_forwarder_effect/test_handler_dispatch_entrypoints.py -v"
+  - kind: "tests"
+    description: "Full node_bus_forwarder_effect unit suite remains green."
+    command: "uv run pytest tests/unit/nodes/node_bus_forwarder_effect/ -v"
+  - kind: "ci"
+    description: "Central OCC evidence for OMN-13546 is carried by onex_change_control PR #2996."
+    command: "gh pr view 2996 --repo OmniNode-ai/onex_change_control --json headRefOid"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-dispatch-entrypoint-tests"
+    description: "Focused dispatch-entrypoint tests pass for HandlerForwardOutbound and HandlerConsumeInbound."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/unit/nodes/node_bus_forwarder_effect/test_handler_dispatch_entrypoints.py -v"
+  - id: "dod-forwarder-unit-suite"
+    description: "The full node_bus_forwarder_effect unit suite passes."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/unit/nodes/node_bus_forwarder_effect/ -v"
+  - id: "dod-deploy-validation"
+    description: "Post-merge deploy validation must verify runtime-effects no longer emits missing handle() dispatch errors for the gateway forwarder handlers."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "deploy omninode-runtime-effects after merge, then verify node_bus_forwarder_effect gateway forwarder dispatch does not raise missing handle()/handle_async() ModelOnexError"

--- a/src/omnibase_infra/nodes/node_bus_forwarder_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_bus_forwarder_effect/contract.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 name: "node_bus_forwarder_effect"
 contract_name: "node_bus_forwarder_effect"
@@ -13,13 +13,10 @@ node_version:
   minor: 1
   patch: 0
 description: >
-  Trust-boundary effect node that mirrors contract-declared tenant gateway
-  topics between a local runtime bus and the hosted cloud Kafka edge. The node
-  owns all publishes; handlers only validate and return transformed envelopes.
+  Trust-boundary effect node that mirrors contract-declared tenant gateway topics between a local runtime bus and the hosted cloud Kafka edge. The node owns all publishes; handlers only validate and return transformed envelopes.
 
 runtime_profiles:
   - effects
-
 input_model:
   name: "ModelGatewayEnvelope"
   module: "omnibase_infra.nodes.node_bus_forwarder_effect.models.model_gateway_envelope"
@@ -28,7 +25,6 @@ output_model:
   name: "ModelGatewayEnvelope"
   module: "omnibase_infra.nodes.node_bus_forwarder_effect.models.model_gateway_envelope"
   description: "Validated gateway envelope after prefix add/strip transformation."
-
 config:
   name: "ModelGatewayForwarderConfig"
   module: "omnibase_infra.nodes.node_bus_forwarder_effect.models.model_gateway_forwarder_config"
@@ -61,7 +57,6 @@ config:
       drain_deadline_seconds: 30
     dedupe:
       retention_hours: 24
-
 event_bus:
   subscribe_topics:
     - "onex.cmd.omnibase-infra.delegation-inference-request.v1"
@@ -71,7 +66,6 @@ event_bus:
     - "onex.cmd.omnibase-infra.delegation-inference-request.v1"
     - "onex.evt.omnibase-infra.inference-response.v1"
     - "onex.evt.omnibase-infra.gateway-heartbeat.v1"
-
 handler_routing:
   routing_strategy: "operation_match"
   handlers:
@@ -80,14 +74,13 @@ handler_routing:
         name: "HandlerForwardOutbound"
         module: "omnibase_infra.nodes.node_bus_forwarder_effect.handlers.handler_forward_outbound"
         handler_type: "COMPUTE"
-      description: "Validate local bare topic and add the tenant cloud wire prefix."
+      description: "Canonical handle() dispatch entrypoint validates local bare topic and delegates to the tenant cloud wire-prefix transform."
     - operation: "gateway.consume_inbound"
       handler:
         name: "HandlerConsumeInbound"
         module: "omnibase_infra.nodes.node_bus_forwarder_effect.handlers.handler_consume_inbound"
         handler_type: "COMPUTE"
-      description: "Validate tenant-prefixed cloud topic and strip to a bare local topic."
-
+      description: "Canonical handle() dispatch entrypoint validates tenant-prefixed cloud topic and delegates to the bare local-topic transform."
 capabilities:
   - name: "tenant_prefix_transform"
     description: "Adds and strips tenant wire prefixes with envelope validation."
@@ -95,7 +88,6 @@ capabilities:
     description: "Rejects any canonical topic not declared in mirror topic sets."
   - name: "node_owned_publish"
     description: "Handlers never publish; the effect node owns both bus legs."
-
 metadata:
   description: "Hybrid gateway local runtime bus forwarder"
   author: "OmniNode Team"

--- a/src/omnibase_infra/nodes/node_bus_forwarder_effect/handlers/handler_consume_inbound.py
+++ b/src/omnibase_infra/nodes/node_bus_forwarder_effect/handlers/handler_consume_inbound.py
@@ -4,7 +4,8 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Protocol
+from uuid import UUID
 
 from omnibase_core.models.dispatch.model_handler_output import ModelHandlerOutput
 from omnibase_infra.enums import EnumHandlerType, EnumHandlerTypeCategory
@@ -17,6 +18,12 @@ from omnibase_infra.nodes.node_bus_forwarder_effect.services.service_gateway_top
     prefix_topic,
     strip_topic_prefix,
 )
+
+
+class GatewayDispatchEnvelope(Protocol):
+    envelope_id: UUID
+    correlation_id: UUID | None
+    payload: object
 
 
 class HandlerConsumeInbound:
@@ -35,19 +42,11 @@ class HandlerConsumeInbound:
 
     async def handle(
         self,
-        envelope: Any,
+        envelope: GatewayDispatchEnvelope,
     ) -> ModelHandlerOutput[ModelGatewayEnvelope]:
         """Dispatch entrypoint: extract gateway envelope, apply inbound transform, return compute output."""
-        payload = envelope.payload if hasattr(envelope, "payload") else envelope
-        if isinstance(payload, dict):
-            gateway_envelope = ModelGatewayEnvelope.model_validate(payload)
-        else:
-            gateway_envelope = payload
+        gateway_envelope, envelope_id, correlation_id = _coerce_dispatch_input(envelope)
         transformed = self.consume_inbound(gateway_envelope)
-        envelope_id = getattr(envelope, "envelope_id", gateway_envelope.envelope_id)
-        correlation_id = getattr(
-            envelope, "correlation_id", gateway_envelope.correlation_id
-        )
         return ModelHandlerOutput.for_compute(
             input_envelope_id=envelope_id,
             correlation_id=correlation_id,
@@ -86,3 +85,19 @@ class HandlerConsumeInbound:
                 "HandlerConsumeInbound requires ModelGatewayForwarderConfig"
             )
         return self._config
+
+
+def _coerce_dispatch_input(
+    envelope: GatewayDispatchEnvelope,
+) -> tuple[ModelGatewayEnvelope, UUID, UUID]:
+    payload = envelope.payload
+    gateway_envelope = (
+        payload
+        if isinstance(payload, ModelGatewayEnvelope)
+        else ModelGatewayEnvelope.model_validate(payload)
+    )
+    return (
+        gateway_envelope,
+        envelope.envelope_id,
+        envelope.correlation_id or gateway_envelope.correlation_id,
+    )

--- a/src/omnibase_infra/nodes/node_bus_forwarder_effect/handlers/handler_consume_inbound.py
+++ b/src/omnibase_infra/nodes/node_bus_forwarder_effect/handlers/handler_consume_inbound.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from typing import Protocol
 from uuid import UUID
 
 from omnibase_core.models.dispatch.model_handler_output import ModelHandlerOutput
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
 from omnibase_infra.enums import EnumHandlerType, EnumHandlerTypeCategory
 from omnibase_infra.errors import ProtocolConfigurationError
 from omnibase_infra.nodes.node_bus_forwarder_effect.models import (
@@ -18,12 +18,6 @@ from omnibase_infra.nodes.node_bus_forwarder_effect.services.service_gateway_top
     prefix_topic,
     strip_topic_prefix,
 )
-
-
-class GatewayDispatchEnvelope(Protocol):
-    envelope_id: UUID
-    correlation_id: UUID | None
-    payload: object
 
 
 class HandlerConsumeInbound:
@@ -42,7 +36,7 @@ class HandlerConsumeInbound:
 
     async def handle(
         self,
-        envelope: GatewayDispatchEnvelope,
+        envelope: ModelEventEnvelope[object],
     ) -> ModelHandlerOutput[ModelGatewayEnvelope]:
         """Dispatch entrypoint: extract gateway envelope, apply inbound transform, return compute output."""
         gateway_envelope, envelope_id, correlation_id = _coerce_dispatch_input(envelope)
@@ -88,7 +82,7 @@ class HandlerConsumeInbound:
 
 
 def _coerce_dispatch_input(
-    envelope: GatewayDispatchEnvelope,
+    envelope: ModelEventEnvelope[object],
 ) -> tuple[ModelGatewayEnvelope, UUID, UUID]:
     payload = envelope.payload
     gateway_envelope = (

--- a/src/omnibase_infra/nodes/node_bus_forwarder_effect/handlers/handler_consume_inbound.py
+++ b/src/omnibase_infra/nodes/node_bus_forwarder_effect/handlers/handler_consume_inbound.py
@@ -4,6 +4,9 @@
 
 from __future__ import annotations
 
+from typing import Any
+
+from omnibase_core.models.dispatch.model_handler_output import ModelHandlerOutput
 from omnibase_infra.enums import EnumHandlerType, EnumHandlerTypeCategory
 from omnibase_infra.errors import ProtocolConfigurationError
 from omnibase_infra.nodes.node_bus_forwarder_effect.models import (
@@ -29,6 +32,28 @@ class HandlerConsumeInbound:
     @property
     def handler_category(self) -> EnumHandlerTypeCategory:
         return EnumHandlerTypeCategory.COMPUTE
+
+    async def handle(
+        self,
+        envelope: Any,
+    ) -> ModelHandlerOutput[ModelGatewayEnvelope]:
+        """Dispatch entrypoint: extract gateway envelope, apply inbound transform, return compute output."""
+        payload = envelope.payload if hasattr(envelope, "payload") else envelope
+        if isinstance(payload, dict):
+            gateway_envelope = ModelGatewayEnvelope.model_validate(payload)
+        else:
+            gateway_envelope = payload
+        transformed = self.consume_inbound(gateway_envelope)
+        envelope_id = getattr(envelope, "envelope_id", gateway_envelope.envelope_id)
+        correlation_id = getattr(
+            envelope, "correlation_id", gateway_envelope.correlation_id
+        )
+        return ModelHandlerOutput.for_compute(
+            input_envelope_id=envelope_id,
+            correlation_id=correlation_id,
+            handler_id=type(self).__name__,
+            result=transformed,
+        )
 
     def consume_inbound(self, envelope: ModelGatewayEnvelope) -> ModelGatewayEnvelope:
         """Return an inbound envelope with a validated bare canonical topic."""

--- a/src/omnibase_infra/nodes/node_bus_forwarder_effect/handlers/handler_forward_outbound.py
+++ b/src/omnibase_infra/nodes/node_bus_forwarder_effect/handlers/handler_forward_outbound.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from typing import Protocol
 from uuid import UUID
 
 from omnibase_core.models.dispatch.model_handler_output import ModelHandlerOutput
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
 from omnibase_infra.enums import EnumHandlerType, EnumHandlerTypeCategory
 from omnibase_infra.errors import ProtocolConfigurationError
 from omnibase_infra.nodes.node_bus_forwarder_effect.models import (
@@ -17,12 +17,6 @@ from omnibase_infra.nodes.node_bus_forwarder_effect.models import (
 from omnibase_infra.nodes.node_bus_forwarder_effect.services.service_gateway_topic_transform import (
     prefix_topic,
 )
-
-
-class GatewayDispatchEnvelope(Protocol):
-    envelope_id: UUID
-    correlation_id: UUID | None
-    payload: object
 
 
 class HandlerForwardOutbound:
@@ -41,7 +35,7 @@ class HandlerForwardOutbound:
 
     async def handle(
         self,
-        envelope: GatewayDispatchEnvelope,
+        envelope: ModelEventEnvelope[object],
     ) -> ModelHandlerOutput[ModelGatewayEnvelope]:
         """Dispatch entrypoint: extract gateway envelope, apply outbound transform, return compute output."""
         gateway_envelope, envelope_id, correlation_id = _coerce_dispatch_input(envelope)
@@ -84,7 +78,7 @@ class HandlerForwardOutbound:
 
 
 def _coerce_dispatch_input(
-    envelope: GatewayDispatchEnvelope,
+    envelope: ModelEventEnvelope[object],
 ) -> tuple[ModelGatewayEnvelope, UUID, UUID]:
     payload = envelope.payload
     gateway_envelope = (

--- a/src/omnibase_infra/nodes/node_bus_forwarder_effect/handlers/handler_forward_outbound.py
+++ b/src/omnibase_infra/nodes/node_bus_forwarder_effect/handlers/handler_forward_outbound.py
@@ -4,7 +4,8 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Protocol
+from uuid import UUID
 
 from omnibase_core.models.dispatch.model_handler_output import ModelHandlerOutput
 from omnibase_infra.enums import EnumHandlerType, EnumHandlerTypeCategory
@@ -16,6 +17,12 @@ from omnibase_infra.nodes.node_bus_forwarder_effect.models import (
 from omnibase_infra.nodes.node_bus_forwarder_effect.services.service_gateway_topic_transform import (
     prefix_topic,
 )
+
+
+class GatewayDispatchEnvelope(Protocol):
+    envelope_id: UUID
+    correlation_id: UUID | None
+    payload: object
 
 
 class HandlerForwardOutbound:
@@ -34,19 +41,11 @@ class HandlerForwardOutbound:
 
     async def handle(
         self,
-        envelope: Any,
+        envelope: GatewayDispatchEnvelope,
     ) -> ModelHandlerOutput[ModelGatewayEnvelope]:
         """Dispatch entrypoint: extract gateway envelope, apply outbound transform, return compute output."""
-        payload = envelope.payload if hasattr(envelope, "payload") else envelope
-        if isinstance(payload, dict):
-            gateway_envelope = ModelGatewayEnvelope.model_validate(payload)
-        else:
-            gateway_envelope = payload
+        gateway_envelope, envelope_id, correlation_id = _coerce_dispatch_input(envelope)
         transformed = self.forward_outbound(gateway_envelope)
-        envelope_id = getattr(envelope, "envelope_id", gateway_envelope.envelope_id)
-        correlation_id = getattr(
-            envelope, "correlation_id", gateway_envelope.correlation_id
-        )
         return ModelHandlerOutput.for_compute(
             input_envelope_id=envelope_id,
             correlation_id=correlation_id,
@@ -82,3 +81,19 @@ class HandlerForwardOutbound:
                 "HandlerForwardOutbound requires ModelGatewayForwarderConfig"
             )
         return self._config
+
+
+def _coerce_dispatch_input(
+    envelope: GatewayDispatchEnvelope,
+) -> tuple[ModelGatewayEnvelope, UUID, UUID]:
+    payload = envelope.payload
+    gateway_envelope = (
+        payload
+        if isinstance(payload, ModelGatewayEnvelope)
+        else ModelGatewayEnvelope.model_validate(payload)
+    )
+    return (
+        gateway_envelope,
+        envelope.envelope_id,
+        envelope.correlation_id or gateway_envelope.correlation_id,
+    )

--- a/src/omnibase_infra/nodes/node_bus_forwarder_effect/handlers/handler_forward_outbound.py
+++ b/src/omnibase_infra/nodes/node_bus_forwarder_effect/handlers/handler_forward_outbound.py
@@ -4,6 +4,9 @@
 
 from __future__ import annotations
 
+from typing import Any
+
+from omnibase_core.models.dispatch.model_handler_output import ModelHandlerOutput
 from omnibase_infra.enums import EnumHandlerType, EnumHandlerTypeCategory
 from omnibase_infra.errors import ProtocolConfigurationError
 from omnibase_infra.nodes.node_bus_forwarder_effect.models import (
@@ -28,6 +31,28 @@ class HandlerForwardOutbound:
     @property
     def handler_category(self) -> EnumHandlerTypeCategory:
         return EnumHandlerTypeCategory.COMPUTE
+
+    async def handle(
+        self,
+        envelope: Any,
+    ) -> ModelHandlerOutput[ModelGatewayEnvelope]:
+        """Dispatch entrypoint: extract gateway envelope, apply outbound transform, return compute output."""
+        payload = envelope.payload if hasattr(envelope, "payload") else envelope
+        if isinstance(payload, dict):
+            gateway_envelope = ModelGatewayEnvelope.model_validate(payload)
+        else:
+            gateway_envelope = payload
+        transformed = self.forward_outbound(gateway_envelope)
+        envelope_id = getattr(envelope, "envelope_id", gateway_envelope.envelope_id)
+        correlation_id = getattr(
+            envelope, "correlation_id", gateway_envelope.correlation_id
+        )
+        return ModelHandlerOutput.for_compute(
+            input_envelope_id=envelope_id,
+            correlation_id=correlation_id,
+            handler_id=type(self).__name__,
+            result=transformed,
+        )
 
     def forward_outbound(self, envelope: ModelGatewayEnvelope) -> ModelGatewayEnvelope:
         """Return an outbound envelope with a validated tenant wire topic."""

--- a/tests/unit/contracts/test_protocol_ownership.py
+++ b/tests/unit/contracts/test_protocol_ownership.py
@@ -156,8 +156,6 @@ KNOWN_INFRA_PROTOCOLS: dict[str, str] = {
     "ProtocolLifecycleEventSink": "nodes/node_remote_agent_invoke_effect/services/lifecycle_event_sink.py",
     # [NODE] OMN-12909 gateway forwarder bus adapter surface for local/cloud bus DI.
     "ProtocolGatewayBus": "nodes/node_bus_forwarder_effect/services/service_gateway_forwarder.py",
-    # [NODE] OMN-13546 gateway dispatcher envelope shape used by handle() entrypoint tests.
-    "GatewayDispatchEnvelope": "nodes/node_bus_forwarder_effect/handlers/handler_forward_outbound.py",
     # [NODE] OMN-10392 replay compute narrows the AIOKafkaConsumer surface and
     # Kafka record/key shapes for isolated replay handler tests.
     "ProtocolKafkaMessage": "nodes/node_kafka_replay_compute/protocols/protocol_kafka_message.py",

--- a/tests/unit/contracts/test_protocol_ownership.py
+++ b/tests/unit/contracts/test_protocol_ownership.py
@@ -156,6 +156,8 @@ KNOWN_INFRA_PROTOCOLS: dict[str, str] = {
     "ProtocolLifecycleEventSink": "nodes/node_remote_agent_invoke_effect/services/lifecycle_event_sink.py",
     # [NODE] OMN-12909 gateway forwarder bus adapter surface for local/cloud bus DI.
     "ProtocolGatewayBus": "nodes/node_bus_forwarder_effect/services/service_gateway_forwarder.py",
+    # [NODE] OMN-13546 gateway dispatcher envelope shape used by handle() entrypoint tests.
+    "GatewayDispatchEnvelope": "nodes/node_bus_forwarder_effect/handlers/handler_forward_outbound.py",
     # [NODE] OMN-10392 replay compute narrows the AIOKafkaConsumer surface and
     # Kafka record/key shapes for isolated replay handler tests.
     "ProtocolKafkaMessage": "nodes/node_kafka_replay_compute/protocols/protocol_kafka_message.py",

--- a/tests/unit/nodes/node_bus_forwarder_effect/test_handler_dispatch_entrypoints.py
+++ b/tests/unit/nodes/node_bus_forwarder_effect/test_handler_dispatch_entrypoints.py
@@ -8,12 +8,12 @@ ModelHandlerOutput so the runtime dispatcher does not raise AttributeError on di
 
 from __future__ import annotations
 
-from types import SimpleNamespace
 from uuid import UUID, uuid4
 
 import pytest
 
 from omnibase_core.models.dispatch.model_handler_output import ModelHandlerOutput
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
 from omnibase_infra.nodes.node_bus_forwarder_effect.handlers.handler_consume_inbound import (
     HandlerConsumeInbound,
 )
@@ -90,9 +90,11 @@ def _inbound_gateway_envelope() -> ModelGatewayEnvelope:
     )
 
 
-def _make_dispatch_envelope(gateway_envelope: ModelGatewayEnvelope) -> SimpleNamespace:
-    """Minimal stand-in for ModelEventEnvelope as seen by the auto-wiring engine."""
-    return SimpleNamespace(
+def _make_dispatch_envelope(
+    gateway_envelope: ModelGatewayEnvelope,
+) -> ModelEventEnvelope[object]:
+    """Canonical ModelEventEnvelope as materialized by the auto-wiring engine."""
+    return ModelEventEnvelope[object](
         envelope_id=gateway_envelope.envelope_id,
         correlation_id=gateway_envelope.correlation_id,
         payload=gateway_envelope.model_dump(),

--- a/tests/unit/nodes/node_bus_forwarder_effect/test_handler_dispatch_entrypoints.py
+++ b/tests/unit/nodes/node_bus_forwarder_effect/test_handler_dispatch_entrypoints.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for OMN-13546: HandlerForwardOutbound and HandlerConsumeInbound handle() dispatch entrypoints.
+
+Confirms that both handlers expose callable handle() methods and return a valid
+ModelHandlerOutput so the runtime dispatcher does not raise AttributeError on dispatch.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import UUID, uuid4
+
+import pytest
+
+from omnibase_core.models.dispatch.model_handler_output import ModelHandlerOutput
+from omnibase_infra.nodes.node_bus_forwarder_effect.handlers.handler_consume_inbound import (
+    HandlerConsumeInbound,
+)
+from omnibase_infra.nodes.node_bus_forwarder_effect.handlers.handler_forward_outbound import (
+    HandlerForwardOutbound,
+)
+from omnibase_infra.nodes.node_bus_forwarder_effect.models import (
+    ModelGatewayCloudBusConfig,
+    ModelGatewayEnvelope,
+    ModelGatewayForwarderConfig,
+    ModelGatewayMirrorTopics,
+    ModelGatewayTenantIdentity,
+)
+
+TENANT_ID = UUID("11111111-1111-1111-1111-111111111111")
+BROKER_PROVIDER_ID = UUID("22222222-2222-2222-2222-222222222222")
+PRINCIPAL_ID = UUID("33333333-3333-3333-3333-333333333333")
+INBOUND_TOPIC = "onex.cmd.omnibase-infra.delegation-inference-request.v1"
+OUTBOUND_TOPIC = "onex.evt.omnibase-infra.inference-response.v1"
+WIRE_INBOUND_TOPIC = f"tenant-acme.{INBOUND_TOPIC}"
+WIRE_OUTBOUND_TOPIC = f"tenant-acme.{OUTBOUND_TOPIC}"
+
+
+def _config() -> ModelGatewayForwarderConfig:
+    return ModelGatewayForwarderConfig(
+        tenant_identity=ModelGatewayTenantIdentity(
+            tenant_id=TENANT_ID,
+            tenant_slug="acme",
+            principal_id=PRINCIPAL_ID,
+        ),
+        cloud_bus=ModelGatewayCloudBusConfig(
+            broker_provider_id=BROKER_PROVIDER_ID,
+            cloud_broker_ref="gateway.cloud.kafka.broker",
+            cloud_auth_ref="gateway.cloud.kafka.oauth",
+            acl_provisioner_ref="gateway.cloud.kafka.authorization",
+            client_id_ref="gateway.cloud.kafka.oauth.client_id",
+            client_secret_api_key_ref="infisical://gateway/redpanda-events",
+        ),
+        local_transport_flavor="containerized",
+        mirror_topics=ModelGatewayMirrorTopics(
+            inbound=(INBOUND_TOPIC,),
+            outbound=(OUTBOUND_TOPIC,),
+        ),
+    )
+
+
+def _outbound_gateway_envelope() -> ModelGatewayEnvelope:
+    return ModelGatewayEnvelope(
+        tenant_id=TENANT_ID,
+        tenant_slug="acme",
+        envelope_id=uuid4(),
+        correlation_id=uuid4(),
+        causation_id="cause-1",
+        event_type="LlmInferenceResponse",
+        source_topic=OUTBOUND_TOPIC,
+        wire_topic="",
+        canonical_topic=OUTBOUND_TOPIC,
+        payload={"ok": True},
+    )
+
+
+def _inbound_gateway_envelope() -> ModelGatewayEnvelope:
+    return ModelGatewayEnvelope(
+        tenant_id=TENANT_ID,
+        tenant_slug="acme",
+        envelope_id=uuid4(),
+        correlation_id=uuid4(),
+        causation_id="cause-2",
+        event_type="DelegationInferenceRequest",
+        source_topic=WIRE_INBOUND_TOPIC,
+        wire_topic=WIRE_INBOUND_TOPIC,
+        canonical_topic=INBOUND_TOPIC,
+        payload={"request": True},
+    )
+
+
+def _make_dispatch_envelope(gateway_envelope: ModelGatewayEnvelope) -> SimpleNamespace:
+    """Minimal stand-in for ModelEventEnvelope as seen by the auto-wiring engine."""
+    return SimpleNamespace(
+        envelope_id=gateway_envelope.envelope_id,
+        correlation_id=gateway_envelope.correlation_id,
+        payload=gateway_envelope.model_dump(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_handler_forward_outbound_handle_returns_model_handler_output() -> None:
+    """HandlerForwardOutbound.handle() returns a valid ModelHandlerOutput (no AttributeError)."""
+    handler = HandlerForwardOutbound(config=_config())
+    gw_envelope = _outbound_gateway_envelope()
+    dispatch_envelope = _make_dispatch_envelope(gw_envelope)
+
+    result = await handler.handle(dispatch_envelope)
+
+    assert isinstance(result, ModelHandlerOutput)
+    assert result.result is not None
+    assert isinstance(result.result, ModelGatewayEnvelope)
+    assert result.result.wire_topic == WIRE_OUTBOUND_TOPIC
+    assert result.result.source_topic == OUTBOUND_TOPIC
+    assert result.correlation_id == gw_envelope.correlation_id
+
+
+@pytest.mark.asyncio
+async def test_handler_consume_inbound_handle_returns_model_handler_output() -> None:
+    """HandlerConsumeInbound.handle() returns a valid ModelHandlerOutput (no AttributeError)."""
+    handler = HandlerConsumeInbound(config=_config())
+    gw_envelope = _inbound_gateway_envelope()
+    dispatch_envelope = _make_dispatch_envelope(gw_envelope)
+
+    result = await handler.handle(dispatch_envelope)
+
+    assert isinstance(result, ModelHandlerOutput)
+    assert result.result is not None
+    assert isinstance(result.result, ModelGatewayEnvelope)
+    assert result.result.canonical_topic == INBOUND_TOPIC
+    assert result.result.source_topic == WIRE_INBOUND_TOPIC
+    assert result.correlation_id == gw_envelope.correlation_id
+
+
+def test_handler_forward_outbound_exposes_callable_handle() -> None:
+    """HandlerForwardOutbound.handle is callable (satisfies ProtocolHandleable check)."""
+    handler = HandlerForwardOutbound(config=_config())
+    assert callable(getattr(handler, "handle", None))
+
+
+def test_handler_consume_inbound_exposes_callable_handle() -> None:
+    """HandlerConsumeInbound.handle is callable (satisfies ProtocolHandleable check)."""
+    handler = HandlerConsumeInbound(config=_config())
+    assert callable(getattr(handler, "handle", None))


### PR DESCRIPTION
## OMN-13546 — 144 dispatch errors per dev redeploy from missing handle() on gateway forwarder handlers

HandlerForwardOutbound and HandlerConsumeInbound in node_bus_forwarder_effect were auto-wired to three gateway topics but lacked the canonical handle() method required by the runtime dispatcher (handler_wiring.py ProtocolHandleable check). Every bus message routed to those handlers raised:

  ModelOnexError: Auto-wired handler HandlerForwardOutbound does not expose a callable handle() or handle_async() dispatch entrypoint.

### Root Cause

Both handlers implemented domain-named methods (forward_outbound, consume_inbound) but not the handle() / handle_async() protocol entrypoint checked by _make_dispatch_callback in handler_wiring.py (line ~426-434).

### Fix

Each handler now implements async def handle(envelope) that:
1. Extracts the ModelGatewayEnvelope from the incoming dispatch envelope payload
2. Delegates to the existing forward_outbound() / consume_inbound() transform logic (unchanged)
3. Returns ModelHandlerOutput.for_compute() carrying the transformed gateway envelope

The existing named methods are preserved — they are the unit-testable pure transform surface and are called by ServiceGatewayForwarder directly.

### Tests

tests/unit/nodes/node_bus_forwarder_effect/test_handler_dispatch_entrypoints.py:
- test_handler_forward_outbound_handle_returns_model_handler_output — dispatches via handle(), asserts ModelHandlerOutput with correct wire_topic
- test_handler_consume_inbound_handle_returns_model_handler_output — dispatches via handle(), asserts ModelHandlerOutput with correct canonical_topic
- test_handler_forward_outbound_exposes_callable_handle — satisfies ProtocolHandleable check
- test_handler_consume_inbound_exposes_callable_handle — satisfies ProtocolHandleable check

Local proof: uv run pytest tests/unit/nodes/node_bus_forwarder_effect/ -v -> 21 passed

### OMN-13543 relation

This fix clears the forwarder-crash re-publish loop that feeds the OMN-13543 inference-amplification issue. Once handle() succeeds, the handler returns a compute result rather than raising, which should eliminate the 144 dispatch errors on dev redeploy.

### dod_evidence
Evidence-Source: 66647eee18390ba1131d4a183b947ae5dedda2e0
Evidence-Ticket: OMN-13546





