### PR TITLE
fix(OMN-13533): provision validator-catch.v1 + hook-context-injected.v1 via savings-estimation contract

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
   # shared baseline at omnibase_core/src/omnibase_core/validation/baselines/url_authority_baseline.json.
   # Baseline is burn-down only. Suppress with: # url-authority-ok: <reason>
   - repo: https://github.com/OmniNode-ai/omnibase_core
-    rev: c93c98c92bd1a5b335d7aa504a8cf63dc029b3e7 # pragma: allowlist secret
+    rev: be4f95460dcd6865264ab0713a5b1cc48b41aef9 # pragma: allowlist secret
     hooks:
       - id: check-url-authority
         args: [--repo, omnibase_infra, --repo-root, .]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
   # Stub implementation detection + transport-mock lint — sourced from omnibase_core.
   # Rev bumped to OMN-13026 (transport-mock-lint hook added).
   - repo: https://github.com/OmniNode-ai/omnibase_core
-    rev: cfaa6ec863c3026b5e65196151ed76cdad13dae3 # pragma: allowlist secret
+    rev: 309d89fa7254701347f95bf99205cccfb3f6c1df # pragma: allowlist secret
     hooks:
       - id: check-stub-implementations
       # OMN-13026: bare AsyncMock/MagicMock without spec=/spec_set= on

--- a/architecture-handshakes/validator-requirements-baseline.yaml
+++ b/architecture-handshakes/validator-requirements-baseline.yaml
@@ -1,4 +1,3 @@
----
 # SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 #
@@ -24,7 +23,6 @@ schema_version:
   patch: 0
 repo: omnibase_infra
 report_format: "all_gaps"
-
 classification:
   arch-002-no-transport-imports:
     pre_commit: backlog
@@ -77,7 +75,6 @@ classification:
   stub-implementations:
     ci_workflow: backlog
     tracking: OMN-9048
-
 gaps:
   - repo: omnibase_infra
     validator: arch-002-no-transport-imports

--- a/architecture-handshakes/validator-requirements.yaml
+++ b/architecture-handshakes/validator-requirements.yaml
@@ -1,4 +1,3 @@
----
 # Canonical validator requirements for OmniNode-ai downstream repos.
 #
 # This file is the single source of truth for which validators must be wired
@@ -14,12 +13,10 @@
 #
 # See: OMN-9048 (validator standardization epic), OMN-9051 (spec),
 #      OMN-9115 (spec consumer + enforcement wiring).
-
 schema_version:
   major: 1
   minor: 2
   patch: 0
-
 # Canonical list of all OmniNode repos governed by this spec. The consumer
 # uses this list to reject typos in repo arguments. Keep in sync when
 # onboarding/offboarding a repo; adding a repo here without wiring its
@@ -37,7 +34,6 @@ known_repos:
   - omninode_infra
   - omniweb
   - onex_change_control
-
 # Scopes:
 #   - pre_commit: "required" | "optional"  — entry in .pre-commit-config.yaml
 #   - ci_workflow: "required" | "optional" — .github/workflows/*.yml that runs it
@@ -56,9 +52,7 @@ known_repos:
 #   - ci_workflow_keywords: list of acceptable CI workflow step-name / run-line
 #     substrings. The consumer accepts any repo whose .github/workflows/*.yml
 #     contains at least one step mentioning one of these keywords.
-
 required_validators:
-
   hardcoded-local-paths:
     description: |
       Blocks /Users/, /Volumes/, /home/, C:\Users\ absolute paths in source.
@@ -78,7 +72,6 @@ required_validators:
       allowed: ["^tests/fixtures/", "^docs/"]
       forbidden: ["^tests/$", "^tests/[^f]", "^src/"]
     applies_to_repos: all
-
   spdx-headers:
     description: |
       Enforces MIT SPDX headers on source + tests + scripts + examples.
@@ -97,7 +90,6 @@ required_validators:
       allowed: ["\\.md$", "\\.ya?ml$", "\\.json$"]
       forbidden: ["^tests/", "^src/"]
     applies_to_repos: all
-
   no-hardcoded-topics:
     description: |
       Kafka topic strings must come from contract.yaml, not hardcoded in source.
@@ -124,7 +116,6 @@ required_validators:
       - omniintelligence
       - omninode_infra
       - onex_change_control
-
   stub-implementations:
     description: |
       Blocks NotImplementedError, bare pass, bare TODO docstrings in non-test source.
@@ -150,7 +141,6 @@ required_validators:
       - omnimarket
       - omnimemory
       - omniintelligence
-
   enum-governance:
     description: |
       Enforces UPPER_SNAKE_CASE enum members + detects Literal-duplication anti-pattern.
@@ -177,7 +167,6 @@ required_validators:
       - omnimarket
       - omnimemory
       - omniintelligence
-
   naming-conventions:
     description: |
       File-naming (model_*, enum_*, protocol_*, handler_*, service_*, node_*) +
@@ -205,7 +194,6 @@ required_validators:
       - omnimarket
       - omnimemory
       - omniintelligence
-
   self-gating-workflows:
     description: |
       Blocks cross-repo @main refs in .github/workflows/*.yml (retro §4.8).
@@ -225,7 +213,6 @@ required_validators:
       allowed: []
       forbidden: []
     applies_to_repos: all
-
   branch-protection-rollout-guard:
     description: |
       PreToolUse Claude Code hook that blocks gh api PUT/PATCH .../branches/*/protection
@@ -245,7 +232,6 @@ required_validators:
       forbidden: []
     applies_to_repos:
       - omniclaude
-
   bandit-security:
     description: |
       Python security linting (medium+ severity).
@@ -271,7 +257,6 @@ required_validators:
       - omnimemory
       - omniintelligence
       - omninode_infra
-
   mypy-type-check:
     description: |
       Strict mypy on src/.
@@ -297,7 +282,6 @@ required_validators:
       - omnimarket
       - omnimemory
       - omniintelligence
-
   ruff-format-check:
     description: |
       Ruff format + check, universal across Python repos.
@@ -326,7 +310,6 @@ required_validators:
       - omniintelligence
       - omninode_infra
       - onex_change_control
-
   aislop-patterns:
     description: |
       Detects AI-generated boilerplate, narrative docstrings, step_narration anti-patterns.
@@ -346,7 +329,6 @@ required_validators:
       allowed: ["^docs/", "^CHANGELOG\\.md$"]
       forbidden: ["^src/"]
     applies_to_repos: all
-
   pydantic-patterns:
     description: |
       Enforces ConfigDict(frozen=True, extra="forbid"), Field(..., description), no Any, PEP 604 unions.
@@ -373,7 +355,6 @@ required_validators:
       - omnimarket
       - omnimemory
       - omniintelligence
-
   single-class-per-file:
     description: |
       Enforces one class per .py file (protocols + TypedDicts exempt).
@@ -400,7 +381,6 @@ required_validators:
       - omnimarket
       - omnimemory
       - omniintelligence
-
   detect-secrets:
     description: |
       Yelp/detect-secrets baseline, catches committed API keys / passwords / PEM keys.
@@ -418,7 +398,6 @@ required_validators:
       allowed: ["\\.secrets\\.baseline$", "^tests/fixtures/"]
       forbidden: []
     applies_to_repos: all
-
   no-untracked-todos:
     description: |
       Blocks bare TODO/FIXME. Requires # TODO(OMN-XXXX): format.
@@ -436,7 +415,6 @@ required_validators:
       allowed: ["^docs/"]
       forbidden: ["^src/", "^tests/"]
     applies_to_repos: all
-
   arch-002-no-transport-imports:
     description: |
       Nodes must not import aiokafka/httpx/asyncpg directly (SPI boundary).
@@ -462,7 +440,6 @@ required_validators:
       - omnimarket
       - omnimemory
       - omniintelligence
-
   banned-compose-env-vars:
     description: |
       Detects docker-compose / Kubernetes manifests that reference env vars the
@@ -488,18 +465,15 @@ required_validators:
     applies_to_repos:
       - omnibase_infra
       - omninode_infra
-
 # Handshake metadata
-
 metadata:
   generated_by: "manually authored (OMN-9051); consumer added OMN-9115"
   last_updated: "2026-04-17"
-  next_review: "on any new validator addition — single source of truth, change propagates via OMN-9050
-    bot"
+  next_review: "on any new validator addition — single source of truth, change propagates via OMN-9050 bot"
   related_tickets:
-    - OMN-9048  # validator standardization epic
-    - OMN-9049  # universal handshake coverage
-    - OMN-9050  # pin-bump bot
-    - OMN-9051  # spec file owner
-    - OMN-9058  # env-store abstraction
-    - OMN-9115  # spec consumer + enforcement wiring
+    - OMN-9048 # validator standardization epic
+    - OMN-9049 # universal handshake coverage
+    - OMN-9050 # pin-bump bot
+    - OMN-9051 # spec file owner
+    - OMN-9058 # env-store abstraction
+    - OMN-9115 # spec consumer + enforcement wiring

--- a/contracts/OMN-12633.yaml
+++ b/contracts/OMN-12633.yaml
@@ -4,12 +4,7 @@ schema_version: "1.0.0"
 ticket_id: "OMN-12633"
 title: "feat(OMN-12633): retire ServiceDlqTracking runtime DDL — dlq_replay_history to migration-managed schema"
 summary: >-
-  Removes ServiceDlqTracking._ensure_table_exists() and the CREATE TABLE IF NOT EXISTS
-  call from initialize(). The dlq_replay_history table is now provisioned by the
-  canonical forward migration runner (086_create_dlq_replay_history.sql), making it
-  visible to public.schema_migrations and owned by node_dlq_replay_effect per
-  CONTRACT/NODE/HANDLER (OMN-12525). Adds static-analysis ratchet test preventing
-  re-introduction of imperative DDL.
+  Removes ServiceDlqTracking._ensure_table_exists() and the CREATE TABLE IF NOT EXISTS call from initialize(). The dlq_replay_history table is now provisioned by the canonical forward migration runner (086_create_dlq_replay_history.sql), making it visible to public.schema_migrations and owned by node_dlq_replay_effect per CONTRACT/NODE/HANDLER (OMN-12525). Adds static-analysis ratchet test preventing re-introduction of imperative DDL.
 is_seam_ticket: false
 interface_change: false
 interfaces_touched: []
@@ -54,9 +49,7 @@ dod_evidence:
         check_value: "test -f docker/migrations/forward/086_create_dlq_replay_history.sql"
   - id: "dod-deploy"
     description: >-
-      Deploy validation: tech-debt cleanup removing runtime table creation from ServiceDlqTracking.
-      The table must be pre-created by the forward migration runner before DLQ plugin activates.
-      No new Kafka topics; no API surface changes. Migration 086 is idempotent (IF NOT EXISTS).
+      Deploy validation: tech-debt cleanup removing runtime table creation from ServiceDlqTracking. The table must be pre-created by the forward migration runner before DLQ plugin activates. No new Kafka topics; no API surface changes. Migration 086 is idempotent (IF NOT EXISTS).
     source: "manual"
     checks:
       - check_type: "command"

--- a/contracts/OMN-13011.yaml
+++ b/contracts/OMN-13011.yaml
@@ -4,22 +4,7 @@ schema_version: "1.0.0"
 ticket_id: "OMN-13011"
 title: "LANE CENSUS RECONCILIATION ratchet — declared desired-state per lane, scheduled + on-demand, drift = auto-ticket"
 summary: >-
-  The class fix for the recurring lane-drift regression. Nothing reconciled the
-  declared desired state of a runtime lane against what is actually running, so
-  the same failure kept recurring with zero signal: volume config drift
-  (OMN-12945), WORKER_REPLICAS silent zero (OMN-12988/12990), and on 2026-06-11
-  prod runtime containers plus the broker network were silently absent for hours
-  during demo prep. This ships a per-lane DESIRED-STATE census: (a) DECLARED in a
-  versioned lane manifest (deploy/lane-census/lane-manifest.yaml) — container set,
-  network, replicas, image-tag pattern per lane (stability-test/prod/judge/dev),
-  derived from the canonical compose lane files; (b) RECONCILED on a schedule on
-  .201 by sharing the OMN-13008 systemd timer (a drop-in 4th ExecStart on
-  onex-disk-gc.service, never a second timer) and on-demand via runtime_sweep;
-  (c) drift = a typed bus event + Linear auto-ticket naming exactly what is
-  missing/extra (container_absent, network_detached, replicas_zero,
-  unexpected_container, oneshot_failed/stuck, image_tag_mismatch). Fail-fast,
-  no warn-only mode (gates-block policy). Builds on the OMN-12988 deploy-agent
-  RUNTIME census (deploy-time) as the complementary steady-state reconciler.
+  The class fix for the recurring lane-drift regression. Nothing reconciled the declared desired state of a runtime lane against what is actually running, so the same failure kept recurring with zero signal: volume config drift (OMN-12945), WORKER_REPLICAS silent zero (OMN-12988/12990), and on 2026-06-11 prod runtime containers plus the broker network were silently absent for hours during demo prep. This ships a per-lane DESIRED-STATE census: (a) DECLARED in a versioned lane manifest (deploy/lane-census/lane-manifest.yaml) — container set, network, replicas, image-tag pattern per lane (stability-test/prod/judge/dev), derived from the canonical compose lane files; (b) RECONCILED on a schedule on .201 by sharing the OMN-13008 systemd timer (a drop-in 4th ExecStart on onex-disk-gc.service, never a second timer) and on-demand via runtime_sweep; (c) drift = a typed bus event + Linear auto-ticket naming exactly what is missing/extra (container_absent, network_detached, replicas_zero, unexpected_container, oneshot_failed/stuck, image_tag_mismatch). Fail-fast, no warn-only mode (gates-block policy). Builds on the OMN-12988 deploy-agent RUNTIME census (deploy-time) as the complementary steady-state reconciler.
 is_seam_ticket: false
 interface_change: false
 interfaces_touched: []
