### PR TITLE
fix(OMN-13548): route projection-handler errors to contract DLQ in handler_wiring (D-03)

### DIFF
--- a/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
+++ b/src/omnibase_infra/runtime/auto_wiring/handler_wiring.py
@@ -1109,6 +1109,35 @@ def _read_db_io_tables(contract_path: Path) -> list[dict[str, str]]:
     return list(db_io.get("db_tables") or [])
 
 
+def _read_dlq_topics(contract_path: Path) -> list[str]:
+    """Read ``event_bus.dlq_topics`` from a contract YAML. Returns [] if absent.
+
+    OMN-13548 (D-03): projection handlers declare the DLQ destination for
+    malformed inbound events under ``event_bus.dlq_topics`` (the same field the
+    omnimarket projection runners read). The typed ``ModelEventBusSubcontract``
+    does not carry this field, so the wiring reads it from the raw contract YAML
+    exactly as ``_read_db_io_tables`` reads ``db_io.db_tables``. The DLQ topic is
+    therefore resolved from the contract — never hardcoded in this module.
+
+    Raises on YAML parse / file I/O failures so a broken contract is surfaced
+    rather than silently degrading to a no-DLQ projection wiring.
+    """
+    try:
+        # Why: Optional integration dependency is validated at runtime but ships incomplete typing.
+        import yaml  # type: ignore[import-untyped]
+
+        with open(contract_path) as f:
+            raw = yaml.safe_load(f)
+    except FileNotFoundError:
+        return []
+    if not isinstance(raw, dict):
+        return []
+    event_bus = raw.get("event_bus") or {}
+    if not isinstance(event_bus, dict):
+        return []
+    return [str(t) for t in (event_bus.get("dlq_topics") or [])]
+
+
 def _contract_declares_db_io(contract: ModelDiscoveredContract) -> bool:
     return bool(_read_db_io_tables(contract.contract_path))
 
@@ -1275,22 +1304,154 @@ def _extract_rows_upserted(result: object) -> int:
     return 0
 
 
