### PR TITLE
chore(OMN-13547): collapse delegation dispatch to omnimarket engine, fail-closed; delete empty infra shell

### DIFF
--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -628,7 +628,8 @@ RUN set -eu; \
     npm install -g \
         @openai/codex@0.141.0 \
         @openai/codex-linux-x64@npm:@openai/codex@0.141.0-linux-x64 \
-        @anthropic-ai/claude-code@2.1.181; \
+        @anthropic-ai/claude-code@2.1.181 \
+        @anthropic-ai/claude-code-linux-x64@2.1.181; \
     npm cache clean --force
 
 # Build-time assert that both coding-agent CLIs resolved on PATH (mirrors the

--- a/src/omnibase_infra/runtime/service_delegation_dispatch_port.py
+++ b/src/omnibase_infra/runtime/service_delegation_dispatch_port.py
@@ -12,6 +12,7 @@ from uuid import UUID
 from omnibase_core.models.dispatch.model_dispatch_bus_command import (
     ModelDispatchBusCommand,
 )
+from omnibase_infra.errors import InfraUnavailableError
 from omnibase_infra.protocols.protocol_pattern_b_broker_transport import (
     ProtocolPatternBBrokerTransport,
 )
@@ -54,11 +55,23 @@ def _has_delegation_terminal_interface(route: ModelRuntimeLocalIngressRoute) -> 
 def _select_delegation_route(
     routes: Mapping[str, ModelRuntimeLocalIngressRoute],
 ) -> ModelSelectedDelegationRoute:
-    """Select the single route with the delegation terminal interface."""
+    """Resolve the omnimarket-backed delegation route, fail-closed otherwise.
+
+    Delegation has exactly one real engine: the omnimarket
+    ``node_delegation_orchestrator`` (routing -> inference -> quality-gate ->
+    escalation FSM). The empty omnibase_infra shell was deleted in OMN-13547
+    (OMN-12525 — no duplicate orchestrators; nodes live in omnimarket), so this
+    resolver MUST bind the omnimarket package only. If no omnimarket route is
+    present the runtime fails closed with a typed ``InfraUnavailableError`` —
+    there is NO silent fallback to a local/infra route, because resolving a
+    non-omnimarket "delegation" surface would route to a dead handler.
+    """
 
     candidates: dict[str, tuple[str, ModelRuntimeLocalIngressRoute]] = {}
     for alias, route in routes.items():
         if route.contract_name != _DELEGATION_CONTRACT_NAME:
+            continue
+        if route.package_name != _PREFERRED_DELEGATION_PACKAGE:
             continue
         if alias != _DELEGATION_OPERATION_ALIAS and not alias.endswith(
             f".{_DELEGATION_CONTRACT_NAME}.{_DELEGATION_OPERATION_ALIAS}"
@@ -72,29 +85,20 @@ def _select_delegation_route(
         alias, route = next(iter(candidates.values()))
         return ModelSelectedDelegationRoute(alias=alias, route=route)
 
-    preferred = [
-        candidate
-        for candidate in candidates.values()
-        if candidate[1].package_name == _PREFERRED_DELEGATION_PACKAGE
-    ]
-    if len(preferred) == 1:
-        alias, route = preferred[0]
-        return ModelSelectedDelegationRoute(alias=alias, route=route)
-
-    fallback_route = routes.get(_DELEGATION_OPERATION_ALIAS)
-    if (
-        not candidates
-        and fallback_route is not None
-        and _has_delegation_terminal_interface(fallback_route)
-    ):
-        return ModelSelectedDelegationRoute(
-            alias=_DELEGATION_OPERATION_ALIAS,
-            route=fallback_route,
+    if len(candidates) > 1:
+        raise InfraUnavailableError(
+            "Ambiguous delegation dispatch: multiple omnimarket "
+            f"'{_DELEGATION_CONTRACT_NAME}' routes expose the "
+            f"'{_DELEGATION_OPERATION_ALIAS}' interface "
+            f"({sorted(candidates)})"
         )
 
-    raise RuntimeError(
-        "Unable to resolve a single delegation dispatch route with success and "
-        "failure terminal events"
+    raise InfraUnavailableError(
+        "No omnimarket delegation engine resolved: the "
+        f"'{_PREFERRED_DELEGATION_PACKAGE}.{_DELEGATION_CONTRACT_NAME}' route "
+        f"with the '{_DELEGATION_OPERATION_ALIAS}' interface is not installed. "
+        "Delegation fails closed — there is no infra-local fallback engine "
+        "(OMN-13547 / OMN-12525)."
     )
 
 

--- a/tests/scripts/test_check_dockerfile_pins.py
+++ b/tests/scripts/test_check_dockerfile_pins.py
@@ -85,7 +85,8 @@ RUN set -eu; \\
     npm install -g \\
         @openai/codex@0.141.0 \\
         @openai/codex-linux-x64@npm:@openai/codex@0.141.0-linux-x64 \\
-        @anthropic-ai/claude-code@2.1.181; \\
+        @anthropic-ai/claude-code@2.1.181 \\
+        @anthropic-ai/claude-code-linux-x64@2.1.181; \\
     npm cache clean --force
 """,
         encoding="utf-8",
@@ -98,6 +99,7 @@ RUN set -eu; \\
         ("@openai/codex", "0.141.0"),
         ("@openai/codex-linux-x64", "0.141.0-linux-x64"),
         ("@anthropic-ai/claude-code", "2.1.181"),
+        ("@anthropic-ai/claude-code-linux-x64", "2.1.181"),
     }
 
 
@@ -150,6 +152,7 @@ def test_real_dockerfile_pins_codex_and_claude_exactly() -> None:
     assert by_pkg.get("@openai/codex") == "0.141.0"
     assert by_pkg.get("@openai/codex-linux-x64") == "0.141.0-linux-x64"
     assert by_pkg.get("@anthropic-ai/claude-code") == "2.1.181"
+    assert by_pkg.get("@anthropic-ai/claude-code-linux-x64") == "2.1.181"
     # And every npm global install in the real Dockerfile passes the pin gate.
     for entry in entries:
         assert _mod._check_npm_exact_pin(entry) is None

--- a/tests/unit/runtime/test_service_delegation_dispatch_port.py
+++ b/tests/unit/runtime/test_service_delegation_dispatch_port.py
@@ -15,6 +15,7 @@ from omnibase_core.models.dispatch.model_dispatch_bus_command import (
 from omnibase_core.models.dispatch.model_dispatch_bus_terminal_result import (
     ModelDispatchBusTerminalResult,
 )
+from omnibase_infra.errors import InfraUnavailableError
 from omnibase_infra.runtime.runtime_local_ingress import ModelRuntimeLocalIngressRoute
 from omnibase_infra.runtime.service_delegation_dispatch_port import (
     RuntimeDelegationDispatchPort,
@@ -31,6 +32,7 @@ def _route(
     terminal_events: tuple[str, ...],
     command_topic: str | None = None,
     contract_name: str = "node_delegation_orchestrator",
+    contract_path: str | None = None,
 ) -> ModelRuntimeLocalIngressRoute:
     return ModelRuntimeLocalIngressRoute(
         node_name=contract_name,
@@ -43,45 +45,32 @@ def _route(
         event_type=f"{package_name}.delegation-request",
         terminal_event=terminal_events[0] if terminal_events else None,
         terminal_events=terminal_events,
-        contract_path=f"/contracts/{package_name}/node_delegation_orchestrator.yaml",
+        contract_path=(
+            contract_path
+            if contract_path is not None
+            else f"/contracts/{package_name}/node_delegation_orchestrator.yaml"
+        ),
         package_name=package_name,
     )
 
 
-def test_select_delegation_route_prefers_success_failure_terminal_interface() -> None:
+def test_select_delegation_route_binds_omnimarket_only() -> None:
+    """Resolution binds the omnimarket route and ignores the infra surface.
+
+    OMN-13547: the empty infra shell was deleted; resolution must bind
+    omnimarket regardless of whether a (now-impossible) infra route would
+    otherwise satisfy the terminal interface.
+    """
     routes = {
         "omnimarket.node_delegation_orchestrator.delegation.orchestrate": _route(
             package_name="omnimarket",
-            terminal_events=("onex.evt.omnimarket.delegation-completed.v1",),
+            terminal_events=(
+                "onex.evt.omnimarket.delegation-completed.v1",
+                "onex.evt.omnimarket.delegation-failed.v1",
+            ),
         ),
         "omnibase_infra.node_delegation_orchestrator.delegation.orchestrate": _route(
             package_name="omnibase_infra",
-            terminal_events=(
-                "onex.evt.omnibase-infra.delegation-completed.v1",
-                "onex.evt.omnibase-infra.delegation-failed.v1",
-            ),
-        ),
-    }
-
-    selected = _select_delegation_route(routes)
-
-    assert (
-        selected.alias
-        == "omnibase_infra.node_delegation_orchestrator.delegation.orchestrate"
-    )
-
-
-def test_select_delegation_route_prefers_omnimarket_when_contracts_overlap() -> None:
-    routes = {
-        "omnibase_infra.node_delegation_orchestrator.delegation.orchestrate": _route(
-            package_name="omnibase_infra",
-            terminal_events=(
-                "onex.evt.omnibase-infra.delegation-completed.v1",
-                "onex.evt.omnibase-infra.delegation-failed.v1",
-            ),
-        ),
-        "omnimarket.node_delegation_orchestrator.delegation.orchestrate": _route(
-            package_name="omnimarket",
             terminal_events=(
                 "onex.evt.omnibase-infra.delegation-completed.v1",
                 "onex.evt.omnibase-infra.delegation-failed.v1",
@@ -95,9 +84,56 @@ def test_select_delegation_route_prefers_omnimarket_when_contracts_overlap() -> 
         selected.alias
         == "omnimarket.node_delegation_orchestrator.delegation.orchestrate"
     )
+    assert selected.route.package_name == "omnimarket"
 
 
-def test_select_delegation_route_rejects_invalid_public_fallback() -> None:
+def test_select_delegation_route_fails_closed_when_only_infra_route_present() -> None:
+    """No omnimarket engine -> fail closed; never resolve a non-omnimarket route.
+
+    OMN-13547: there is no infra-local fallback. A residual infra-shaped route
+    must NOT be selected; the resolver raises a typed InfraUnavailableError.
+    """
+    routes = {
+        "omnibase_infra.node_delegation_orchestrator.delegation.orchestrate": _route(
+            package_name="omnibase_infra",
+            terminal_events=(
+                "onex.evt.omnibase-infra.delegation-completed.v1",
+                "onex.evt.omnibase-infra.delegation-failed.v1",
+            ),
+        ),
+    }
+
+    with pytest.raises(InfraUnavailableError, match="No omnimarket delegation engine"):
+        _select_delegation_route(routes)
+
+
+def test_select_delegation_route_fails_closed_when_no_route_present() -> None:
+    """Empty route map -> fail closed (omnimarket package absent)."""
+    with pytest.raises(InfraUnavailableError, match="No omnimarket delegation engine"):
+        _select_delegation_route({})
+
+
+def test_select_delegation_route_resolves_single_omnimarket_route() -> None:
+    routes = {
+        "omnimarket.node_delegation_orchestrator.delegation.orchestrate": _route(
+            package_name="omnimarket",
+            terminal_events=(
+                "onex.evt.omnimarket.delegation-completed.v1",
+                "onex.evt.omnimarket.delegation-failed.v1",
+            ),
+        ),
+    }
+
+    selected = _select_delegation_route(routes)
+
+    assert (
+        selected.alias
+        == "omnimarket.node_delegation_orchestrator.delegation.orchestrate"
+    )
+
+
+def test_select_delegation_route_rejects_invalid_omnimarket_route() -> None:
+    """An omnimarket route without a success+failure terminal interface fails closed."""
     routes = {
         "delegation.orchestrate": _route(
             package_name="omnimarket",
@@ -106,11 +142,12 @@ def test_select_delegation_route_rejects_invalid_public_fallback() -> None:
         ),
     }
 
-    with pytest.raises(RuntimeError, match="delegation dispatch route"):
+    with pytest.raises(InfraUnavailableError, match="No omnimarket delegation engine"):
         _select_delegation_route(routes)
 
 
-def test_select_delegation_route_accepts_valid_public_fallback() -> None:
+def test_select_delegation_route_accepts_valid_public_omnimarket_fallback() -> None:
+    """The bare 'delegation.orchestrate' alias resolves only for omnimarket."""
     route = _route(
         package_name="omnimarket",
         terminal_events=(
@@ -123,6 +160,47 @@ def test_select_delegation_route_accepts_valid_public_fallback() -> None:
 
     assert selected.alias == "delegation.orchestrate"
     assert selected.route is route
+
+
+def test_select_delegation_route_rejects_bare_alias_for_non_omnimarket() -> None:
+    """The bare alias must NOT resolve a non-omnimarket (e.g. infra) route."""
+    route = _route(
+        package_name="omnibase_infra",
+        terminal_events=(
+            "onex.evt.omnibase-infra.delegation-completed.v1",
+            "onex.evt.omnibase-infra.delegation-failed.v1",
+        ),
+    )
+
+    with pytest.raises(InfraUnavailableError, match="No omnimarket delegation engine"):
+        _select_delegation_route({"delegation.orchestrate": route})
+
+
+def test_select_delegation_route_ambiguous_omnimarket_routes_fail_closed() -> None:
+    """Two distinct omnimarket routes with the interface -> ambiguous, fail closed."""
+    routes = {
+        "delegation.orchestrate": _route(
+            package_name="omnimarket",
+            terminal_events=(
+                "onex.evt.omnimarket.delegation-completed.v1",
+                "onex.evt.omnimarket.delegation-failed.v1",
+            ),
+            command_topic="onex.cmd.omnimarket.delegation-request.v1",
+            contract_path="/contracts/omnimarket/node_delegation_orchestrator.yaml",
+        ),
+        "omnimarket.node_delegation_orchestrator.delegation.orchestrate": _route(
+            package_name="omnimarket",
+            terminal_events=(
+                "onex.evt.omnimarket.delegation-completed-alt.v1",
+                "onex.evt.omnimarket.delegation-failed-alt.v1",
+            ),
+            command_topic="onex.cmd.omnimarket.delegation-request-alt.v1",
+            contract_path="/contracts/omnimarket/node_delegation_orchestrator_alt.yaml",
+        ),
+    }
+
+    with pytest.raises(InfraUnavailableError, match="Ambiguous delegation dispatch"):
+        _select_delegation_route(routes)
 
 
 async def _dispatch_with_fake_broker(


### PR DESCRIPTION
## OMN-13547 — Delete empty infra delegation shell + collapse delegation dispatch to the omnimarket engine

Delegation has exactly one real engine: the omnimarket `node_delegation_orchestrator` (routing → inference → quality-gate → escalation FSM), fronted by the thin `node_delegate_skill_orchestrator` consumer. The empty `omnibase_infra/src/omnibase_infra/nodes/node_delegation_orchestrator/` shell (handlers/models/dispatchers — 0 tracked files, created 2026-06-18) was dead: the runtime already binds omnimarket (`service_kernel.py` imports `omnimarket.nodes.node_delegation_orchestrator.plugin`), and `service_delegation_dispatch_port.py` already prefers `_PREFERRED_DELEGATION_PACKAGE="omnimarket"`.

Per OMN-12525 (canonical architecture — three primitives, no duplicate orchestrators; nodes live in omnimarket).

### What changed

**Shell removal.** The empty shell was never committed to `origin/dev` — it existed only as an untracked artifact in the canonical clone (confirmed: `git ls-tree -r origin/dev` has no `src/omnibase_infra/nodes/node_delegation_orchestrator`). There was nothing to `git rm`; the untracked directory was removed from the canonical clone. No tracked file deletion appears in this diff because the shell was never tracked.

**`service_delegation_dispatch_port.py` — fail-closed on omnimarket.** `_select_delegation_route` is hardened so delegation resolves the **omnimarket package only** and fails closed otherwise:

- Candidates are filtered to `package_name == "omnimarket"` up front. A non-omnimarket route (e.g. a residual infra surface, or a route reached via the bare `delegation.orchestrate` public alias) can **never** be selected.
- Removed the any-package single-candidate branch and the any-package bare-alias `fallback_route` branch that could otherwise have resolved a non-omnimarket / deleted-shell route.
- When no omnimarket delegation route is installed, the resolver raises a typed `InfraUnavailableError` (`SERVICE_UNAVAILABLE`) — **no silent fallback** to a local/infra engine. Ambiguous omnimarket routes also fail closed with a typed error.

### Verification

- `_select_delegation_route` unit tests rewritten/extended to assert fail-closed semantics: omnimarket-only binding; infra-only route → `InfraUnavailableError`; empty route map → `InfraUnavailableError`; bare alias accepted **only** for omnimarket and rejected for non-omnimarket; ambiguous omnimarket routes → typed error.
- `uv run ruff format src/ tests/` — clean.
- `uv run ruff check --fix src/ tests/` — All checks passed.
- `uv run mypy src/ --strict` — Success: no issues found in 2490 source files.
- `uv run pytest tests/unit/runtime/ -n auto` — 4845 passed, 5 skipped (full runtime blast radius).
- `uv run pytest tests/unit/runtime/test_service_delegation_dispatch_port.py tests/unit/runtime/test_runtime_local_ingress.py` — 36 passed.
- `uv run pytest tests/ci/test_handler_architecture_invariants.py tests/unit/nodes/node_architecture_validator/` — 255 passed.
- `pre-commit run --files <changed>` — exit 0 (all hooks Passed, incl. ruff + mypy hooks, architecture validation, SPDX, AI-slop, topic naming).
- Repo-wide grep confirms **no remaining `omnibase_infra.nodes.node_delegation_orchestrator` import/reference**; only the omnimarket import in `service_kernel.py` and the `_DELEGATION_CONTRACT_NAME` contract-name string remain (both correct). `service_kernel.py` import still resolves (`dispatch_port OK`).

### Live routing re-proof — owed (deferred)

The dev lane (`omninode-runtime`, healthy) was reachable, but this change is **not deployed** to the running container, so a synthetic publish on the live lane cannot prove the post-change binary — only the pre-change image. Observed live state: the omnimarket delegation FSM consumer groups are all `Stable` on the dev lane (routing/quality-gate/escalation/feedback reducers + `node_delegate_skill_orchestrator` on `delegate-skill.v1`), and a `delegation_events` row for `glm-5.2` landed at 2026-06-23 22:30 — confirming the omnimarket engine routes today. A bare publish to `onex.cmd.omnibase-infra.delegation-request.v1` DLQ'd on the deployed image (no orchestrator dispatcher for that entry on the running build — a pre-existing dev deploy-state gap, unrelated to this resolver change; the working front-door is `delegate-skill.v1`).

Gate for this PR: the resolver unit tests + full runtime suite green. The live FSM re-proof (fresh `delegate-skill.v1` publish → `delegation_events` row, verifier ≠ runner) is **owed post-deploy** of this change to the dev lane.

### dod_evidence
Evidence-Source: 552200ce4ac3dae5ac38d2fe1adf17adc7b8a7ac
Evidence-Ticket: OMN-13547

Related: OMN-12525 (canonical architecture — 3 primitives, no duplicate orchestrators), project node-consolidation-to-omnimarket.




<!-- ci-refresh OMN-13547 -->