@@ -31,22 +16,14 @@ evidence_requirements:
   - kind: "tests"
     description: "Event-builder, manifest-parity, dry-run, and timer-dropin tests pass"
     command: >-
-      uv run pytest
-      tests/unit/scripts/test_lane_census_event.py
-      tests/unit/scripts/test_lane_census_manifest_parity.py
-      tests/unit/scripts/test_lane_census_dry_run.py
-      tests/unit/scripts/test_lane_census_timer_dropin.py -q
+      uv run pytest tests/unit/scripts/test_lane_census_event.py tests/unit/scripts/test_lane_census_manifest_parity.py tests/unit/scripts/test_lane_census_dry_run.py tests/unit/scripts/test_lane_census_timer_dropin.py -q
   - kind: "ci"
     description: "New source passes ruff and mypy --strict"
     command: >-
-      uv run ruff check scripts/lane_census_plan.py scripts/lane_census_event.py
-      && uv run mypy scripts/lane_census_plan.py scripts/lane_census_event.py --strict
+      uv run ruff check scripts/lane_census_plan.py scripts/lane_census_event.py && uv run mypy scripts/lane_census_plan.py scripts/lane_census_event.py --strict
   - kind: "manual"
     description: >-
-      On .201, after OMN-13008's install-disk-gc.sh, run
-      deploy/lane-census/install-lane-census.sh and confirm via
-      `systemctl --user cat onex-disk-gc.service` that the lane-census ExecStart
-      is the 4th pass on the shared unit (no second timer)
+      On .201, after OMN-13008's install-disk-gc.sh, run deploy/lane-census/install-lane-census.sh and confirm via `systemctl --user cat onex-disk-gc.service` that the lane-census ExecStart is the 4th pass on the shared unit (no second timer)
 emergency_bypass:
   enabled: false
   justification: ""

--- a/contracts/OMN-13141.yaml
+++ b/contracts/OMN-13141.yaml
@@ -5,15 +5,7 @@ schema_version: "1.0.0"
 ticket_id: "OMN-13141"
 title: "fix(OMN-13141): runtime executor skips event_model import for operation_match entries"
 summary: >-
-  Executor companion to OMN-13137's validator half (#1973, merged). _run_event_driven
-  unconditionally imported entry.event_model_module for every resolved routing entry.
-  operation_match entries declare no event_model, so event_model_module is empty and
-  importlib.import_module("") raised ValueError: Empty module name — not caught by the
-  (ImportError, AttributeError) clause, swallowed by the outer except in run_async ->
-  result FAILED. The node never booted end-to-end (e.g. node_integration_sweep_orchestrator).
-  Fix gates the import on a non-empty event_model_module: operation_match forwards the raw
-  decoded payload (input_model_cls=None); only payload_type_match resolves a typed event
-  model. _validate_routing (the OMN-13137 half) is left untouched.
+  Executor companion to OMN-13137's validator half (#1973, merged). _run_event_driven unconditionally imported entry.event_model_module for every resolved routing entry. operation_match entries declare no event_model, so event_model_module is empty and importlib.import_module("") raised ValueError: Empty module name — not caught by the (ImportError, AttributeError) clause, swallowed by the outer except in run_async -> result FAILED. The node never booted end-to-end (e.g. node_integration_sweep_orchestrator). Fix gates the import on a non-empty event_model_module: operation_match forwards the raw decoded payload (input_model_cls=None); only payload_type_match resolves a typed event model. _validate_routing (the OMN-13137 half) is left untouched.
 is_seam_ticket: false
 interface_change: false
 interfaces_touched: []
@@ -37,9 +29,7 @@ dod_evidence:
         check_value: "test -f contracts/OMN-13141.yaml"
   - id: "dod-boot-e2e"
     description: >-
-      operation_match contract boots end-to-end through RuntimeLocal.run_async()
-      with no empty-module ValueError, and the payload_type_match import path is
-      unchanged (regression guard). This boot test is the CI gate for the fix.
+      operation_match contract boots end-to-end through RuntimeLocal.run_async() with no empty-module ValueError, and the payload_type_match import path is unchanged (regression guard). This boot test is the CI gate for the fix.
     source: "manual"
     checks:
       - check_type: "command"
@@ -52,10 +42,7 @@ dod_evidence:
         check_value: "uv run pytest tests/unit/runtime/ -q"
   - id: "dod-deploy"
     description: >-
-      Deploy validation: change is an internal correctness fix to the local-runtime
-      event-driven executor (_run_event_driven) and its bus adapter. No new Kafka topics,
-      no schema changes, no container image changes, no API surface changes. Runtime
-      restart picks up the change automatically on next deploy.
+      Deploy validation: change is an internal correctness fix to the local-runtime event-driven executor (_run_event_driven) and its bus adapter. No new Kafka topics, no schema changes, no container image changes, no API surface changes. Runtime restart picks up the change automatically on next deploy.
     source: "manual"
     checks:
       - check_type: "command"

--- a/contracts/OMN-13149.yaml
+++ b/contracts/OMN-13149.yaml
@@ -5,18 +5,7 @@ schema_version: "1.0.0"
 ticket_id: "OMN-13149"
 title: "fix(OMN-13149): savings_estimation consumer decodes typed ModelEventMessage instead of calling .get()"
 summary: >-
-  The savings-estimation consumer is wired in service_kernel via event_bus.subscribe;
-  both the Kafka and in-memory buses deliver a typed ModelEventMessage to the
-  on_message callback. The pre-fix _savings_on_message did json.loads only when msg
-  was str/bytes and otherwise passed the value through unchanged, so a ModelEventMessage
-  reached ServiceSavingsEstimator.ingest_event -> _session_id_for_topic, which calls
-  payload.get("session_id"). ModelEventMessage has no .get(), raising
-  AttributeError: 'ModelEventMessage' object has no attribute 'get' at runtime — the
-  consumer wrote zero rows. Fix adds module-level decode_event_message(message) that
-  reads the JSON payload off the typed .value field directly (strongly typed, fail-fast:
-  raises TypeError on a non-object payload — no getattr-default, no dict-style fallback).
-  The kernel callback now decodes then calls ingest_event(topic, payload). Same
-  dict/typed-model family as OMN-13141 / golden-chain BUG A.
+  The savings-estimation consumer is wired in service_kernel via event_bus.subscribe; both the Kafka and in-memory buses deliver a typed ModelEventMessage to the on_message callback. The pre-fix _savings_on_message did json.loads only when msg was str/bytes and otherwise passed the value through unchanged, so a ModelEventMessage reached ServiceSavingsEstimator.ingest_event -> _session_id_for_topic, which calls payload.get("session_id"). ModelEventMessage has no .get(), raising AttributeError: 'ModelEventMessage' object has no attribute 'get' at runtime — the consumer wrote zero rows. Fix adds module-level decode_event_message(message) that reads the JSON payload off the typed .value field directly (strongly typed, fail-fast: raises TypeError on a non-object payload — no getattr-default, no dict-style fallback). The kernel callback now decodes then calls ingest_event(topic, payload). Same dict/typed-model family as OMN-13141 / golden-chain BUG A.
 is_seam_ticket: false
 interface_change: false
 interfaces_touched: []
@@ -40,10 +29,7 @@ dod_evidence:
         check_value: "test -f contracts/OMN-13149.yaml"
   - id: "dod-typed-message-regression"
     description: >-
-      Through the REAL consumer path (EventBusInmemory.subscribe/publish ->
-      on_message(ModelEventMessage) -> decode_event_message -> ingest_event) a typed
-      ModelEventMessage correlates a session; the pre-fix path (typed message straight
-      to ingest_event) reproduces AttributeError. This is the CI gate for the fix.
+      Through the REAL consumer path (EventBusInmemory.subscribe/publish -> on_message(ModelEventMessage) -> decode_event_message -> ingest_event) a typed ModelEventMessage correlates a session; the pre-fix path (typed message straight to ingest_event) reproduces AttributeError. This is the CI gate for the fix.
     source: "manual"
     checks:
       - check_type: "command"
@@ -56,10 +42,7 @@ dod_evidence:
         check_value: "uv run pytest tests/unit/runtime/ tests/unit/services/observability/savings_estimation/ -q"
   - id: "dod-deploy"
     description: >-
-      Deploy validation: change is an internal correctness fix to the savings-estimation
-      consumer wiring in service_kernel (_savings_on_message) plus a module-level decode
-      helper in the consumer. No new Kafka topics, no schema changes, no container image
-      changes, no API surface changes. Runtime restart picks up the change on next deploy.
+      Deploy validation: change is an internal correctness fix to the savings-estimation consumer wiring in service_kernel (_savings_on_message) plus a module-level decode helper in the consumer. No new Kafka topics, no schema changes, no container image changes, no API surface changes. Runtime restart picks up the change on next deploy.
     source: "manual"
     checks:
       - check_type: "command"

--- a/contracts/OMN-13190.yaml
+++ b/contracts/OMN-13190.yaml
@@ -5,34 +5,18 @@ schema_version: "1.0.0"
 ticket_id: "OMN-13190"
 title: "chore(OMN-13190): remove 3 zero-consumer TOPIC_* constants from topic_constants.py"
 summary: >-
-  Platform-debt cleanup (epic OMN-13188). The plan listed 6 candidate dead TOPIC_*
-  constants; verification refuted one (TOPIC_SESSION_COORDINATION_SIGNAL has a live
-  omnimarket emit_daemon consumer). During the build a second pair was also found NOT
-  dead: TOPIC_DELEGATE_SKILL_COMPLETED / TOPIC_DELEGATE_SKILL_FAILED are the
-  TopicEnumGenerator (OMN-2964) source for EnumOmnimarketTopic.EVT_DELEGATE_SKILL_*_V1,
-  which runtime/service_kernel.py:2045-2048 consumes to wire the delegate-skill terminal
-  result applier (OMN-11996). Deleting them dropped the generated enum members and broke
-  bootstrap() (caught by tests/unit/runtime/test_kernel.py). They were restored. Only the
-  3 genuinely-dead constants are removed: TOPIC_DLQ_QUARANTINE (constant-only; the
-  quarantine topic itself stays live via build_dlq_topic("quarantine")),
-  TOPIC_EVAL_COMPLETED, and TOPIC_SESSION_STATUS_CHANGED. The 16 DLQ builder/format
-  helpers are untouched. Generated topic enums were regenerated from source so the
-  Topic Enum Drift Check passes (only EVT_EVAL_COMPLETED_V1 and EVT_SESSION_STATUS_CHANGED_V1
-  drop, both with zero consumers).
+  Platform-debt cleanup (epic OMN-13188). The plan listed 6 candidate dead TOPIC_* constants; verification refuted one (TOPIC_SESSION_COORDINATION_SIGNAL has a live omnimarket emit_daemon consumer). During the build a second pair was also found NOT dead: TOPIC_DELEGATE_SKILL_COMPLETED / TOPIC_DELEGATE_SKILL_FAILED are the TopicEnumGenerator (OMN-2964) source for EnumOmnimarketTopic.EVT_DELEGATE_SKILL_*_V1, which runtime/service_kernel.py:2045-2048 consumes to wire the delegate-skill terminal result applier (OMN-11996). Deleting them dropped the generated enum members and broke bootstrap() (caught by tests/unit/runtime/test_kernel.py). They were restored. Only the 3 genuinely-dead constants are removed: TOPIC_DLQ_QUARANTINE (constant-only; the quarantine topic itself stays live via build_dlq_topic("quarantine")), TOPIC_EVAL_COMPLETED, and TOPIC_SESSION_STATUS_CHANGED. The 16 DLQ builder/format helpers are untouched. Generated topic enums were regenerated from source so the Topic Enum Drift Check passes (only EVT_EVAL_COMPLETED_V1 and EVT_SESSION_STATUS_CHANGED_V1 drop, both with zero consumers).
 is_seam_ticket: false
 interface_change: false
 interfaces_touched: []
 evidence_requirements:
   - kind: tests
     description: >-
-      Topic-constant, DLQ-replay, session-registry projector, delegation-topic, and
-      topic-registry-integration unit suites pass; full unit suite green (20436 passed,
-      kernel suite 56/56 serially) with the deleted constants gone and no new failures.
+      Topic-constant, DLQ-replay, session-registry projector, delegation-topic, and topic-registry-integration unit suites pass; full unit suite green (20436 passed, kernel suite 56/56 serially) with the deleted constants gone and no new failures.
     command: "uv run pytest tests/unit/event_bus/ tests/unit/topics/ tests/unit/nodes/node_dlq_replay_effect/test_handler_dlq_replay.py tests/unit/services/session_registry/test_session_registry_projector.py tests/unit/runtime/test_kernel.py -q"
   - kind: ci
     description: >-
-      Both topic gates green: no-hardcoded-topics pre-commit hook + check_topic_literals.py
-      arch-invariant, plus the Topic Enum Drift Check (generate_topic_enums.py --check).
+      Both topic gates green: no-hardcoded-topics pre-commit hook + check_topic_literals.py arch-invariant, plus the Topic Enum Drift Check (generate_topic_enums.py --check).
     command: "uv run python scripts/validation/check_topic_literals.py && uv run python scripts/generate_topic_enums.py --check"
 emergency_bypass:
   enabled: false
@@ -41,26 +25,21 @@ emergency_bypass:
 dod_evidence:
   - id: dod-zero-consumer-grep
     description: >-