+async def _route_projection_error_to_dlq(
+    event_bus: object | None,
+    dlq_topics: list[str],
+    envelope: object,
+    handler_name: str,
+    failure_reason: str,
+) -> bool:
+    """Publish a malformed/erroring projection event to its contract DLQ topic.
+
+    OMN-13548 (D-03): when a projection handler raises (most commonly a
+    ``ValidationError`` because the inbound event is missing a required field),
+    the wiring previously logged at ERROR and dropped the message — no DLQ row,
+    no durable trace. This routes the offending raw envelope to the
+    contract-declared DLQ topic (``event_bus.dlq_topics[0]``) so the dropped
+    event is recoverable on the bus. The DLQ envelope carries the offending
+    payload, the failure reason, the handler name, and the correlation_id
+    (hoisted to the top level so the failure is recoverable by correlation even
+    when the payload itself is unparseable).
+
+    Generic for ALL projection handlers, not delegation-only. Best-effort:
+    returns ``True`` when the DLQ envelope was published, ``False`` when no DLQ
+    topic is declared, no publishable event bus is available, or the publish
+    itself fails (each logged at ERROR). A DLQ publish failure never propagates,
+    so it cannot wedge the consumer.
+    """
+    import json
+    from datetime import UTC, datetime
+
+    if not dlq_topics:
+        logger.error(
+            "Projection handler %s dropped a malformed/erroring event with NO DLQ "
+            "topic declared in contract.event_bus.dlq_topics: %s",
+            handler_name,
+            failure_reason,
+        )
+        return False
+    if event_bus is None or not hasattr(event_bus, "publish"):
+        logger.error(
+            "Projection handler %s would route malformed/erroring event to DLQ %s "
+            "but no publishable event bus is bound: %s",
+            handler_name,
+            dlq_topics[0],
+            failure_reason,
+        )
+        return False
+
+    dlq_topic = dlq_topics[0]
+    payload = _extract_dispatch_payload(envelope)
+    correlation = _extract_dispatch_correlation_id(envelope, payload)
+    correlation_id = str(correlation) if correlation is not None else ""
+    original_message: object
+    model_dump = getattr(payload, "model_dump", None)
+    if isinstance(payload, Mapping):
+        original_message = dict(payload)
+    elif callable(model_dump):
+        original_message = model_dump(mode="json")
+    else:
+        original_message = {"raw": str(payload)}
+    dlq_envelope = {
+        "original_message": original_message,
+        "failure_reason": failure_reason,
+        "correlation_id": correlation_id,
+        "retry_count": 0,
+        "failed_at": datetime.now(UTC).isoformat(),
+        "handler": handler_name,
+    }
+    raw = json.dumps(dlq_envelope, default=str).encode("utf-8")
+    publish = getattr(event_bus, "publish", None)
+    if not callable(publish):
+        logger.error(
+            "Projection handler %s would route malformed/erroring event to DLQ %s "
+            "but the bound event bus publish attribute is not callable: %s",
+            handler_name,
+            dlq_topic,
+            failure_reason,
+        )
+        return False
+    try:
+        await publish(dlq_topic, None, raw)
+    except Exception as exc:  # noqa: BLE001 — DLQ publish is best-effort; never wedge the consumer
+        logger.error(
+            "Projection handler %s failed to route malformed/erroring event to DLQ %s "
+            "(correlation_id=%s): %s",
+            handler_name,
+            dlq_topic,
+            correlation_id,
+            _sanitize_exc(exc),
+        )
+        return False
+    logger.warning(
+        "Projection handler %s routed malformed/erroring event to DLQ %s "
+        "(correlation_id=%s): %s",
+        handler_name,
+        dlq_topic,
+        correlation_id,
+        failure_reason,
+    )
+    return True
+
+
+@dataclass(
+    frozen=True
+)  # internal-dataclass-ok: wiring-internal sink bundle; event_bus is a non-serializable publishable object
+class ProjectionDispatchSinks:
+    """Bus-side output sinks for a projection dispatch callback.
+
+    Bundles the optional bus, terminal-event topic, and DLQ topics so the
+    callback factory stays within the parameter-count budget while each sink
+    remains an explicitly named, typed field. A frozen dataclass (not a Pydantic
+    model) keeps this wiring-internal value object out of the model layer:
+    ``event_bus`` is an arbitrary publishable object (in-memory bus, Kafka
+    wiring, or a test double), so no schema validation is wanted here.
+    """
+
+    event_bus: object | None = None
+    terminal_event: str | None = None
+    dlq_topics: tuple[str, ...] = ()
+
+
 def _make_projection_dispatch_callback(
     handler_instance: object,
     db_tables: list[dict[str, str]],
     subscribe_topics: tuple[str, ...],
-    event_bus: object | None = None,
-    terminal_event: str | None = None,
+    sinks: ProjectionDispatchSinks | None = None,
 ) -> DispatcherFunc:
     """Create a dispatch callback for projection handlers (db_io.db_tables declared).
 
     Builds a synchronous psycopg2 DatabaseAdapter per call and injects it into
     input_data alongside _event_type derived from the topic name.
 
-    When event_bus and terminal_event are provided, emits a terminal event
-    envelope to terminal_event after each successful projection so downstream
-    Pattern-B consumers and golden-chain tests can observe completion.
+    ``sinks`` carries the bus-side outputs. When ``sinks.event_bus`` and
+    ``sinks.terminal_event`` are set, a terminal event envelope is emitted to
+    that topic after each successful projection so downstream Pattern-B
+    consumers and golden-chain tests can observe completion.
+
+    OMN-13548 (D-03): when ``sinks.dlq_topics`` is supplied (resolved from the
+    contract's ``event_bus.dlq_topics``) and the projection handler raises, the
+    offending raw envelope is routed to the DLQ topic instead of being logged +
+    dropped silently. This is the robust layer for the fail-loud/observability
+    guarantee: a malformed inbound event whose ``ValidationError`` escapes the
+    handler is now durably captured on the bus on the REAL dispatch path, not
+    only when a handler happens to catch it internally.
     """
