### PR TITLE
fix(OMN-13549): de-flake sub-ms cache-timing assertion blocking the infra merge queue

### DIFF
--- a/tests/integration/mixins/test_mixin_node_introspection_contract_integration.py
+++ b/tests/integration/mixins/test_mixin_node_introspection_contract_integration.py
@@ -909,29 +909,20 @@ class TestContractIntegrationPerformance:
         assert metrics2 is not None
         assert metrics2.cache_hit is True
 
-        # Cache hit performance assertion:
-        # A cache hit should be faster than a cache miss because it skips the
-        # expensive reflection operations (inspect.getmembers, signature analysis).
+        # Cache-hit metrics assertion (OMN-13549):
+        # Previously this asserted a cache-hit-vs-miss *wall-clock* comparison.
+        # At the resolution involved (sub-millisecond — e.g. miss 0.243ms vs
+        # hit 1.335ms) the comparison measured scheduler/JIT/GC noise, not the
+        # cache effect, so it flaked intermittently in CI and blocked the
+        # required merge-queue gate.
         #
-        # However, in CI environments with variable load, timing can be noisy.
-        # We use a robust comparison that passes if EITHER:
-        # 1. Cache hit is faster than cache miss (expected behavior), OR
-        # 2. Both are very fast (< 1ms), meaning timing noise dominates
-        #
-        # This avoids flakiness while still catching regressions where cache
-        # hits become slower than cache misses (which would indicate a bug).
-        cache_hit_faster = (
-            metrics2.total_introspection_ms <= metrics1.total_introspection_ms
-        )
-        both_very_fast = (
-            metrics1.total_introspection_ms < 1.0
-            and metrics2.total_introspection_ms < 1.0
-        )
-        assert cache_hit_faster or both_very_fast, (
-            f"Cache hit should be faster than cache miss. "
-            f"Cache miss: {metrics1.total_introspection_ms:.3f}ms, "
-            f"Cache hit: {metrics2.total_introspection_ms:.3f}ms"
-        )
+        # The cache-hit behavior is already proven deterministically by the
+        # `cache_hit is True` flag above (the cached path returns without
+        # re-introspecting). Here we assert only that timing metrics are
+        # *present and recorded* — a non-negative float — never a sub-ms
+        # relative wall-clock comparison.
+        assert isinstance(metrics2.total_introspection_ms, float)
+        assert metrics2.total_introspection_ms >= 0.0
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

De-flakes `tests/integration/mixins/test_mixin_node_introspection_contract_integration.py::TestContractIntegrationPerformance::test_performance_metrics_available_after_introspection`, a recurring merge-queue-blocking flake (OMN-13549).

The test asserted a cache-hit-vs-miss **sub-millisecond wall-clock** comparison (observed miss 0.243ms vs hit 1.335ms). At that resolution the comparison measures scheduler/JIT/GC noise, not the cache effect, so it passed locally and on retry but flaked intermittently in CI — taking down a required `Tests (Split N/15)` → `CI Tests Gate` and blocking merge-queue admission for every infra PR. Confirmed flaking on #2088 (Split 4/15) and #2089 (Split 2/15) in one night.

## Fix

Removed the relative wall-clock comparison (`cache_hit_faster` / `both_very_fast`). The required path now asserts only that the timing metric is **present and recorded** — a non-negative float — never a sub-ms relative comparison. The cache-hit behavior itself stays fully proven by the deterministic `metrics2.cache_hit is True` assertion above it (the cached path returns without re-introspecting).

Test-only change; no source, runtime, or deploy impact.

## Local evidence

- Target test 20×, deterministic order (`-p no:randomly`): **20/20 passed**.
- Full test file: **20/20 passed**.
- `ruff format` + `ruff check`: clean.
- `pre-commit run --files <test>`: all hooks pass.

## DoD

The test no longer asserts sub-millisecond relative timing in the required test path; runs deterministically 20× locally; will no longer appear in merge-queue flake retries.

Evidence-Source: 560d6973207faddf761cac7fcd11035b5bf37c1f
Evidence-Ticket: OMN-13549

OCC evidence PR: OmniNode-ai/onex_change_control#3010