-      Grep proves zero production AND zero test references to the 3 removed constants
-      (TOPIC_DLQ_QUARANTINE, TOPIC_EVAL_COMPLETED, TOPIC_SESSION_STATUS_CHANGED) and to the
-      2 dropped generated enum members (EVT_EVAL_COMPLETED_V1, EVT_SESSION_STATUS_CHANGED_V1)
-      across omnibase_infra, omnibase_core, and omnimarket.
+      Grep proves zero production AND zero test references to the 3 removed constants (TOPIC_DLQ_QUARANTINE, TOPIC_EVAL_COMPLETED, TOPIC_SESSION_STATUS_CHANGED) and to the 2 dropped generated enum members (EVT_EVAL_COMPLETED_V1, EVT_SESSION_STATUS_CHANGED_V1) across omnibase_infra, omnibase_core, and omnimarket.
     source: manual
     checks:
       - check_type: command
         check_value: "! grep -rn -e 'TOPIC_DLQ_QUARANTINE' -e 'TOPIC_EVAL_COMPLETED' -e 'TOPIC_SESSION_STATUS_CHANGED' -e 'EVT_EVAL_COMPLETED_V1' -e 'EVT_SESSION_STATUS_CHANGED_V1' --include='*.py' src/ tests/"
   - id: dod-topic-gates
     description: >-
-      Topic literal arch-invariant and Topic Enum Drift Check both pass after deletion +
-      enum regeneration.
+      Topic literal arch-invariant and Topic Enum Drift Check both pass after deletion + enum regeneration.
     source: manual
     checks:
       - check_type: command
         check_value: "uv run python scripts/validation/check_topic_literals.py && uv run python scripts/generate_topic_enums.py --check"
   - id: dod-focused-tests
     description: >-
-      Topic + DLQ + session-registry + kernel unit suites pass, proving the removed
-      constants had no live consumer and the kept delegate-skill enum members remain wired.
+      Topic + DLQ + session-registry + kernel unit suites pass, proving the removed constants had no live consumer and the kept delegate-skill enum members remain wired.
     source: manual
     checks:
       - check_type: command

--- a/contracts/OMN-13191.yaml
+++ b/contracts/OMN-13191.yaml
@@ -1,4 +1,3 @@
----
 # OMN-13191 contract file for omnibase_infra deploy-gate.
 # The canonical ticket contract and PASS receipts live in onex_change_control.
 # This file is the per-repo deploy-evidence carrier only.
@@ -6,30 +5,15 @@ schema_version: "1.0.0"
 ticket_id: "OMN-13191"
 title: "feat(OMN-13191): resolve delegation topics via ServiceTopicRegistry in dispatch result applier"
 summary: >-
-  A2 of epic OMN-13188 (Workstream A — all topics from contracts). runtime/service_dispatch_result_applier.py
-  no longer imports TOPIC_* string constants from event_bus/topic_constants.py; it resolves the 4 delegation
-  intent topics (baseline-comparison-request, delegation-inference-request, delegation-quality-gate-request,
-  delegation-routing-request) through ServiceTopicRegistry (the OMN-5839 contract-sourced registry pattern).
-  For registry completeness all 13 TOPIC_DELEGATION_* topics were added as logical keys (topic_keys.py),
-  suffix constants + provisioned ModelTopicSpec entries (platform_topic_suffixes.py), and from_defaults()
-  mappings (service_topic_registry.py), exported via topics/__init__.py. No constant is deleted from topic_constants.py
-  — that is A4. The cross-repo-declared delegation topics are added to the check_contract_topic_parity.py
-  _LEGACY_ALLOWLIST with structured "contract.yaml in omnimarket repo (cross-repo provisioning)" reasons,
-  mirroring the existing omniintelligence cross-repo entries (this parity scanner reads only omnibase_infra/nodes,
-  so omnimarket-owned contracts are invisible to it).
+  A2 of epic OMN-13188 (Workstream A — all topics from contracts). runtime/service_dispatch_result_applier.py no longer imports TOPIC_* string constants from event_bus/topic_constants.py; it resolves the 4 delegation intent topics (baseline-comparison-request, delegation-inference-request, delegation-quality-gate-request, delegation-routing-request) through ServiceTopicRegistry (the OMN-5839 contract-sourced registry pattern). For registry completeness all 13 TOPIC_DELEGATION_* topics were added as logical keys (topic_keys.py), suffix constants + provisioned ModelTopicSpec entries (platform_topic_suffixes.py), and from_defaults() mappings (service_topic_registry.py), exported via topics/__init__.py. No constant is deleted from topic_constants.py — that is A4. The cross-repo-declared delegation topics are added to the check_contract_topic_parity.py _LEGACY_ALLOWLIST with structured "contract.yaml in omnimarket repo (cross-repo provisioning)" reasons, mirroring the existing omniintelligence cross-repo entries (this parity scanner reads only omnibase_infra/nodes, so omnimarket-owned contracts are invisible to it).
 is_seam_ticket: false
 interface_change: false
 interfaces_touched: []
 evidence_requirements:
   - kind: tests
     description: >-
-      Topic-registry and dispatch-result-applier unit suites pass, including the new no-drift proof TestDelegationTopicRegistryNoDrift.
-      Full unit suite green (24025 passed) with the applier resolving topics via the registry and importing
-      zero TOPIC_* constants; the only failures are pre-existing integration/performance tests that require
-      live PostgreSQL / Kafka / runtime containers / LLM endpoints (environment-dependent, not a regression
-      from this PR).
-    command: "uv run pytest tests/unit/topics/ tests/unit/runtime/test_dispatch_result_applier_topic_routing.py
-      tests/unit/runtime/test_service_dispatch_result_applier.py -q"
+      Topic-registry and dispatch-result-applier unit suites pass, including the new no-drift proof TestDelegationTopicRegistryNoDrift. Full unit suite green (24025 passed) with the applier resolving topics via the registry and importing zero TOPIC_* constants; the only failures are pre-existing integration/performance tests that require live PostgreSQL / Kafka / runtime containers / LLM endpoints (environment-dependent, not a regression from this PR).
+    command: "uv run pytest tests/unit/topics/ tests/unit/runtime/test_dispatch_result_applier_topic_routing.py tests/unit/runtime/test_service_dispatch_result_applier.py -q"
   - kind: ci
     description: >-
       Both topic gates green: no-hardcoded-topics pre-commit hook + check_topic_literals.py arch-invariant.
@@ -41,42 +25,29 @@ emergency_bypass:
 dod_evidence:
   - id: dod-applier-no-topic-constant-imports
     description: >-
-      The applier module imports zero TOPIC_* constants from event_bus/topic_constants.py (grep returns
-      no match).
+      The applier module imports zero TOPIC_* constants from event_bus/topic_constants.py (grep returns no match).
     source: manual
     checks:
       - check_type: command
-        check_value: "! grep -qE 'from omnibase_infra.event_bus.topic_constants import|TOPIC_DELEGATION_'
-          src/omnibase_infra/runtime/service_dispatch_result_applier.py"
+        check_value: "! grep -qE 'from omnibase_infra.event_bus.topic_constants import|TOPIC_DELEGATION_' src/omnibase_infra/runtime/service_dispatch_result_applier.py"
   - id: dod-registry-equals-constant-equals-contract
     description: >-
-      For all 13 delegation keys the registry-resolved string EQUALS the legacy TOPIC_* constant; for
-      the 4 applier topics the registry-resolved string EQUALS the topic declared in the owning omnimarket
-      node_delegation_orchestrator/contract.yaml. Both legs are asserted by the permanent test TestDelegationTopicRegistryNoDrift.
+      For all 13 delegation keys the registry-resolved string EQUALS the legacy TOPIC_* constant; for the 4 applier topics the registry-resolved string EQUALS the topic declared in the owning omnimarket node_delegation_orchestrator/contract.yaml. Both legs are asserted by the permanent test TestDelegationTopicRegistryNoDrift.
     source: manual
     checks:
       - check_type: command
-        check_value: "uv run pytest tests/unit/runtime/test_dispatch_result_applier_topic_routing.py::TestDelegationTopicRegistryNoDrift
-          -q"
+        check_value: "uv run pytest tests/unit/runtime/test_dispatch_result_applier_topic_routing.py::TestDelegationTopicRegistryNoDrift -q"
   - id: dod-topic-gates
     description: >-
-      Topic literal arch-invariant (check_topic_literals.py) and the no-hardcoded-topics pre-commit hook
-      both pass on the changed files.
+      Topic literal arch-invariant (check_topic_literals.py) and the no-hardcoded-topics pre-commit hook both pass on the changed files.
     source: manual
     checks:
       - check_type: command
         check_value: "uv run python scripts/validation/check_topic_literals.py"
   - id: dod-deploy-runtime-readiness
     description: >-
-      Post-merge runtime readiness smoke for the runtime-path touch (runtime/service_dispatch_result_applier.py):
-      imports the migrated applier and the ServiceTopicRegistry inside the deployed omninode-runtime container
-      and resolves a delegation topic, proving the registry-backed import path loads cleanly in the deployed
-      runtime (no broken import from removing the TOPIC_* dependency).
+      Post-merge runtime readiness smoke for the runtime-path touch (runtime/service_dispatch_result_applier.py): imports the migrated applier and the ServiceTopicRegistry inside the deployed omninode-runtime container and resolves a delegation topic, proving the registry-backed import path loads cleanly in the deployed runtime (no broken import from removing the TOPIC_* dependency).
     source: manual
     checks:
       - check_type: command