+    sinks = sinks or ProjectionDispatchSinks()
+    event_bus = sinks.event_bus
+    terminal_event = sinks.terminal_event
+    dlq_topics = list(sinks.dlq_topics)
+    handler_name = type(handler_instance).__name__
     database = (
         db_tables[0].get("database", "omnidash_analytics")
         if db_tables
@@ -1388,17 +1549,38 @@ def _make_projection_dispatch_callback(
             logger.error(
                 "Projection handler TypeError (likely missing _db or _event_type): "
                 "handler=%s topic=%s error_type=%s",
-                type(handler_instance).__name__,
+                handler_name,
                 _extract_projection_topic(envelope) or "unknown",
                 type(exc).__name__,
+            )
+            # OMN-13548 (D-03): route the offending event to the contract DLQ
+            # instead of dropping it silently.
+            await _route_projection_error_to_dlq(
+                event_bus,
+                dlq_topics,
+                envelope,
+                handler_name,
+                f"{type(exc).__name__}: {_sanitize_exc(exc)}",
             )
         except Exception as exc:  # noqa: BLE001
             logger.error(
                 "Projection handler error: handler=%s topic=%s error_type=%s error=%s",
-                type(handler_instance).__name__,
+                handler_name,
                 _extract_projection_topic(envelope) or "unknown",
                 type(exc).__name__,
                 exc,
+            )
+            # OMN-13548 (D-03): a ValidationError (e.g. a malformed delegation
+            # event missing a required field) raised by the projection handler
+            # on the REAL dispatch path lands here. Route the raw envelope to the
+            # contract-declared DLQ topic so the dropped event is durably
+            # recoverable on the bus rather than vanishing after this log line.
+            await _route_projection_error_to_dlq(
+                event_bus,
+                dlq_topics,
+                envelope,
+                handler_name,
+                f"{type(exc).__name__}: {_sanitize_exc(exc)}",
             )
 
         if projected and event_bus is not None and terminal_event is not None:
@@ -3367,18 +3549,28 @@ def _prepare_handler_wiring(
             and contract.terminal_event in contract.event_bus.publish_topics
             else None
         )
+        # OMN-13548 (D-03): resolve the malformed-event DLQ destination from the
+        # contract's event_bus.dlq_topics (not the typed subcontract, which omits
+        # the field) so a projection handler error routes to the bus instead of
+        # being logged + dropped. Never hardcoded here.
+        projection_dlq_topics = _read_dlq_topics(contract.contract_path)
         callback = _make_projection_dispatch_callback(
             handler_instance,
             db_tables,
             subscribe_topics,
-            event_bus=event_bus,
-            terminal_event=projection_terminal_event,
+            sinks=ProjectionDispatchSinks(
+                event_bus=event_bus,
+                terminal_event=projection_terminal_event,
+                dlq_topics=tuple(projection_dlq_topics),
+            ),
         )
         logger.info(
-            "Auto-wired projection handler with DB injection: handler=%s db_tables=%s terminal_event=%s",
+            "Auto-wired projection handler with DB injection: handler=%s db_tables=%s "
+            "terminal_event=%s dlq_topics=%s",
             handler_ref.name,
             [t.get("name") for t in db_tables],
             projection_terminal_event,
+            projection_dlq_topics,
         )
         # Projection handlers route by topic/db_io, not event_model; leave
         # them untyped so the projection dispatch path is unchanged.

--- a/tests/integration/projectors/test_projection_terminal_event_emission.py
+++ b/tests/integration/projectors/test_projection_terminal_event_emission.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from omnibase_infra.runtime.auto_wiring.handler_wiring import (
+    ProjectionDispatchSinks,
     _make_projection_dispatch_callback,
 )
 
@@ -54,8 +55,10 @@ def test_terminal_event_emitted_after_successful_projection() -> None:
         FakeDelegationHandler(),
         DB_TABLES,
         SUBSCRIBE_TOPICS,
-        event_bus=FakeEventBus(),
-        terminal_event=TERMINAL_TOPIC,
+        sinks=ProjectionDispatchSinks(
+            event_bus=FakeEventBus(),
+            terminal_event=TERMINAL_TOPIC,
+        ),
     )
 
     envelope = MagicMock()
@@ -99,8 +102,10 @@ def test_terminal_event_not_emitted_when_projection_fails() -> None:
         FailingHandler(),
         DB_TABLES,
         SUBSCRIBE_TOPICS,
-        event_bus=FakeEventBus(),
-        terminal_event=TERMINAL_TOPIC,
+        sinks=ProjectionDispatchSinks(
+            event_bus=FakeEventBus(),
+            terminal_event=TERMINAL_TOPIC,
+        ),
     )
 
     envelope = MagicMock()