-        check_value: "docker exec ${RUNTIME_CONTAINER:-omninode-runtime} python -c \"from omnibase_infra.runtime.service_dispatch_result_applier
-          import DispatchResultApplier; from omnibase_infra.topics.service_topic_registry import ServiceTopicRegistry;
-          from omnibase_infra.topics import topic_keys; assert ServiceTopicRegistry.from_defaults().resolve(topic_keys.DELEGATION_ROUTING_REQUEST)
-          == 'onex.cmd.omnibase-infra.delegation-routing-request.v1'; print('OMN-13191 applier+registry
-          deploy readiness smoke ok')\""
+        check_value: "docker exec ${RUNTIME_CONTAINER:-omninode-runtime} python -c \"from omnibase_infra.runtime.service_dispatch_result_applier import DispatchResultApplier; from omnibase_infra.topics.service_topic_registry import ServiceTopicRegistry; from omnibase_infra.topics import topic_keys; assert ServiceTopicRegistry.from_defaults().resolve(topic_keys.DELEGATION_ROUTING_REQUEST) == 'onex.cmd.omnibase-infra.delegation-routing-request.v1'; print('OMN-13191 applier+registry deploy readiness smoke ok')\""

--- a/contracts/OMN-13238.yaml
+++ b/contracts/OMN-13238.yaml
@@ -5,51 +5,18 @@ schema_version: "1.0.0"
 ticket_id: "OMN-13238"
 title: "feat(OMN-13238): contract-declared per-topic config + migrate ALL_PROVISIONED_TOPIC_SPECS"
 summary: >-
-  Ticket 2 of 2 of epic OMN-12651 (W3/W4). W3 makes per-topic provisioning config
-  (partitions / replication_factor / kafka_config) contract-declared: contracts may
-  carry an optional topic_config block on a structured topic item
-  (published_events[].topic_config, or an event_bus dict-form item the extractor reads).
-  The EXISTING ModelContractTopicEntry (omnibase_infra tools/contract_topic_extractor.py)
-  is extended with partitions|replication_factor|kafka_config (PEP 604, frozen, no new
-  parallel model); _extract_raw_topics_from_contract threads the parsed config onto each
-  entry; service_topic_manager._build_topic_specs maps it onto ModelTopicSpec (which
-  already supports all four fields), falling back to ModelTopicSpec defaults when absent.
-  No topic machinery added to omnibase_core. W4 migrates the config-bearing topics whose
-  OWNING omnibase_infra contract already declares a published_events entry (9 topics across
-  5 contracts) into those contracts' published_events[].topic_config — attaching config to
-  pre-existing entries only, so no new published events are synthesized and orchestrator/
-  effect event-purity invariants stay green. ALL_PROVISIONED_TOPIC_SPECS is NOT deleted:
-  118 of the 141 config-bearing source entries are owned by contracts in other repos
-  (omnimemory/omniintelligence/omnimarket build-loop+delegation/omninode routing), emitted
-  directly by the runtime kernel (no owning node contract), or are cmd/intent topics that
-  must not appear in published_events. Forcing those would require cross-repo PRs + an
-  omnibase_core event_bus schema extension and would compound the active omnimarket<->core
-  pin-drift (OMN-13224). Per AC-8/§3.5, ALL_PROVISIONED_TOPIC_SPECS is therefore explicitly
-  annotated TRANSITIONAL (a warm source pending per-repo migration, NOT a standing
-  provisioning authority; the misleading "single source of truth for topic creation"
-  docstring is corrected) with the per-repo follow-up tickets documented in-source and the
-  deletion tracked under OMN-12651. registry_outcome = transitional. Scope = W3/W4.
+  Ticket 2 of 2 of epic OMN-12651 (W3/W4). W3 makes per-topic provisioning config (partitions / replication_factor / kafka_config) contract-declared: contracts may carry an optional topic_config block on a structured topic item (published_events[].topic_config, or an event_bus dict-form item the extractor reads). The EXISTING ModelContractTopicEntry (omnibase_infra tools/contract_topic_extractor.py) is extended with partitions|replication_factor|kafka_config (PEP 604, frozen, no new parallel model); _extract_raw_topics_from_contract threads the parsed config onto each entry; service_topic_manager._build_topic_specs maps it onto ModelTopicSpec (which already supports all four fields), falling back to ModelTopicSpec defaults when absent. No topic machinery added to omnibase_core. W4 migrates the config-bearing topics whose OWNING omnibase_infra contract already declares a published_events entry (9 topics across 5 contracts) into those contracts' published_events[].topic_config — attaching config to pre-existing entries only, so no new published events are synthesized and orchestrator/ effect event-purity invariants stay green. ALL_PROVISIONED_TOPIC_SPECS is NOT deleted: 118 of the 141 config-bearing source entries are owned by contracts in other repos (omnimemory/omniintelligence/omnimarket build-loop+delegation/omninode routing), emitted directly by the runtime kernel (no owning node contract), or are cmd/intent topics that must not appear in published_events. Forcing those would require cross-repo PRs + an omnibase_core event_bus schema extension and would compound the active omnimarket<->core pin-drift (OMN-13224). Per AC-8/§3.5, ALL_PROVISIONED_TOPIC_SPECS is therefore explicitly annotated TRANSITIONAL (a warm source pending per-repo migration, NOT a standing provisioning authority; the misleading "single source of truth for topic creation" docstring is corrected) with the per-repo follow-up tickets documented in-source and the deletion tracked under OMN-12651. registry_outcome = transitional. Scope = W3/W4.
 is_seam_ticket: false
 interface_change: false
 interfaces_touched: []
 evidence_requirements:
   - kind: tests
     description: >-
-      New W3 unit suite (contract topic_config carried onto ModelContractTopicEntry,
-      mapped onto ModelTopicSpec/NewTopic, defaults when absent, merge keeps declared
-      config) and W4 parity suite (every migrated topic resolves the SAME
-      partitions/replication/kafka_config from its owning contract as the legacy registry;
-      registry marked transitional) pass with NO live broker. Existing extractor + topic
-      parity + orchestrator purity + registration/validation orchestrator suites remain
-      green (no regressions; the per-contract-config change is lossless).
+      New W3 unit suite (contract topic_config carried onto ModelContractTopicEntry, mapped onto ModelTopicSpec/NewTopic, defaults when absent, merge keeps declared config) and W4 parity suite (every migrated topic resolves the SAME partitions/replication/kafka_config from its owning contract as the legacy registry; registry marked transitional) pass with NO live broker. Existing extractor + topic parity + orchestrator purity + registration/validation orchestrator suites remain green (no regressions; the per-contract-config change is lossless).
     command: "uv run pytest tests/unit/tools/test_contract_topic_config.py tests/ci/test_topic_config_contract_parity.py tests/unit/tools/test_contract_topic_extractor.py tests/ci/test_topic_parity.py tests/unit/topics/ tests/unit/event_bus/test_service_topic_manager.py tests/unit/nodes/test_orchestrator_purity.py tests/unit/nodes/test_orchestrator_decision_paths.py -q"
   - kind: ci
     description: >-
-      mypy --strict clean on src/ (2452 files); ruff format + check clean; no new onex
-      topic literals in Python (topic_literal_baseline.txt unchanged — new topic config
-      lives in contract YAML only); Topic Contract Parity Gate passes; no new model/enum in
-      omnibase_core; ModelContractTopicEntry extended in omnibase_infra; no backwards-compat
-      re-export of ALL_PROVISIONED_TOPIC_SPECS added.
+      mypy --strict clean on src/ (2452 files); ruff format + check clean; no new onex topic literals in Python (topic_literal_baseline.txt unchanged — new topic config lives in contract YAML only); Topic Contract Parity Gate passes; no new model/enum in omnibase_core; ModelContractTopicEntry extended in omnibase_infra; no backwards-compat re-export of ALL_PROVISIONED_TOPIC_SPECS added.
     command: "uv run mypy src/ --strict"
 emergency_bypass:
   enabled: false
@@ -58,46 +25,35 @@ emergency_bypass:
 dod_evidence:
   - id: dod-w3-config-carry
     description: >-
-      AC-2 topic-spec fidelity: a contract declaring topic_config (e.g. partitions=1,
-      retention.ms=604800000) produces a ModelContractTopicEntry and a
-      ModelTopicSpec/NewTopic with those values; a contract with no topic_config falls back
-      to ModelTopicSpec defaults (partitions=6, replication_factor=1, kafka_config=None).
+      AC-2 topic-spec fidelity: a contract declaring topic_config (e.g. partitions=1, retention.ms=604800000) produces a ModelContractTopicEntry and a ModelTopicSpec/NewTopic with those values; a contract with no topic_config falls back to ModelTopicSpec defaults (partitions=6, replication_factor=1, kafka_config=None).
     source: manual
     checks:
       - check_type: command
         check_value: "uv run pytest tests/unit/tools/test_contract_topic_config.py -q"
   - id: dod-w4-parity
     description: >-
-      Every migrated topic (9 infra-owned, pre-existing published_events entry) resolves the
-      same partitions/replication/kafka_config from its owning contract as the legacy
-      ALL_PROVISIONED_TOPIC_SPECS registry — proving the migration is lossless and free of
-      contract drift.
+      Every migrated topic (9 infra-owned, pre-existing published_events entry) resolves the same partitions/replication/kafka_config from its owning contract as the legacy ALL_PROVISIONED_TOPIC_SPECS registry — proving the migration is lossless and free of contract drift.
     source: manual
     checks:
       - check_type: command
         check_value: "uv run pytest tests/ci/test_topic_config_contract_parity.py -q"
   - id: dod-w4-no-shadow-registry
     description: >-
-      AC-8 no shadow registry: ALL_PROVISIONED_TOPIC_SPECS is explicitly annotated
-      TRANSITIONAL with a deletion ticket (OMN-12651) and per-repo follow-ups, never left as
-      a second standing provisioning authority. The transitional banner + corrected
-      docstring are asserted by test, and no backwards-compat re-export was added.
+      AC-8 no shadow registry: ALL_PROVISIONED_TOPIC_SPECS is explicitly annotated TRANSITIONAL with a deletion ticket (OMN-12651) and per-repo follow-ups, never left as a second standing provisioning authority. The transitional banner + corrected docstring are asserted by test, and no backwards-compat re-export was added.
     source: manual
     checks:
       - check_type: command
         check_value: "grep -q 'TRANSITIONAL' src/omnibase_infra/topics/platform_topic_suffixes.py && ! grep -q 'single source of truth for topic creation' src/omnibase_infra/topics/platform_topic_suffixes.py"
   - id: dod-no-new-topic-literals
     description: >-
-      AC-7 no topic literals: no new onex.*.v* string literals added to Python source; the
-      topic_literal_baseline.txt is unchanged. New per-topic config lives in contract YAML.
+      AC-7 no topic literals: no new onex.*.v* string literals added to Python source; the topic_literal_baseline.txt is unchanged. New per-topic config lives in contract YAML.
     source: manual
     checks:
       - check_type: command
         check_value: "git diff origin/dev -- scripts/validation/topic_literal_baseline.txt | grep -q . && exit 1 || exit 0"
   - id: dod-mypy-strict
     description: >-
-      mypy --strict is clean across src/ with the extended ModelContractTopicEntry and the
-      service_topic_manager config mapping.
+      mypy --strict is clean across src/ with the extended ModelContractTopicEntry and the service_topic_manager config mapping.
     source: manual
     checks:
       - check_type: command

--- a/contracts/OMN-13404.yaml
+++ b/contracts/OMN-13404.yaml
@@ -27,7 +27,14 @@ dod_evidence:
     source: "manual"
     checks:
       - check_type: "command"
-        check_value: "docker run -d --rm --name rte2e-coldtest-pg -e POSTGRES_PASSWORD=test postgres:16; createdb omnidash_analytics; for f in 0007..0019; do psql -d omnidash_analytics -v ON_ERROR_STOP=1 -f $f; done  # all clean (60-cold-apply-proof.log)"
+        check_value: >
+          bash -lc 'docker run -d --rm --name rte2e-coldtest-pg -e POSTGRES_PASSWORD=test postgres:16;
+          trap "docker rm -f rte2e-coldtest-pg >/dev/null 2>&1 || true" EXIT;
+          until docker exec rte2e-coldtest-pg pg_isready -U postgres >/dev/null; do sleep 1; done;
+          docker exec rte2e-coldtest-pg createdb -U postgres omnidash_analytics;
+          for f in docker/migrations/forward/nodes/node_projection_delegation/00{07..19}_*.sql; do
+          docker exec -i rte2e-coldtest-pg psql -U postgres -d omnidash_analytics -v ON_ERROR_STOP=1 < "$f";
+          done'
   - id: "dod-003"
     description: >
       sync-node-migrations --check passes once omnimarket dev carries the fix (after the paired source PR merges). Locally, run against the fixed omnimarket worktree reports in-sync (0 drift) for this file.

--- a/contracts/OMN-13404.yaml
+++ b/contracts/OMN-13404.yaml
@@ -2,23 +2,8 @@ schema_version: "1.0.0"
 ticket_id: "OMN-13404"
 title: "Vendor fixed 0016_delegation_quality_bar_evidence (cold-apply CREATE OR REPLACE VIEW fix) into deployed forward tree"
 summary: >
-  Re-vendors the OMN-13404 fix for node_projection_delegation migration
-  0016_delegation_quality_bar_evidence from the omnimarket source into
-  docker/migrations/forward/nodes/node_projection_delegation/. The source defect:
-  0016 did CREATE OR REPLACE VIEW projection_delegation_quality_gate AS ... that
-  inserted the new avg_actual_score / avg_required_bar columns AHEAD of the
-  existing by_check_type column, which Postgres rejects on a view that already
-  exists (from 0010) with "ERROR: cannot change name of view column
-  by_check_type to avg_actual_score". Under the forward-migration runner's
-  ON_ERROR_STOP=1, that failure blocked 0017/0018/0019 on every cold lane. The
-  fix preserves the 15 existing column ordinals/names from 0010 and APPENDS the
-  two new columns at ordinals 16-17, making CREATE OR REPLACE VIEW legal;
-  name-based projection consumers are unaffected. This PR only updates the single
-  vendored .sql file, produced byte-identically by
-  scripts/sync-node-migrations.sh against the fixed omnimarket worktree. The
-  node-migration-sync CI gate compares the vendored tree against the omnimarket
-  dev tip, so this PR's node-migration-sync check goes green only AFTER the
-  paired omnimarket source PR merges to dev (standard cross-repo vendor ordering).
+  Re-vendors the OMN-13404 fix for node_projection_delegation migration 0016_delegation_quality_bar_evidence from the omnimarket source into docker/migrations/forward/nodes/node_projection_delegation/. The source defect: 0016 did CREATE OR REPLACE VIEW projection_delegation_quality_gate AS ... that inserted the new avg_actual_score / avg_required_bar columns AHEAD of the existing by_check_type column, which Postgres rejects on a view that already exists (from 0010) with "ERROR: cannot change name of view column by_check_type to avg_actual_score". Under the forward-migration runner's ON_ERROR_STOP=1, that failure blocked 0017/0018/0019 on every cold lane. The fix preserves the 15 existing column ordinals/names from 0010 and APPENDS the two new columns at ordinals 16-17, making CREATE OR REPLACE VIEW legal; name-based projection consumers are unaffected. This PR only updates the single vendored .sql file, produced byte-identically by scripts/sync-node-migrations.sh against the fixed omnimarket worktree. The node-migration-sync CI gate compares the vendored tree against the omnimarket dev tip, so this PR's node-migration-sync check goes green only AFTER the paired omnimarket source PR merges to dev (standard cross-repo vendor ordering).
+
 is_seam_ticket: false
 interface_change: false
 interfaces_touched: []
@@ -29,43 +14,32 @@ emergency_bypass:
 dod_evidence:
   - id: "dod-001"
     description: >
-      Vendored 0016 is byte-identical to the fixed omnimarket source (cmp -s
-      passes). Produced via OMNIMARKET_SRC=<fixed omnimarket worktree> bash
-      scripts/sync-node-migrations.sh — only one file changed.
+      Vendored 0016 is byte-identical to the fixed omnimarket source (cmp -s passes). Produced via OMNIMARKET_SRC=<fixed omnimarket worktree> bash scripts/sync-node-migrations.sh — only one file changed.
+
     source: "manual"
     checks:
       - check_type: "command"
         check_value: "cmp -s ../omnimarket/src/omnimarket/nodes/node_projection_delegation/migrations/0016_delegation_quality_bar_evidence.sql docker/migrations/forward/nodes/node_projection_delegation/0016_delegation_quality_bar_evidence.sql"
   - id: "dod-002"
     description: >
-      MANDATORY EMPIRICAL COLD-APPLY PROOF (shared with the omnimarket PR): a
-      scratch throwaway Postgres 16 with a cold omnidash_analytics DB applied
-      node_projection_delegation 0007..0019 in lexical order with
-      psql -v ON_ERROR_STOP=1 -f (exact runner semantics). All 14 applied clean,
-      including the previously-failing 0016_delegation_quality_bar_evidence and
-      0017/0018/0019. Full log:
-      .onex_state/runtime-e2e-2026-06-21/02-dev-deploy/60-cold-apply-proof.log
+      MANDATORY EMPIRICAL COLD-APPLY PROOF (shared with the omnimarket PR): a scratch throwaway Postgres 16 with a cold omnidash_analytics DB applied node_projection_delegation 0007..0019 in lexical order with psql -v ON_ERROR_STOP=1 -f (exact runner semantics). All 14 applied clean, including the previously-failing 0016_delegation_quality_bar_evidence and 0017/0018/0019. Full log: .onex_state/runtime-e2e-2026-06-21/02-dev-deploy/60-cold-apply-proof.log
+
     source: "manual"
     checks:
       - check_type: "command"
         check_value: "docker run -d --rm --name rte2e-coldtest-pg -e POSTGRES_PASSWORD=test postgres:16; createdb omnidash_analytics; for f in 0007..0019; do psql -d omnidash_analytics -v ON_ERROR_STOP=1 -f $f; done  # all clean (60-cold-apply-proof.log)"
   - id: "dod-003"
     description: >
-      sync-node-migrations --check passes once omnimarket dev carries the fix
-      (after the paired source PR merges). Locally, run against the fixed
-      omnimarket worktree reports in-sync (0 drift) for this file.
+      sync-node-migrations --check passes once omnimarket dev carries the fix (after the paired source PR merges). Locally, run against the fixed omnimarket worktree reports in-sync (0 drift) for this file.
+
     source: "manual"
     checks:
       - check_type: "command"
         check_value: "OMNIMARKET_SRC=$OMNI_HOME/omni_worktrees/OMN-13404/omnimarket bash scripts/sync-node-migrations.sh --check"
   - id: "dod-deploy"
     description: >
-      Deploy-gate evidence: pure re-vendor of one idempotent forward-migration
-      SQL file into the deployed forward tree; the forward-migration runner
-      applies it on the next redeploy. No infra source/contract/schema-intent
-      change. The id-based runner (schema_migrations PK, no checksum) applies the
-      fixed 0016 on every lane (none has it applied — it has been failing
-      everywhere). Proven clean on a cold scratch Postgres (dod-002).
+      Deploy-gate evidence: pure re-vendor of one idempotent forward-migration SQL file into the deployed forward tree; the forward-migration runner applies it on the next redeploy. No infra source/contract/schema-intent change. The id-based runner (schema_migrations PK, no checksum) applies the fixed 0016 on every lane (none has it applied — it has been failing everywhere). Proven clean on a cold scratch Postgres (dod-002).
+
     source: "manual"
     checks:
       - check_type: "command"

--- a/contracts/OMN-13531.yaml
+++ b/contracts/OMN-13531.yaml
@@ -2,19 +2,8 @@ schema_version: "1.0.0"
 ticket_id: "OMN-13531"
 title: "CI gate asserting every skill_mapping node_name resolves in the canonical omnimarket node catalog"
 summary: >
-  The pr_review_bot / pr_review / hostile_reviewer skill->node mappings drifted after the OMN-13212
-  decomposition. Live failure (reproduced): `onex skill pr_review_bot` dispatched to node_pr_review_orchestrator
-  and the resolver raised `Unknown node node_pr_review_orchestrator`. Root cause is the inverse of the ticket's
-  stated diagnosis: OMN-13212 (omnimarket commit 0f116553, titled "rebuild node_pr_review_bot canonically ...
-  delete shell") DELETED node_pr_review_bot and node_hostile_reviewer and replaced them with
-  node_pr_review_orchestrator and node_hostile_reviewer_orchestrator. The canonical surviving nodes are the
-  *_orchestrator names, which skill_mapping.yaml already targets. The live `Unknown node` came from a STALE
-  installed omnimarket wheel (0.4.3) whose entry-point catalog predates the decomposition, NOT from a wrong
-  mapping. skill_mapping.yaml is therefore unchanged. This PR adds the missing enforcement that converts the
-  drift class from a dispatch-time-only failure into a CI-caught regression: a fixture asserting every mapped
-  node_name is declared in omnimarket's canonical [project.entry-points."onex.nodes"] catalog, plus a workflow
-  (skill-node-mapping-sync.yml) that wires the omnimarket sibling checkout so the test runs as a real pre-merge
-  gate. No source, migration, schema, endpoint, or env change -- a new test + a new CI workflow only.
+  The pr_review_bot / pr_review / hostile_reviewer skill->node mappings drifted after the OMN-13212 decomposition. Live failure (reproduced): `onex skill pr_review_bot` dispatched to node_pr_review_orchestrator and the resolver raised `Unknown node node_pr_review_orchestrator`. Root cause is the inverse of the ticket's stated diagnosis: OMN-13212 (omnimarket commit 0f116553, titled "rebuild node_pr_review_bot canonically ... delete shell") DELETED node_pr_review_bot and node_hostile_reviewer and replaced them with node_pr_review_orchestrator and node_hostile_reviewer_orchestrator. The canonical surviving nodes are the *_orchestrator names, which skill_mapping.yaml already targets. The live `Unknown node` came from a STALE installed omnimarket wheel (0.4.3) whose entry-point catalog predates the decomposition, NOT from a wrong mapping. skill_mapping.yaml is therefore unchanged. This PR adds the missing enforcement that converts the drift class from a dispatch-time-only failure into a CI-caught regression: a fixture asserting every mapped node_name is declared in omnimarket's canonical [project.entry-points."onex.nodes"] catalog, plus a workflow (skill-node-mapping-sync.yml) that wires the omnimarket sibling checkout so the test runs as a real pre-merge gate. No source, migration, schema, endpoint, or env change -- a new test + a new CI workflow only.
+
 is_seam_ticket: false
 interface_change: false
 interfaces_touched: []
@@ -25,10 +14,7 @@ emergency_bypass:
 dod_evidence:
   - id: "dod-resolver-fixture"
     description: >-
-      test_every_mapped_node_resolves_in_omnimarket_catalog and
-      test_pr_review_and_hostile_skills_target_existing_nodes assert every node_name in skill_mapping.yaml is
-      declared in omnimarket's canonical onex.nodes entry-point catalog (the group cli_node._resolve_packaged_contract
-      resolves against). Resolving the omnimarket source via OMNI_HOME, both tests pass on the corrected mapping.
+      test_every_mapped_node_resolves_in_omnimarket_catalog and test_pr_review_and_hostile_skills_target_existing_nodes assert every node_name in skill_mapping.yaml is declared in omnimarket's canonical onex.nodes entry-point catalog (the group cli_node._resolve_packaged_contract resolves against). Resolving the omnimarket source via OMNI_HOME, both tests pass on the corrected mapping.
     source: "manual"
     status: "verified"
     checks:
@@ -37,9 +23,7 @@ dod_evidence:
           uv run pytest tests/unit/cli/test_cli_skill.py -k "resolves_in_omnimarket_catalog or pr_review_and_hostile_skills_target_existing_nodes" -p no:randomly -q
   - id: "dod-gate-fires-on-drift"
     description: >-
-      The fixture is a real gate, not a vacuous skip: temporarily setting pr_review_bot -> node_pr_review_bot
-      (the deleted shell) fails both new tests with the documented `Unknown node ... at dispatch time` diagnostic;
-      reverted. Proven locally during development.
+      The fixture is a real gate, not a vacuous skip: temporarily setting pr_review_bot -> node_pr_review_bot (the deleted shell) fails both new tests with the documented `Unknown node ... at dispatch time` diagnostic; reverted. Proven locally during development.
     source: "manual"
     status: "verified"
     checks:
@@ -48,11 +32,7 @@ dod_evidence:
           printf 'gate proven: pr_review_bot -> node_pr_review_bot (deleted shell) fails test_every_mapped_node_resolves_in_omnimarket_catalog AND test_pr_review_and_hostile_skills_target_existing_nodes'
   - id: "dod-headless-load-proof"
     description: >-
-      Headless resolution proof after refreshing the catalog to omnimarket dev source: pr_review_bot / pr_review /
-      hostile_reviewer all resolve to a real node with an existing contract.yaml; `onex skill pr_review_bot --dry-run`
-      loads node_pr_review_orchestrator's contract (terminal_event onex.evt.omnimarket.pr-review-bot-completed.v1)
-      with no Unknown-node error. The original failure (installed 0.4.3) was reproduced first:
-      `Unknown node 'node_pr_review_orchestrator'`.
+      Headless resolution proof after refreshing the catalog to omnimarket dev source: pr_review_bot / pr_review / hostile_reviewer all resolve to a real node with an existing contract.yaml; `onex skill pr_review_bot --dry-run` loads node_pr_review_orchestrator's contract (terminal_event onex.evt.omnimarket.pr-review-bot-completed.v1) with no Unknown-node error. The original failure (installed 0.4.3) was reproduced first: `Unknown node 'node_pr_review_orchestrator'`.
     source: "manual"
     status: "verified"
     checks:
@@ -61,9 +41,7 @@ dod_evidence:
           uv run --no-sync python -c "from omnibase_infra.cli.cli_node import _resolve_packaged_contract; from omnibase_infra.cli.cli_skill import load_skill_registry; m={s.skill_name:s.node_name for s in load_skill_registry().skills}; [_resolve_packaged_contract(m[k]) for k in ('pr_review_bot','pr_review','hostile_reviewer')]"
   - id: "dod-ci-gate-wired"
     description: >-
-      skill-node-mapping-sync.yml runs on pull_request (main, dev), push (main), and merge_group, checks out the
-      omnimarket dev sibling (sparse pyproject.toml), and runs the two catalog-resolution tests with OMNIMARKET_SRC
-      pointed at it. Per Rule 5 the detection is wired as a real pre-merge gate, not advisory.
+      skill-node-mapping-sync.yml runs on pull_request (main, dev), push (main), and merge_group, checks out the omnimarket dev sibling (sparse pyproject.toml), and runs the two catalog-resolution tests with OMNIMARKET_SRC pointed at it. Per Rule 5 the detection is wired as a real pre-merge gate, not advisory.
     source: "manual"
     status: "verified"
     checks:

--- a/contracts/OMN-13533.yaml
+++ b/contracts/OMN-13533.yaml
@@ -1,32 +1,28 @@
+---
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 schema_version: '1.0.0'
 ticket_id: OMN-13533
 title: 'Provision validator-catch.v1 + hook-context-injected.v1 via savings-estimation contract'
 summary: >-
-  The savings-estimation runtime consumer subscribes to 6 topics
-  (config.py::_default_consumed_topics) but node_savings_estimation_compute's
-  contract.yaml declared only session-ended.v1 under event_bus.subscribe_topics.
-  The contract-driven topic provisioner (scripts/create_kafka_topics.py) only
-  creates topics it finds in a contract, so validator-catch.v1 and
-  hook-context-injected.v1 were never provisioned on the dev broker. The
-  consumer's subscribe loop then error-stormed "topic not found in cluster"
-  (174 + 220 errors / 15m) on every fresh dev redeploy. Fix: declare all 6
-  consumed topics in the contract subscribe_topics/topics.consumes so the
-  provisioner creates them, and drop the 5 now-contract-covered parity-gate
-  allowlist entries (the two target topics + the three already-provisioned
-  siblings). Adds a unit gate asserting every runtime-consumed topic is declared
-  in the contract.
+  The savings-estimation runtime consumer subscribes to 6 topics (config.py::_default_consumed_topics)
+  but node_savings_estimation_compute's contract.yaml declared only session-ended.v1 under event_bus.subscribe_topics.
+  The contract-driven topic provisioner (scripts/create_kafka_topics.py) only creates topics it finds
+  in a contract, so validator-catch.v1 and hook-context-injected.v1 were never provisioned on the dev
+  broker. The consumer's subscribe loop then error-stormed "topic not found in cluster" (174 + 220 errors
+  / 15m) on every fresh dev redeploy. Fix: declare all 6 consumed topics in the contract subscribe_topics/topics.consumes
+  so the provisioner creates them, and drop the 5 now-contract-covered parity-gate allowlist entries (the
+  two target topics + the three already-provisioned siblings). Adds a unit gate asserting every runtime-consumed
+  topic is declared in the contract.
 is_seam_ticket: false
 interface_change: false
 interfaces_touched: []
 evidence_requirements:
   - kind: tests
     description: >-
-      Config unit suite proves every ConfigSavingsEstimation.consumed_topics
-      entry is present in node_savings_estimation_compute/contract.yaml
-      subscribe_topics (the provisioner-visible surface), gating the
-      consumer-subscribed-but-unprovisioned regression class.
+      Config unit suite proves every ConfigSavingsEstimation.consumed_topics entry is present in node_savings_estimation_compute/contract.yaml
+      subscribe_topics (the provisioner-visible surface), gating the consumer-subscribed-but-unprovisioned
+      regression class.
     command: >-
       uv run pytest tests/unit/observability/test_savings_estimation_config.py -q
   - kind: ci
@@ -39,30 +35,45 @@ emergency_bypass:
 dod_evidence:
   - id: dod-001
     description: >-
-      The contract-driven topic provisioner now extracts
-      onex.evt.omniclaude.validator-catch.v1 and
-      onex.evt.omniclaude.hook-context-injected.v1 from
-      node_savings_estimation_compute/contract.yaml; before this change neither
-      appeared in the provisioner's create plan (dry-run grep returned nothing).
+      The contract-driven topic provisioner now extracts onex.evt.omniclaude.validator-catch.v1 and onex.evt.omniclaude.hook-context-injected.v1
+      from node_savings_estimation_compute/contract.yaml; before this change neither appeared in the provisioner's
+      create plan (dry-run grep returned nothing).
     source: generated
     checks:
       - check_type: command
-        check_value: 'uv run python scripts/create_kafka_topics.py --dry-run --contracts-root src/omnibase_infra/nodes/'
+        check_value: >-
+          grep -q '^status: PASS$' drift/dod_receipts/OMN-13533/dod-001/command.yaml && grep -q '^ticket_id:
+          OMN-13533$' drift/dod_receipts/OMN-13533/dod-001/command.yaml && grep -q '^pr_number: 2092$'
+          drift/dod_receipts/OMN-13533/dod-001/command.yaml
   - id: dod-002
     description: >-
-      test_every_consumed_topic_is_declared_in_contract fails if any
-      runtime-consumed topic is missing from the contract subscribe_topics,
-      gating the OMN-13533 regression so a future consumed-topic addition that
-      skips the contract is caught pre-merge.
+      test_every_consumed_topic_is_declared_in_contract fails if any runtime-consumed topic is missing
+      from the contract subscribe_topics, gating the OMN-13533 regression so a future consumed-topic addition
+      that skips the contract is caught pre-merge.
     source: generated
     checks:
       - check_type: command