@@ -139,8 +144,10 @@ def test_no_terminal_event_without_event_bus() -> None:
         FakeDelegationHandler(),
         DB_TABLES,
         SUBSCRIBE_TOPICS,
-        event_bus=None,
-        terminal_event=TERMINAL_TOPIC,
+        sinks=ProjectionDispatchSinks(
+            event_bus=None,
+            terminal_event=TERMINAL_TOPIC,
+        ),
     )
 
     envelope = MagicMock()

--- a/tests/unit/runtime/auto_wiring/test_handler_wiring_db_injection.py
+++ b/tests/unit/runtime/auto_wiring/test_handler_wiring_db_injection.py
@@ -13,10 +13,12 @@ import pytest
 
 from omnibase_infra.runtime.auto_wiring.handler_wiring import (
     _DB_URL_ENV_MAP,
+    ProjectionDispatchSinks,
     _build_sync_db_adapter,
     _make_dispatch_callback,
     _make_projection_dispatch_callback,
     _read_db_io_tables,
+    _read_dlq_topics,
 )
 
 _PATCH_BUILD_ADAPTER = (
@@ -501,8 +503,10 @@ def test_projection_callback_emits_terminal_event_on_success() -> None:
         handler,
         db_tables,
         ("onex.evt.omniclaude.task-delegated.v1",),
-        event_bus=fake_bus,
-        terminal_event=terminal_topic,
+        sinks=ProjectionDispatchSinks(
+            event_bus=fake_bus,
+            terminal_event=terminal_topic,
+        ),
     )
 
     envelope = MagicMock()
@@ -554,8 +558,10 @@ def test_projection_callback_does_not_emit_terminal_event_on_zero_rows() -> None
         ZeroRowHandler(),
         db_tables,
         ("onex.evt.omniclaude.task-delegated.v1",),
-        event_bus=FakeEventBus(),
-        terminal_event=terminal_topic,
+        sinks=ProjectionDispatchSinks(
+            event_bus=FakeEventBus(),
+            terminal_event=terminal_topic,
+        ),
     )
 
     envelope = MagicMock()
@@ -599,8 +605,10 @@ def test_projection_callback_emits_terminal_event_from_materialized_dict() -> No
         FakeHandler(),
         db_tables,
         ("onex.evt.omniclaude.task-delegated.v1",),
-        event_bus=FakeEventBus(),
-        terminal_event=terminal_topic,
+        sinks=ProjectionDispatchSinks(
+            event_bus=FakeEventBus(),
+            terminal_event=terminal_topic,
+        ),
     )
     envelope = {
         "payload": {"task_type": "code-review"},
@@ -647,8 +655,10 @@ def test_projection_callback_does_not_emit_terminal_event_on_handler_error() -> 
         handler,
         db_tables,
         (),
-        event_bus=fake_bus,
-        terminal_event=terminal_topic,
+        sinks=ProjectionDispatchSinks(
+            event_bus=fake_bus,
+            terminal_event=terminal_topic,
+        ),
     )
 
     envelope = MagicMock()