-        check_value: 'uv run pytest tests/unit/observability/test_savings_estimation_config.py -q'
+        check_value: >-
+          grep -q '^status: PASS$' drift/dod_receipts/OMN-13533/dod-002/command.yaml && grep -q '^ticket_id:
+          OMN-13533$' drift/dod_receipts/OMN-13533/dod-002/command.yaml && grep -q '^pr_number: 2092$'
+          drift/dod_receipts/OMN-13533/dod-002/command.yaml
   - id: dod-003
     description: >-
-      Parity gate stays green with the two target topics (plus three siblings)
-      moved from allowlist to contract-covered.
+      Parity gate stays green with the two target topics (plus three siblings) moved from allowlist to
+      contract-covered.
     source: generated
     checks:
       - check_type: command
-        check_value: 'uv run python scripts/check_contract_topic_parity.py'
+        check_value: >-
+          grep -q '^status: PASS$' drift/dod_receipts/OMN-13533/dod-003/command.yaml && grep -q '^ticket_id:
+          OMN-13533$' drift/dod_receipts/OMN-13533/dod-003/command.yaml && grep -q '^pr_number: 2092$'
+          drift/dod_receipts/OMN-13533/dod-003/command.yaml
+  - id: dod-occ-pr
+    description: OCC PR carrying this OMN-13533 contract and downstream receipts.
+    source: generated
+    checks:
+      - check_type: command
+        check_value: >-
+          grep -q '^status: PASS$' drift/dod_receipts/OMN-13533/dod-occ-pr/command.yaml && grep -q '^ticket_id:
+          OMN-13533$' drift/dod_receipts/OMN-13533/dod-occ-pr/command.yaml && grep -q '^pr_number: 3021$'
+          drift/dod_receipts/OMN-13533/dod-occ-pr/command.yaml

--- a/contracts/OMN-13533.yaml
+++ b/contracts/OMN-13533.yaml
@@ -1,28 +1,17 @@
----
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 schema_version: '1.0.0'
 ticket_id: OMN-13533
 title: 'Provision validator-catch.v1 + hook-context-injected.v1 via savings-estimation contract'
 summary: >-
-  The savings-estimation runtime consumer subscribes to 6 topics (config.py::_default_consumed_topics)
-  but node_savings_estimation_compute's contract.yaml declared only session-ended.v1 under event_bus.subscribe_topics.
-  The contract-driven topic provisioner (scripts/create_kafka_topics.py) only creates topics it finds
-  in a contract, so validator-catch.v1 and hook-context-injected.v1 were never provisioned on the dev
-  broker. The consumer's subscribe loop then error-stormed "topic not found in cluster" (174 + 220 errors
-  / 15m) on every fresh dev redeploy. Fix: declare all 6 consumed topics in the contract subscribe_topics/topics.consumes
-  so the provisioner creates them, and drop the 5 now-contract-covered parity-gate allowlist entries (the
-  two target topics + the three already-provisioned siblings). Adds a unit gate asserting every runtime-consumed
-  topic is declared in the contract.
+  The savings-estimation runtime consumer subscribes to 6 topics (config.py::_default_consumed_topics) but node_savings_estimation_compute's contract.yaml declared only session-ended.v1 under event_bus.subscribe_topics. The contract-driven topic provisioner (scripts/create_kafka_topics.py) only creates topics it finds in a contract, so validator-catch.v1 and hook-context-injected.v1 were never provisioned on the dev broker. The consumer's subscribe loop then error-stormed "topic not found in cluster" (174 + 220 errors / 15m) on every fresh dev redeploy. Fix: declare all 6 consumed topics in the contract subscribe_topics/topics.consumes so the provisioner creates them, and drop the 5 now-contract-covered parity-gate allowlist entries (the two target topics + the three already-provisioned siblings). Adds a unit gate asserting every runtime-consumed topic is declared in the contract.
 is_seam_ticket: false
 interface_change: false
 interfaces_touched: []
 evidence_requirements:
   - kind: tests
     description: >-
-      Config unit suite proves every ConfigSavingsEstimation.consumed_topics entry is present in node_savings_estimation_compute/contract.yaml
-      subscribe_topics (the provisioner-visible surface), gating the consumer-subscribed-but-unprovisioned
-      regression class.
+      Config unit suite proves every ConfigSavingsEstimation.consumed_topics entry is present in node_savings_estimation_compute/contract.yaml subscribe_topics (the provisioner-visible surface), gating the consumer-subscribed-but-unprovisioned regression class.
     command: >-
       uv run pytest tests/unit/observability/test_savings_estimation_config.py -q
   - kind: ci
@@ -35,45 +24,32 @@ emergency_bypass:
 dod_evidence:
   - id: dod-001
     description: >-
-      The contract-driven topic provisioner now extracts onex.evt.omniclaude.validator-catch.v1 and onex.evt.omniclaude.hook-context-injected.v1
-      from node_savings_estimation_compute/contract.yaml; before this change neither appeared in the provisioner's
-      create plan (dry-run grep returned nothing).
+      The contract-driven topic provisioner now extracts onex.evt.omniclaude.validator-catch.v1 and onex.evt.omniclaude.hook-context-injected.v1 from node_savings_estimation_compute/contract.yaml; before this change neither appeared in the provisioner's create plan (dry-run grep returned nothing).
     source: generated
     checks:
       - check_type: command
         check_value: >-
-          grep -q '^status: PASS$' drift/dod_receipts/OMN-13533/dod-001/command.yaml && grep -q '^ticket_id:
-          OMN-13533$' drift/dod_receipts/OMN-13533/dod-001/command.yaml && grep -q '^pr_number: 2092$'
-          drift/dod_receipts/OMN-13533/dod-001/command.yaml
+          grep -q '^status: PASS$' drift/dod_receipts/OMN-13533/dod-001/command.yaml && grep -q '^ticket_id: OMN-13533$' drift/dod_receipts/OMN-13533/dod-001/command.yaml && grep -q '^pr_number: 2092$' drift/dod_receipts/OMN-13533/dod-001/command.yaml
   - id: dod-002
     description: >-
-      test_every_consumed_topic_is_declared_in_contract fails if any runtime-consumed topic is missing
-      from the contract subscribe_topics, gating the OMN-13533 regression so a future consumed-topic addition
-      that skips the contract is caught pre-merge.
+      test_every_consumed_topic_is_declared_in_contract fails if any runtime-consumed topic is missing from the contract subscribe_topics, gating the OMN-13533 regression so a future consumed-topic addition that skips the contract is caught pre-merge.
     source: generated
     checks:
       - check_type: command
         check_value: >-
-          grep -q '^status: PASS$' drift/dod_receipts/OMN-13533/dod-002/command.yaml && grep -q '^ticket_id:
-          OMN-13533$' drift/dod_receipts/OMN-13533/dod-002/command.yaml && grep -q '^pr_number: 2092$'
-          drift/dod_receipts/OMN-13533/dod-002/command.yaml
+          grep -q '^status: PASS$' drift/dod_receipts/OMN-13533/dod-002/command.yaml && grep -q '^ticket_id: OMN-13533$' drift/dod_receipts/OMN-13533/dod-002/command.yaml && grep -q '^pr_number: 2092$' drift/dod_receipts/OMN-13533/dod-002/command.yaml
   - id: dod-003
     description: >-
-      Parity gate stays green with the two target topics (plus three siblings) moved from allowlist to
-      contract-covered.
+      Parity gate stays green with the two target topics (plus three siblings) moved from allowlist to contract-covered.
     source: generated
     checks:
       - check_type: command
         check_value: >-
-          grep -q '^status: PASS$' drift/dod_receipts/OMN-13533/dod-003/command.yaml && grep -q '^ticket_id:
-          OMN-13533$' drift/dod_receipts/OMN-13533/dod-003/command.yaml && grep -q '^pr_number: 2092$'
-          drift/dod_receipts/OMN-13533/dod-003/command.yaml
+          grep -q '^status: PASS$' drift/dod_receipts/OMN-13533/dod-003/command.yaml && grep -q '^ticket_id: OMN-13533$' drift/dod_receipts/OMN-13533/dod-003/command.yaml && grep -q '^pr_number: 2092$' drift/dod_receipts/OMN-13533/dod-003/command.yaml
   - id: dod-occ-pr
     description: OCC PR carrying this OMN-13533 contract and downstream receipts.
     source: generated
     checks:
       - check_type: command
         check_value: >-
-          grep -q '^status: PASS$' drift/dod_receipts/OMN-13533/dod-occ-pr/command.yaml && grep -q '^ticket_id:
-          OMN-13533$' drift/dod_receipts/OMN-13533/dod-occ-pr/command.yaml && grep -q '^pr_number: 3021$'
-          drift/dod_receipts/OMN-13533/dod-occ-pr/command.yaml
+          grep -q '^status: PASS$' drift/dod_receipts/OMN-13533/dod-occ-pr/command.yaml && grep -q '^ticket_id: OMN-13533$' drift/dod_receipts/OMN-13533/dod-occ-pr/command.yaml && grep -q '^pr_number: 3021$' drift/dod_receipts/OMN-13533/dod-occ-pr/command.yaml

--- a/contracts/OMN-13533.yaml
+++ b/contracts/OMN-13533.yaml
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+schema_version: '1.0.0'
+ticket_id: OMN-13533
+title: 'Provision validator-catch.v1 + hook-context-injected.v1 via savings-estimation contract'
+summary: >-
+  The savings-estimation runtime consumer subscribes to 6 topics
+  (config.py::_default_consumed_topics) but node_savings_estimation_compute's
+  contract.yaml declared only session-ended.v1 under event_bus.subscribe_topics.
+  The contract-driven topic provisioner (scripts/create_kafka_topics.py) only
+  creates topics it finds in a contract, so validator-catch.v1 and
+  hook-context-injected.v1 were never provisioned on the dev broker. The
+  consumer's subscribe loop then error-stormed "topic not found in cluster"
+  (174 + 220 errors / 15m) on every fresh dev redeploy. Fix: declare all 6
+  consumed topics in the contract subscribe_topics/topics.consumes so the
+  provisioner creates them, and drop the 5 now-contract-covered parity-gate
+  allowlist entries (the two target topics + the three already-provisioned
+  siblings). Adds a unit gate asserting every runtime-consumed topic is declared
+  in the contract.
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: tests
+    description: >-
+      Config unit suite proves every ConfigSavingsEstimation.consumed_topics
+      entry is present in node_savings_estimation_compute/contract.yaml
+      subscribe_topics (the provisioner-visible surface), gating the
+      consumer-subscribed-but-unprovisioned regression class.
+    command: >-
+      uv run pytest tests/unit/observability/test_savings_estimation_config.py -q
+  - kind: ci
+    description: CI pipeline green on PR
+    command: gh pr checks <PR> --repo OmniNode-ai/omnibase_infra
+emergency_bypass:
+  enabled: false
+  justification: ''
+  follow_up_ticket_id: ''
+dod_evidence:
+  - id: dod-001
+    description: >-
+      The contract-driven topic provisioner now extracts
+      onex.evt.omniclaude.validator-catch.v1 and
+      onex.evt.omniclaude.hook-context-injected.v1 from
+      node_savings_estimation_compute/contract.yaml; before this change neither
+      appeared in the provisioner's create plan (dry-run grep returned nothing).
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run python scripts/create_kafka_topics.py --dry-run --contracts-root src/omnibase_infra/nodes/'
+  - id: dod-002
+    description: >-
+      test_every_consumed_topic_is_declared_in_contract fails if any
+      runtime-consumed topic is missing from the contract subscribe_topics,
+      gating the OMN-13533 regression so a future consumed-topic addition that
+      skips the contract is caught pre-merge.
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/unit/observability/test_savings_estimation_config.py -q'
+  - id: dod-003
+    description: >-
+      Parity gate stays green with the two target topics (plus three siblings)
+      moved from allowlist to contract-covered.
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run python scripts/check_contract_topic_parity.py'

--- a/docker/migrations/skip-manifest.yaml
+++ b/docker/migrations/skip-manifest.yaml
@@ -30,5 +30,4 @@
 # EXIT CODES for run-forward-migrations.sh
 #   0 — all migrations applied (or skipped by this manifest)
 #   1 — migration failure (nonzero psql exit)
-
 skipped_migrations: []

--- a/scripts/check_contract_topic_parity.py
+++ b/scripts/check_contract_topic_parity.py
@@ -427,12 +427,13 @@ _LEGACY_ALLOWLIST: dict[str, str] = {
     "onex.evt.omnibase-infra.llm-endpoint-health.v1": "pre-existing parity gap; declared in services/topics.yaml (service-emitted, not node-owned); needs contract.yaml producer | owner: jonah | expiry: 2026-09-01 | epic: OMN-13188",
     "onex.evt.omnibase-infra.routing-decided.v1": "pre-existing parity gap; routing decision event; needs contract.yaml producer | owner: jonah | expiry: 2026-09-01 | epic: OMN-13188",
     "onex.evt.omniclaude.context-enrichment.v1": "pre-existing parity gap; omniclaude hook event (cross-repo); contract.yaml owned in omniclaude | owner: jonah | expiry: 2026-09-01 | epic: OMN-13188",
-    "onex.evt.omniclaude.hook-context-injected.v1": "pre-existing parity gap; omniclaude hook event (cross-repo); contract.yaml owned in omniclaude | owner: jonah | expiry: 2026-09-01 | epic: OMN-13188",
+    # OMN-13533: hook-context-injected.v1, validator-catch.v1, pattern-enforcement.v1,
+    # session-outcome.v1, dispatch-outcome-evaluated.v1 are now declared in
+    # node_savings_estimation_compute/contract.yaml subscribe_topics (the savings
+    # estimation consumer's real subscriptions), so they are contract-covered and
+    # no longer need allowlisting. The contract-driven provisioner now creates them
+    # on the broker, fixing the consumer-start "topic not found in cluster" storm.
     "onex.evt.omniclaude.injection-recorded.v1": "pre-existing parity gap; omniclaude hook event (cross-repo); contract.yaml owned in omniclaude | owner: jonah | expiry: 2026-09-01 | epic: OMN-13188",
-    "onex.evt.omniclaude.pattern-enforcement.v1": "pre-existing parity gap; omniclaude hook event (cross-repo); contract.yaml owned in omniclaude | owner: jonah | expiry: 2026-09-01 | epic: OMN-13188",
-    "onex.evt.omniclaude.session-outcome.v1": "pre-existing parity gap; omniclaude session-outcome event (cross-repo); contract.yaml owned in omniclaude | owner: jonah | expiry: 2026-09-01 | epic: OMN-13188",
-    "onex.evt.omniclaude.validator-catch.v1": "pre-existing parity gap; omniclaude hook event (cross-repo); contract.yaml owned in omniclaude | owner: jonah | expiry: 2026-09-01 | epic: OMN-13188",
-    "onex.evt.omniintelligence.dispatch-outcome-evaluated.v1": "pre-existing parity gap; omniintelligence evaluation event (cross-repo); contract.yaml owned in omniintelligence | owner: jonah | expiry: 2026-09-01 | epic: OMN-13188",
     "onex.evt.omniweb.waitlist-signup.v1": "pre-existing parity gap; omniweb waitlist signup event (cross-repo); consumer: waitlist-signup-notifier | owner: jonah | expiry: 2026-09-01 | epic: OMN-13188",
 }
 # fmt: on

--- a/scripts/check_subscribe_wiring_health.py
+++ b/scripts/check_subscribe_wiring_health.py
@@ -57,10 +57,15 @@ _EXTERNAL_PUBLISHER_ALLOWLIST: dict[str, str] = {
     # omniclaude publishes these via hook scripts, not contract.yaml
     "onex.evt.omniclaude.session-started.v1": "Published by omniclaude hooks, not contract-declared | owner: jonah | expiry: 2026-12-01",
     "onex.evt.omniclaude.session-ended.v1": "Published by omniclaude SessionEnd hook, not contract-declared | owner: jonah | expiry: 2026-12-01",
+    "onex.evt.omniclaude.session-outcome.v1": "Published by omniclaude SessionEnd hook outcome processing, not contract-declared | owner: jonah | expiry: 2026-12-01",
     "onex.evt.omniclaude.prompt-submitted.v1": "Published by omniclaude hooks, not contract-declared | owner: jonah | expiry: 2026-12-01",
     "onex.evt.omniclaude.tool-executed.v1": "Published by omniclaude hooks, not contract-declared | owner: jonah | expiry: 2026-12-01",
+    "onex.evt.omniclaude.hook-context-injected.v1": "Published by omniclaude hook context injection, not contract-declared | owner: jonah | expiry: 2026-12-01",
+    "onex.evt.omniclaude.validator-catch.v1": "Published by omniclaude validator hooks, not contract-declared | owner: jonah | expiry: 2026-12-01",
+    "onex.evt.omniclaude.pattern-enforcement.v1": "Published by omniclaude pattern enforcement hooks, not contract-declared | owner: jonah | expiry: 2026-12-01",
     "onex.cmd.omniintelligence.claude-hook-event.v1": "Published by omniclaude hooks | owner: jonah | expiry: 2026-12-01",
     "onex.cmd.omniintelligence.tool-content.v1": "Published by omniclaude hooks | owner: jonah | expiry: 2026-12-01",
+    "onex.evt.omniintelligence.dispatch-outcome-evaluated.v1": "Published by omniintelligence dispatch evaluation, not an omnibase_infra node contract | owner: jonah | expiry: 2026-12-01",
     # GitHub webhooks are external triggers
     "onex.evt.github.pr-webhook.v1": "Published by GitHub webhook relay, not a node | owner: jonah | expiry: 2026-12-01",
     "onex.evt.github.push-webhook.v1": "Published by GitHub webhook relay | owner: jonah | expiry: 2026-12-01",

--- a/scripts/check_test_failure_ratchet.py
+++ b/scripts/check_test_failure_ratchet.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode Team
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 """PR ratchet check — OMN-13027.
 

--- a/scripts/lane_census_event.py
+++ b/scripts/lane_census_event.py
@@ -128,7 +128,6 @@ def build_event(
 
 
 def main() -> int:
-
     host = os.environ.get("LANE_CENSUS_HOST", "")
     if not host:
         # Fail-fast: never silently fabricate a host into the alert_key.

--- a/scripts/publish_test_failure_baseline.py
+++ b/scripts/publish_test_failure_baseline.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode Team
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 """Dev-baseline publisher — OMN-13027.
 

--- a/scripts/validation/validate_clean_root.py
+++ b/scripts/validation/validate_clean_root.py
@@ -147,8 +147,6 @@ ALLOWED_ROOT_DIRECTORIES: frozenset[str] = frozenset(
         "bin",
         "deploy",
         "observability",
-        # Immutable DoD receipt evidence lives under drift/dod_receipts.
-        "drift",
         # Docker workspace staging: stage_workspace.sh rsync target (OMN-9470)
         "workspace",
         # Pre-commit hook scripts directory

--- a/src/omnibase_infra/enums/generated/enum_omniclaude_topic.py
+++ b/src/omnibase_infra/enums/generated/enum_omniclaude_topic.py
@@ -19,5 +19,9 @@ class EnumOmniclaudeTopic(str, Enum):
     Members are sorted by (kind, event_name, version).
     """
     EVT_CONTEXT_AUDIT_DLQ_V1 = "onex.evt.omniclaude.context-audit-dlq.v1"  # onex.evt.omniclaude.context-audit-dlq.v1
+    EVT_HOOK_CONTEXT_INJECTED_V1 = "onex.evt.omniclaude.hook-context-injected.v1"  # onex.evt.omniclaude.hook-context-injected.v1
+    EVT_PATTERN_ENFORCEMENT_V1 = "onex.evt.omniclaude.pattern-enforcement.v1"  # onex.evt.omniclaude.pattern-enforcement.v1
     EVT_SESSION_COORDINATION_SIGNAL_V1 = "onex.evt.omniclaude.session-coordination-signal.v1"  # onex.evt.omniclaude.session-coordination-signal.v1
     EVT_SESSION_ENDED_V1 = "onex.evt.omniclaude.session-ended.v1"  # onex.evt.omniclaude.session-ended.v1
+    EVT_SESSION_OUTCOME_V1 = "onex.evt.omniclaude.session-outcome.v1"  # onex.evt.omniclaude.session-outcome.v1
+    EVT_VALIDATOR_CATCH_V1 = "onex.evt.omniclaude.validator-catch.v1"  # onex.evt.omniclaude.validator-catch.v1

--- a/src/omnibase_infra/enums/generated/enum_omniintelligence_topic.py
+++ b/src/omnibase_infra/enums/generated/enum_omniintelligence_topic.py
@@ -18,5 +18,6 @@ class EnumOmniintelligenceTopic(str, Enum):
     All values are raw topic strings as declared in contract.yaml.
     Members are sorted by (kind, event_name, version).
     """
+    EVT_DISPATCH_OUTCOME_EVALUATED_V1 = "onex.evt.omniintelligence.dispatch-outcome-evaluated.v1"  # onex.evt.omniintelligence.dispatch-outcome-evaluated.v1
     EVT_LLM_CALL_COMPLETED_V1 = "onex.evt.omniintelligence.llm-call-completed.v1"  # onex.evt.omniintelligence.llm-call-completed.v1
     EVT_WASTE_DETECTED_V1 = "onex.evt.omniintelligence.waste-detected.v1"  # onex.evt.omniintelligence.waste-detected.v1

--- a/src/omnibase_infra/nodes/node_bus_forwarder_effect/__init__.py
+++ b/src/omnibase_infra/nodes/node_bus_forwarder_effect/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 """Tenant gateway bus forwarder effect node."""
 

--- a/src/omnibase_infra/nodes/node_bus_forwarder_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_bus_forwarder_effect/contract.yaml
@@ -92,6 +92,7 @@ metadata:
   description: "Hybrid gateway local runtime bus forwarder"
   author: "OmniNode Team"
   created: "2026-06-10"
+  updated: "2026-06-24"
   tags:
     - gateway
     - event-bus

--- a/src/omnibase_infra/nodes/node_bus_forwarder_effect/handlers/__init__.py
+++ b/src/omnibase_infra/nodes/node_bus_forwarder_effect/handlers/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 """Pure transform handlers for the gateway forwarder."""
 

--- a/src/omnibase_infra/nodes/node_bus_forwarder_effect/models/__init__.py
+++ b/src/omnibase_infra/nodes/node_bus_forwarder_effect/models/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 """Models for the tenant gateway bus forwarder."""
 

--- a/src/omnibase_infra/nodes/node_bus_forwarder_effect/models/model_gateway_cloud_bus_config.py
+++ b/src/omnibase_infra/nodes/node_bus_forwarder_effect/models/model_gateway_cloud_bus_config.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 """Cloud bus config model for the gateway forwarder."""
 

--- a/src/omnibase_infra/nodes/node_bus_forwarder_effect/models/model_gateway_envelope.py
+++ b/src/omnibase_infra/nodes/node_bus_forwarder_effect/models/model_gateway_envelope.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 """Canonical gateway envelope model."""
 

--- a/src/omnibase_infra/nodes/node_bus_forwarder_effect/models/model_gateway_forwarder_config.py
+++ b/src/omnibase_infra/nodes/node_bus_forwarder_effect/models/model_gateway_forwarder_config.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 """Typed config for the tenant gateway bus forwarder."""
 

--- a/src/omnibase_infra/nodes/node_bus_forwarder_effect/models/model_gateway_mirror_topics.py
+++ b/src/omnibase_infra/nodes/node_bus_forwarder_effect/models/model_gateway_mirror_topics.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 """Mirror topic config model for the gateway forwarder."""
 

--- a/src/omnibase_infra/nodes/node_bus_forwarder_effect/models/model_gateway_tenant_identity.py
+++ b/src/omnibase_infra/nodes/node_bus_forwarder_effect/models/model_gateway_tenant_identity.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 """Tenant identity model for the gateway forwarder."""
 

--- a/src/omnibase_infra/nodes/node_bus_forwarder_effect/node.py
+++ b/src/omnibase_infra/nodes/node_bus_forwarder_effect/node.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 """Bus forwarder effect node.
 

--- a/src/omnibase_infra/nodes/node_bus_forwarder_effect/services/__init__.py
+++ b/src/omnibase_infra/nodes/node_bus_forwarder_effect/services/__init__.py
@@ -1,3 +1,3 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 """Services for gateway bus forwarding and topic transforms."""

--- a/src/omnibase_infra/nodes/node_bus_forwarder_effect/services/service_gateway_forwarder.py
+++ b/src/omnibase_infra/nodes/node_bus_forwarder_effect/services/service_gateway_forwarder.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 """Executable bus-to-bus gateway forwarder service."""
 

--- a/src/omnibase_infra/nodes/node_bus_forwarder_effect/services/service_gateway_topic_transform.py
+++ b/src/omnibase_infra/nodes/node_bus_forwarder_effect/services/service_gateway_topic_transform.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 """Tenant-prefix transform helpers for the gateway trust boundary."""
 

--- a/src/omnibase_infra/nodes/node_savings_estimation_compute/contract.yaml
+++ b/src/omnibase_infra/nodes/node_savings_estimation_compute/contract.yaml
@@ -54,8 +54,21 @@ event_bus:
     major: 1
     minor: 0
     patch: 0
+  # OMN-13533: declare every topic the savings-estimation runtime consumer
+  # actually subscribes to (see services/observability/savings_estimation/
+  # config.py::_default_consumed_topics). Prior to this the contract declared
+  # only session-ended.v1, so the contract-driven topic provisioner
+  # (scripts/create_kafka_topics.py) never created validator-catch.v1 or
+  # hook-context-injected.v1 on the broker — the consumer's subscribe loop then
+  # error-stormed "topic not found in cluster" on every fresh redeploy.
   subscribe_topics:
     - "onex.evt.omniclaude.session-ended.v1"
+    - "onex.evt.omniintelligence.llm-call-completed.v1"
+    - "onex.evt.omniintelligence.dispatch-outcome-evaluated.v1"
+    - "onex.evt.omniclaude.session-outcome.v1"
+    - "onex.evt.omniclaude.hook-context-injected.v1"
+    - "onex.evt.omniclaude.validator-catch.v1"
+    - "onex.evt.omniclaude.pattern-enforcement.v1"
   publish_topics:
     - "onex.evt.omnibase-infra.savings-estimated.v1"
 topics:
@@ -66,6 +79,18 @@ topics:
   consumes:
     - topic: "onex.evt.omniclaude.session-ended.v1"
       description: "Session ended events that trigger savings estimation computation"
+    - topic: "onex.evt.omniintelligence.llm-call-completed.v1"
+      description: "LLM call completion events correlated by session_id for cost attribution"
+    - topic: "onex.evt.omniintelligence.dispatch-outcome-evaluated.v1"
+      description: "Dispatch outcome evaluation events correlated by session_id"
+    - topic: "onex.evt.omniclaude.session-outcome.v1"
+      description: "Session outcome events that trigger finalization of a savings estimate"
+    - topic: "onex.evt.omniclaude.hook-context-injected.v1"
+      description: "Hook context injection signals accumulated into injection effectiveness"
+    - topic: "onex.evt.omniclaude.validator-catch.v1"
+      description: "Validator catch events contributing heuristic avoided-rework savings"
+    - topic: "onex.evt.omniclaude.pattern-enforcement.v1"
+      description: "Pattern enforcement events contributing heuristic avoided-rework savings"
 error_handling:
   retry_policy:
     max_retries: 0

--- a/src/omnibase_infra/runtime/render_secret_resolver_config.py
+++ b/src/omnibase_infra/runtime/render_secret_resolver_config.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 """Render the deployed secret resolver config for runtime boot.
 

--- a/src/omnibase_infra/runtime/service_kernel.py
+++ b/src/omnibase_infra/runtime/service_kernel.py
@@ -1626,28 +1626,14 @@ async def bootstrap() -> int:
                     ServiceSavingsEstimator,
                     decode_event_message,
                 )
-                from omnibase_infra.topics import topic_keys
-                from omnibase_infra.topics.service_topic_registry import (
-                    ServiceTopicRegistry,
-                )
 
                 _savings_config = ConfigSavingsEstimation()
                 _savings_estimator = ServiceSavingsEstimator(
                     config=_savings_config,
                 )
-                _savings_topic = ServiceTopicRegistry.from_defaults().resolve(
-                    topic_keys.SAVINGS_ESTIMATED
-                )
+                _savings_topic = _savings_config.produce_topic
 
-                # Subscribe to input topics (resolved via topic registry)
-                _savings_registry = ServiceTopicRegistry.from_defaults()
-                _savings_input_topics = [
-                    _savings_registry.resolve(topic_keys.LLM_CALL_COMPLETED),
-                    _savings_registry.resolve(topic_keys.SESSION_OUTCOME_CANONICAL),
-                    _savings_registry.resolve(topic_keys.HOOK_CONTEXT_INJECTED),
-                    _savings_registry.resolve(topic_keys.VALIDATOR_CATCH),
-                    _savings_registry.resolve(topic_keys.PATTERN_ENFORCEMENT),
-                ]
+                _savings_input_topics = list(_savings_config.consumed_topics)
 
                 async def _savings_consumer_loop() -> None:
                     """Consume input events and produce savings estimates."""

--- a/src/omnibase_infra/services/observability/agent_actions/tests/test_consumer.py
+++ b/src/omnibase_infra/services/observability/agent_actions/tests/test_consumer.py
@@ -23,6 +23,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
+from aiokafka import AIOKafkaConsumer, AIOKafkaProducer
 
 from omnibase_core.errors import OnexError
 from omnibase_core.types import JsonType
@@ -1503,10 +1504,10 @@ class TestConsumerLifecycle:
                     mock_pool.return_value = AsyncMock()
                     mock_pool.return_value.close = AsyncMock()
 
-                    mock_kafka_instance = AsyncMock()
+                    mock_kafka_instance = AsyncMock(spec_set=AIOKafkaConsumer)
                     mock_kafka.return_value = mock_kafka_instance
 
-                    mock_producer_instance = AsyncMock()
+                    mock_producer_instance = AsyncMock(spec_set=AIOKafkaProducer)
                     mock_producer.return_value = mock_producer_instance
 
                     consumer = AgentActionsConsumer(mock_config)
@@ -1563,7 +1564,7 @@ class TestCommitOffsets:
         consumer: AgentActionsConsumer,
     ) -> None:
         """Commit should use offset + 1 (next offset to consume)."""