@@ -681,8 +691,10 @@ def test_projection_callback_no_terminal_event_when_bus_is_none() -> None:
         handler,
         db_tables,
         (),
-        event_bus=None,
-        terminal_event="onex.evt.omnimarket.projection-delegation-applied.v1",
+        sinks=ProjectionDispatchSinks(
+            event_bus=None,
+            terminal_event="onex.evt.omnimarket.projection-delegation-applied.v1",
+        ),
     )
 
     envelope = MagicMock()
@@ -722,8 +734,10 @@ def test_projection_callback_terminal_event_publish_failure_does_not_propagate(
         handler,
         db_tables,
         (),
-        event_bus=BrokenEventBus(),
-        terminal_event="onex.evt.omnimarket.projection-delegation-applied.v1",
+        sinks=ProjectionDispatchSinks(
+            event_bus=BrokenEventBus(),
+            terminal_event="onex.evt.omnimarket.projection-delegation-applied.v1",
+        ),
     )
 
     envelope = MagicMock()
@@ -814,3 +828,174 @@ def test_omniintelligence_is_accepted_db_identity_per_db_url_contract() -> None:
     assert "OMNIINTELLIGENCE_DB_URL" in captured_env
     assert len(received) == 1
     assert received[0]["_db"] is fake_adapter