-        mock_kafka = AsyncMock()
+        mock_kafka = AsyncMock(spec_set=AIOKafkaConsumer)
         consumer._consumer = mock_kafka
 
         from aiokafka import TopicPartition
@@ -1592,7 +1593,7 @@ class TestCommitOffsets:
         consumer: AgentActionsConsumer,
     ) -> None:
         """Empty offsets dict should skip commit call."""
-        mock_kafka = AsyncMock()
+        mock_kafka = AsyncMock(spec_set=AIOKafkaConsumer)
         consumer._consumer = mock_kafka
 
         await consumer._commit_offsets({}, uuid4())
@@ -1607,7 +1608,7 @@ class TestCommitOffsets:
         """Kafka commit errors should be logged but not raised."""
         from aiokafka.errors import KafkaError
 
-        mock_kafka = AsyncMock()
+        mock_kafka = AsyncMock(spec_set=AIOKafkaConsumer)
         mock_kafka.commit = AsyncMock(side_effect=KafkaError())
         consumer._consumer = mock_kafka
 
@@ -1682,7 +1683,7 @@ class TestKafkaReconnectHealth:
             consumer._running = False
             raise TimeoutError
 
-        mock_kafka = AsyncMock()
+        mock_kafka = AsyncMock(spec_set=AIOKafkaConsumer)
         consumer._consumer = mock_kafka
 
         with patch(
@@ -1722,7 +1723,7 @@ class TestKafkaReconnectHealth:
                 consumer._running = False
             raise TimeoutError
 
-        mock_kafka = AsyncMock()
+        mock_kafka = AsyncMock(spec_set=AIOKafkaConsumer)
         consumer._consumer = mock_kafka
 
         with patch(

--- a/tests/ci/test_test_failure_ratchet.py
+++ b/tests/ci/test_test_failure_ratchet.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode Team
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 """Unit tests for scripts/check_test_failure_ratchet.py and
 scripts/publish_test_failure_baseline.py (OMN-13027).

--- a/tests/ci/test_vllm_qwen_coder_service_unit.py
+++ b/tests/ci/test_vllm_qwen_coder_service_unit.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 """Regression guard for the Qwen coder vLLM systemd unit."""
 

--- a/tests/integration/gateway/test_bus_forwarder_contract_integration.py
+++ b/tests/integration/gateway/test_bus_forwarder_contract_integration.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations

--- a/tests/integration/test_omn12816_main_promotion_coverage.py
+++ b/tests/integration/test_omn12816_main_promotion_coverage.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
 from pathlib import Path

--- a/tests/unit/docker/test_runtime_entrypoint_volume_bootstrap.py
+++ b/tests/unit/docker/test_runtime_entrypoint_volume_bootstrap.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 """Regression tests for runtime fresh-volume bootstrap."""
 

--- a/tests/unit/nodes/node_bus_forwarder_effect/__init__.py
+++ b/tests/unit/nodes/node_bus_forwarder_effect/__init__.py
@@ -1,3 +1,3 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 """Tests for node_bus_forwarder_effect."""

--- a/tests/unit/nodes/node_bus_forwarder_effect/test_gateway_forwarder_config.py
+++ b/tests/unit/nodes/node_bus_forwarder_effect/test_gateway_forwarder_config.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations

--- a/tests/unit/nodes/node_bus_forwarder_effect/test_gateway_forwarder_service.py
+++ b/tests/unit/nodes/node_bus_forwarder_effect/test_gateway_forwarder_service.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations

--- a/tests/unit/observability/test_savings_estimation_config.py
+++ b/tests/unit/observability/test_savings_estimation_config.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 from pydantic import ValidationError
 
@@ -92,4 +94,53 @@ class TestSavingsEstimationConfig:
 
         assert registry.resolve(topic_keys.DISPATCH_OUTCOME_EVALUATED) in (
             cfg.consumed_topics
+        )
+
+    def test_every_consumed_topic_is_declared_in_contract(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Gate the OMN-13533 regression class.
+
+        The savings-estimation runtime consumer subscribes to the topics in
+        ``ConfigSavingsEstimation.consumed_topics``. The contract-driven topic
+        provisioner (``scripts/create_kafka_topics.py``) only creates topics it
+        finds in a contract's ``event_bus.subscribe_topics``. If a consumed topic
+        is NOT declared in the contract, the broker never provisions it and the
+        consumer's subscribe loop error-storms ``topic not found in cluster`` on
+        every fresh redeploy (validator-catch.v1 + hook-context-injected.v1 did
+        exactly this: 174 + 220 errors / 15m).
+
+        This test fails if any runtime-consumed topic is missing from the
+        node_savings_estimation_compute contract's declared subscribe_topics.
+        """
+        import yaml
+
+        from omnibase_infra.services.observability.savings_estimation.config import (
+            ConfigSavingsEstimation,
+        )
+
+        monkeypatch.setenv(
+            "OMNIBASE_INFRA_SAVINGS_KAFKA_BOOTSTRAP_SERVERS", "broker-specific:9092"
+        )
+
+        contract_path = (
+            Path(__file__).resolve().parents[3]
+            / "src"
+            / "omnibase_infra"
+            / "nodes"
+            / "node_savings_estimation_compute"
+            / "contract.yaml"
+        )
+        contract = yaml.safe_load(contract_path.read_text())
+        declared = set(contract["event_bus"]["subscribe_topics"])
+
+        cfg = ConfigSavingsEstimation()
+        consumed = set(cfg.consumed_topics)
+
+        undeclared = consumed - declared
+        assert not undeclared, (
+            "Runtime-consumed topics are not declared in "
+            "node_savings_estimation_compute/contract.yaml subscribe_topics, so "
+            "the contract-driven provisioner will not create them on the broker "
+            f"(consumer-start error storm risk, OMN-13533): {sorted(undeclared)}"
         )

--- a/tests/unit/runtime/test_render_secret_resolver_config.py
+++ b/tests/unit/runtime/test_render_secret_resolver_config.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 """Tests for runtime secret resolver config rendering."""
 

--- a/tests/unit/scripts/validation/test_check_no_infra_inmemory_import.py
+++ b/tests/unit/scripts/validation/test_check_no_infra_inmemory_import.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
 """Tests for the OMN-13419 single-canonical in-memory bus import gate."""
 
 from __future__ import annotations


### PR DESCRIPTION
## OMN-13533 — Dev runtime consumer-start error storm: validator-catch.v1 + hook-context-injected.v1 "topic not found in cluster"

### Root cause (live-verified)
The savings-estimation runtime consumer (`services/observability/savings_estimation/consumer.py`) subscribes to **6 topics** via `config.py::_default_consumed_topics`, but `node_savings_estimation_compute/contract.yaml` declared only `session-ended.v1` under `event_bus.subscribe_topics`. The contract-driven topic provisioner (`scripts/create_kafka_topics.py`) **only creates topics it finds in a contract**, so `onex.evt.omniclaude.validator-catch.v1` and `onex.evt.omniclaude.hook-context-injected.v1` were never provisioned on the dev broker. The consumer's subscribe loop then error-stormed `topic not found in cluster` — **174 + 220 errors / 15m** on every fresh dev redeploy.

Live broker proof (`omnibase-infra-redpanda`, dev lane, 2026-06-24):
- Provisioned (consumer subscribes fine): `pattern-enforcement.v1`, `session-outcome.v1`, `session-ended.v1`, `llm-call-completed.v1`
- **Missing** (the two error-storm topics, exactly as the ticket states): `validator-catch.v1`, `hook-context-injected.v1`

Producers exist in omniclaude hooks (e.g. `hooks/handlers/context_scope_auditor.py` emits `validator-catch`), so these are **live subscriptions, not dead** → the DoD-correct fix is **provision**, not remove.

### Fix
- Declare all 6 runtime-consumed topics in the contract's `event_bus.subscribe_topics` + `topics.consumes`. The provisioner now extracts and creates `validator-catch.v1` and `hook-context-injected.v1` on every fresh redeploy → error storm stops.
- Remove the 5 now-contract-covered parity-gate allowlist entries (the 2 target topics + 3 already-provisioned siblings now declared by the same contract). Parity gate stays green; tech-debt allowlist shrinks toward 0.
- Add `test_every_consumed_topic_is_declared_in_contract` — fails if any runtime-consumed topic is missing from the contract's declared `subscribe_topics`. This **gates the consumer-subscribed-but-unprovisioned regression class pre-merge** (DoD item 3).

### Evidence
- `uv run python scripts/create_kafka_topics.py --dry-run --contracts-root src/omnibase_infra/nodes/` now lists both target topics in the create plan (returned nothing before).
- `uv run pytest tests/unit/observability/test_savings_estimation_config.py -q` → 7 passed (incl. the new parity gate).
- Focused savings-estimation suite (config + consumer + node + non-dispatch): 239 passed.
- `uv run python scripts/check_contract_topic_parity.py` → parity gate passed.
- `uv run mypy src/omnibase_infra/` → Success: no issues found.

### DoD status
- [x] `validator-catch.v1` + `hook-context-injected.v1` now contract-declared → provisioned by the contract-driven creator on fresh redeploy (errors stop).
- [x] Provisioner check catches a consumer-subscribed-but-unprovisioned topic pre-merge (new unit gate).
- [ ] Fresh dev redeploy 0-error-over-15m proof — to be confirmed post-merge on the next dev redeploy (provisioner runs at deploy time; this PR makes the topics visible to it).

Evidence-Source: ff3d679f29e8c688141bce2eb250272fcb36dc3a
Evidence-Ticket: OMN-13533

### OCC receipt pairing
Paired OCC PR: OmniNode-ai/onex_change_control#3021 (`evidence(OMN-13533)`), carrying `contracts/OMN-13533.yaml` + PASS `dod_receipts` for dod-001, dod-002, dod-003, and dod-occ-pr. OCC eligibility = PASS (hash-bound + PR-bound). OCC PR #3021 merged via squash to OCC dev as `ff3d679f`; Evidence-Source pins that merge commit (on OCC dev ancestry) rather than the dead pre-squash head, per the OCC-squash Receipt-Gate ancestry rule.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded topic coverage for savings-estimation and bus-forwarding components so more event streams are recognized and provisioned automatically.
  * Added validation checks to catch missing topic declarations and disallowed imports earlier.

* **Bug Fixes**
  * Improved handling of runtime event routing and consumer payload processing to avoid failures during execution and redeploys.
  * Tightened parity checks so previously exempted topics are now validated consistently.

* **Tests**
  * Added and updated automated tests covering topic declaration coverage, gate behavior, and Kafka mock usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->