+
+
+# ---------------------------------------------------------------------------
+# Tests: _read_dlq_topics (OMN-13548 / D-03)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_read_dlq_topics_returns_declared(tmp_path: Path) -> None:
+    contract = tmp_path / "contract.yaml"
+    contract.write_text(
+        "name: test\n"
+        "event_bus:\n"
+        "  dlq_topics:\n"
+        "    - onex.dlq.omnimarket.projection-delegation-malformed.v1\n"
+    )
+    assert _read_dlq_topics(contract) == [
+        "onex.dlq.omnimarket.projection-delegation-malformed.v1"
+    ]
+
+
+@pytest.mark.unit
+def test_read_dlq_topics_empty_when_absent(tmp_path: Path) -> None:
+    contract = tmp_path / "contract.yaml"
+    contract.write_text("name: test\nevent_bus:\n  subscribe_topics: []\n")
+    assert _read_dlq_topics(contract) == []
+
+
+@pytest.mark.unit
+def test_read_dlq_topics_empty_on_missing_file() -> None:
+    assert _read_dlq_topics(Path("/nonexistent/contract.yaml")) == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: projection-handler-error -> DLQ on the REAL dispatch path
+# (OMN-13548 / D-03). These exercise the wiring's projection dispatch callback
+# directly — NOT a direct handler call — so a malformed envelope whose
+# ValidationError escapes the handler must produce a DLQ publish.
+# ---------------------------------------------------------------------------
+
+_DLQ_TOPIC = "onex.dlq.omnimarket.projection-delegation-malformed.v1"
+
+
+class _CapturingEventBus:
+    """Minimal event bus capturing publish(topic, key, value) calls."""
+
+    def __init__(self) -> None:
+        self.published: list[tuple[str, object, bytes]] = []
+
+    async def publish(self, topic: str, key: object, value: bytes) -> None:
+        self.published.append((topic, key, value))
+
+
+def _raising_validation_handler() -> object:
+    """A projection handler whose handle() raises ValidationError, mirroring the
+    real path where the inbound delegation event is missing task_type."""
+    from pydantic import BaseModel, ValidationError
+
+    class _RequiresTaskType(BaseModel):
+        task_type: str
+
+    class _ValidatingHandler:
+        def handle(self, input_data: dict) -> dict:
+            # Validate against a model requiring task_type — a malformed event
+            # (no task_type) raises ValidationError that escapes handle(), which
+            # is exactly the live failure proven in OMN-13548.
+            try:
+                _RequiresTaskType.model_validate(
+                    {k: v for k, v in input_data.items() if not k.startswith("_")}
+                )
+            except ValidationError:
+                raise
+            return {"rows_upserted": 1}
+
+    return _ValidatingHandler()
+
+
+@pytest.mark.unit
+def test_projection_callback_routes_validation_error_to_dlq() -> None:
+    """A malformed envelope through the dispatch callback publishes to the DLQ.
+
+    This is the de-fake of the prior boundary-faked unit tests: the handler
+    error is raised on the wiring's dispatch path and the wiring (not the
+    handler) routes the offending envelope to the contract-declared DLQ topic.
+    """
+    import json
+
+    bus = _CapturingEventBus()
+    callback = _make_projection_dispatch_callback(
+        _raising_validation_handler(),
+        [{"name": "delegation_events", "database": "omnidash_analytics"}],
+        ("onex.evt.omniclaude.task-delegated.v1",),
+        sinks=ProjectionDispatchSinks(event_bus=bus, dlq_topics=(_DLQ_TOPIC,)),
+    )
+
+    envelope = MagicMock()
+    envelope.topic = "onex.evt.omniclaude.task-delegated.v1"
+    # Malformed: missing required task_type.
+    envelope.payload = {"correlation_id": "corr-malformed-1", "delegated_to": "glm"}
+
+    with patch(
+        _PATCH_ENVIRON_GET,
+        return_value="postgresql://user:pass@host:5432/omnidash_analytics",
+    ):
+        with patch(_PATCH_BUILD_ADAPTER, return_value=MagicMock()):
+            asyncio.run(callback(envelope))
+
+    assert len(bus.published) == 1, (
+        "malformed event must produce exactly one DLQ publish"
+    )
+    topic, _key, value = bus.published[0]
+    assert topic == _DLQ_TOPIC
+    dlq = json.loads(value.decode("utf-8"))
+    assert dlq["correlation_id"] == "corr-malformed-1"
+    assert dlq["handler"] == "_ValidatingHandler"
+    assert "ValidationError" in dlq["failure_reason"]
+    assert dlq["original_message"]["delegated_to"] == "glm"
+
+
+@pytest.mark.unit
+def test_projection_callback_no_dlq_publish_on_success() -> None:
+    """A well-formed event projects normally and never touches the DLQ."""
+    bus = _CapturingEventBus()
+    callback = _make_projection_dispatch_callback(
+        _raising_validation_handler(),
+        [{"name": "delegation_events", "database": "omnidash_analytics"}],
+        ("onex.evt.omniclaude.task-delegated.v1",),
+        sinks=ProjectionDispatchSinks(event_bus=bus, dlq_topics=(_DLQ_TOPIC,)),
+    )
+
+    envelope = MagicMock()
+    envelope.topic = "onex.evt.omniclaude.task-delegated.v1"
+    envelope.payload = {"correlation_id": "corr-ok-1", "task_type": "release-proof"}
+
+    with patch(
+        _PATCH_ENVIRON_GET,
+        return_value="postgresql://user:pass@host:5432/omnidash_analytics",
+    ):
+        with patch(_PATCH_BUILD_ADAPTER, return_value=MagicMock()):
+            asyncio.run(callback(envelope))
+
+    assert bus.published == []
+
+
+@pytest.mark.unit
+def test_projection_callback_logs_error_when_no_dlq_topic_declared(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """With no DLQ topic declared, the error is logged loudly (no silent drop)."""
+    bus = _CapturingEventBus()
+    callback = _make_projection_dispatch_callback(
+        _raising_validation_handler(),
+        [{"name": "delegation_events", "database": "omnidash_analytics"}],
+        ("onex.evt.omniclaude.task-delegated.v1",),
+        sinks=ProjectionDispatchSinks(event_bus=bus, dlq_topics=()),
+    )
+
+    envelope = MagicMock()
+    envelope.topic = "onex.evt.omniclaude.task-delegated.v1"
+    envelope.payload = {"correlation_id": "corr-nodlq-1"}
+
+    with caplog.at_level(logging.ERROR):
+        with patch(
+            _PATCH_ENVIRON_GET,
+            return_value="postgresql://user:pass@host:5432/omnidash_analytics",
+        ):
+            with patch(_PATCH_BUILD_ADAPTER, return_value=MagicMock()):
+                asyncio.run(callback(envelope))
+
+    assert bus.published == []
+    assert any("NO DLQ topic declared" in r.message for r in caplog.records)


### PR DESCRIPTION
## OMN-13548 (D-03): route projection-handler errors to the contract DLQ in the runtime wiring

The prior fix (omnimarket#1372, merged) is broken on the REAL bus path. It put the DLQ route inside `HandlerProjectionDelegation` behind a dict-check, but the runtime wiring's projection dispatch callback (`_make_projection_dispatch_callback` in `omnibase_infra/.../auto_wiring/handler_wiring.py`) invokes the handler's `handle()` and catches any raised `ValidationError` in its generic `except Exception -> log + drop` arm. A malformed delegation event whose `ValidationError` escapes `handle()` therefore hit the wiring drop, not the handler's DLQ branch.

Proven live: malformed event -> `ERROR 'Projection handler error ... ValidationError ... task_type Field required'` -> 0 DLQ rows. The 9 prior unit tests were boundary-fakes (direct handler calls, bypassing the wiring).

### Canonical fix (robust layer = the wiring)
`_make_projection_dispatch_callback`'s `except TypeError` and `except Exception` arms now route the offending raw envelope to the **contract-declared** DLQ topic (`event_bus.dlq_topics[0]`, read from the contract YAML via `_read_dlq_topics` — never hardcoded), carrying `correlation_id` + failure reason. This is **general for ALL projection handlers**, not delegation-only — the same fail-loud/observability principle as OMN-12408 but for runtime events.

- `_route_projection_error_to_dlq`: best-effort publish to the DLQ topic; logs loudly (no silent drop) when no DLQ topic is declared or no bus is bound; a DLQ publish failure never wedges the consumer.
- `_read_dlq_topics`: reads `event_bus.dlq_topics` from the contract YAML (the typed subcontract omits the field), mirroring `_read_db_io_tables`.
- `ProjectionDispatchSinks`: frozen value object bundling `event_bus` + `terminal_event` + `dlq_topics` (keeps the callback factory within the parameter budget).

### Test exercises the REAL wiring dispatch path (not a direct handler call)
`tests/unit/runtime/auto_wiring/test_handler_wiring_db_injection.py`:
- `test_projection_callback_routes_validation_error_to_dlq` — a malformed envelope routed THROUGH the dispatch callback publishes exactly one DLQ envelope to the contract topic carrying its `correlation_id`.
- `test_projection_callback_no_dlq_publish_on_success` — a well-formed event publishes none.
- `test_projection_callback_logs_error_when_no_dlq_topic_declared` — no-DLQ-topic contract logs loudly.

Local proof: `uv run pytest tests/unit/runtime/auto_wiring/test_handler_wiring_db_injection.py -q` -> 29 passed; ruff + `mypy --strict` clean; all pre-commit hooks pass.

### Evidence
Evidence-Source: 6ec4ee4649d56329a1ab0f5c58b003de6ba2666f
Evidence-Ticket: OMN-13548

DoD: the malformed-event DLQ route now fires on the real bus path. Live-lane proof (dod-deploy) happens in the Prove phase after dev redeploy — NOT marked PASS here.
