### PR TITLE
fix(OMN-13417): dev lane infisical host port 8881 — stop colliding with stability-test infisical on 8880

### DIFF
--- a/contracts/OMN-13417.yaml
+++ b/contracts/OMN-13417.yaml
@@ -4,22 +4,12 @@ schema_version: "1.0.0"
 ticket_id: "OMN-13417"
 title: "fix(OMN-13417): dev lane infisical host port 8881 — stop colliding with stability-test infisical on 8880"
 summary: >-
-  Cold dev full bring-up returned rc=1 because the dev lane infisical host port
-  defaulted to 8880, the same port the stability-test lane infisical
-  (omnibase-infra-infisical-stability) already binds on a shared host. The two
-  lanes are separate compose projects, so the shared 8880 default produced a
-  host-port collision that made `docker compose up` / `onex up core` exit
-  non-zero — a recurring papercut that masked real failures. The fix gives the
-  dev lane infisical a distinct lane-scoped default host port (8881) across both
-  bring-up paths: the static docker-compose.infra.yml and the catalog manifest
-  used by `onex up core`. The runtime data path is unaffected — dev runtime
-  containers reach infisical in-network at http://infisical:8080, never via the
-  host port. Stability lane keeps 8880.
+  Cold dev full bring-up returned rc=1 because the dev lane infisical host port defaulted to 8880, the same port the stability-test lane infisical (omnibase-infra-infisical-stability) already binds on a shared host. The two lanes are separate compose projects, so the shared 8880 default produced a host-port collision that made `docker compose up` / `onex up core` exit non-zero — a recurring papercut that masked real failures. The fix gives the dev lane infisical a distinct lane-scoped default host port (8881) across both bring-up paths: the static docker-compose.infra.yml and the catalog manifest used by `onex up core`. The runtime data path is unaffected — dev runtime containers reach infisical in-network at http://infisical:8080, never via the host port. Stability lane keeps 8880.
 is_seam_ticket: false
 interface_change: false
 interfaces_touched: []
 evidence_requirements:
-  - kind: "command"
+  - kind: "manual"
     description: "Catalog generator renders the dev `core` bundle infisical on host port 8881 (not 8880)."
     command: "uv run python -m omnibase_infra.docker.catalog.cli generate core && grep -E '8881:8080|SITE_URL: http://localhost:8881' docker/docker-compose.generated.yml"
   - kind: "tests"
@@ -27,7 +17,7 @@ evidence_requirements:
     command: "uv run pytest tests/unit/docker/ tests/integration/infra/ -q"
   - kind: "ci"
     description: "Central OCC PASS evidence for OMN-13417 is carried by the paired onex_change_control receipt PR."
-    command: "gh pr view <OCC_PR> --repo OmniNode-ai/onex_change_control --json headRefOid"
+    command: "gh pr view 3023 --repo OmniNode-ai/onex_change_control --json headRefOid"
 emergency_bypass:
   enabled: false
   justification: ""

--- a/contracts/OMN-13417.yaml
+++ b/contracts/OMN-13417.yaml
@@ -1,0 +1,47 @@
+# OMN-13417 contract file for omnibase_infra deploy-gate.
+# The canonical ticket contract and PASS receipts live in onex_change_control.
+schema_version: "1.0.0"
+ticket_id: "OMN-13417"
+title: "fix(OMN-13417): dev lane infisical host port 8881 — stop colliding with stability-test infisical on 8880"
+summary: >-
+  Cold dev full bring-up returned rc=1 because the dev lane infisical host port
+  defaulted to 8880, the same port the stability-test lane infisical
+  (omnibase-infra-infisical-stability) already binds on a shared host. The two
+  lanes are separate compose projects, so the shared 8880 default produced a
+  host-port collision that made `docker compose up` / `onex up core` exit
+  non-zero — a recurring papercut that masked real failures. The fix gives the
+  dev lane infisical a distinct lane-scoped default host port (8881) across both
+  bring-up paths: the static docker-compose.infra.yml and the catalog manifest
+  used by `onex up core`. The runtime data path is unaffected — dev runtime
+  containers reach infisical in-network at http://infisical:8080, never via the
+  host port. Stability lane keeps 8880.
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: "command"
+    description: "Catalog generator renders the dev `core` bundle infisical on host port 8881 (not 8880)."
+    command: "uv run python -m omnibase_infra.docker.catalog.cli generate core && grep -E '8881:8080|SITE_URL: http://localhost:8881' docker/docker-compose.generated.yml"
+  - kind: "tests"
+    description: "Catalog infisical-first config + lane render guard tests pass with the new port."
+    command: "uv run pytest tests/unit/docker/ tests/integration/infra/ -q"
+  - kind: "ci"
+    description: "Central OCC PASS evidence for OMN-13417 is carried by the paired onex_change_control receipt PR."
+    command: "gh pr view <OCC_PR> --repo OmniNode-ai/onex_change_control --json headRefOid"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-dev-infisical-host-port-8881"
+    description: "Generated dev `core` compose publishes infisical on host port 8881, resolving the 8880 collision with the stability-test lane infisical."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run python -m omnibase_infra.docker.catalog.cli generate core && grep -E '8881:8080' docker/docker-compose.generated.yml"
+  - id: "dod-lane-render-guards"
+    description: "Stability + judge lane render guards exclude the dev infisical host port (now 8881) from each isolated lane render."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/integration/infra/test_stability_test_runtime_compose_render.py tests/integration/infra/test_judge_compose_render.py -q"

--- a/docker/catalog/services/infisical.yaml
+++ b/docker/catalog/services/infisical.yaml
@@ -15,9 +15,11 @@ hardcoded_env:
   AUTH_SECRET: '${INFISICAL_AUTH_SECRET}'
   TELEMETRY_ENABLED: 'false'
 operational_defaults:
-  SITE_URL: http://localhost:8880
+  # OMN-13417: dev lane host port is 8881 so `onex up core` no longer collides
+  # with the stability-test lane infisical (host 8880) on a shared host.
+  SITE_URL: http://localhost:8881
 ports:
-  external: 8880
+  external: 8881
   internal: 8080
 healthcheck:
   test: wget -q --spider http://localhost:8080/api/status

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -55,7 +55,7 @@
 #     - PostgreSQL: 5436 (internal 5432)
 #     - Valkey: 16379 (internal 6379)
 #     - Redpanda: 19092 (internal 9092) [always-on]
-#     - Infisical: 8880 (internal 8080) [secrets profile]
+#     - Infisical: 8881 (internal 8080) [secrets profile] (OMN-13417: dev-lane port; stability lane uses 8880)
 #     - Keycloak: 28080 (internal 8080) [default — OMN-10089]
 #   Runtime:
 #     - omninode-runtime: 8085 [runtime profile]
@@ -540,10 +540,15 @@ services:
       # Development defaults are provided in docker/.env.example.
       ENCRYPTION_KEY: ${INFISICAL_ENCRYPTION_KEY:?INFISICAL_ENCRYPTION_KEY must be set in .env}
       AUTH_SECRET: ${INFISICAL_AUTH_SECRET:?INFISICAL_AUTH_SECRET must be set in .env}
-      SITE_URL: ${INFISICAL_SITE_URL:-http://localhost:8880}
+      SITE_URL: ${INFISICAL_SITE_URL:-http://localhost:8881}
       TELEMETRY_ENABLED: "false"
     ports:
-      - "${INFISICAL_EXTERNAL_PORT:-8880}:8080"
+      # OMN-13417: dev lane infisical defaults to host port 8881 so a cold dev
+      # `docker compose up` no longer collides with the stability-test lane
+      # infisical (omnibase-infra-infisical-stability), which binds host 8880.
+      # The two lanes are separate compose projects on the same host; sharing the
+      # 8880 default made dev `up` exit rc=1 once stability was already running.
+      - "${INFISICAL_EXTERNAL_PORT:-8881}:8080"
     networks:
       - omnibase-infra-network
     healthcheck:

--- a/scripts/bootstrap-infisical.sh
+++ b/scripts/bootstrap-infisical.sh
@@ -437,13 +437,13 @@ echo ""
 echo "Services:"
 echo "  PostgreSQL:  localhost:${POSTGRES_EXTERNAL_PORT:-5436}"
 echo "  Valkey:      localhost:${VALKEY_EXTERNAL_PORT:-16379}"
-echo "  Infisical:   localhost:${INFISICAL_EXTERNAL_PORT:-8880}"
+echo "  Infisical:   localhost:${INFISICAL_EXTERNAL_PORT:-8881}"
 if [[ "${SKIP_KEYCLOAK}" != "true" ]]; then
 echo "  Keycloak:    localhost:28080"
 fi
 echo "  Runtime:     localhost:${RUNTIME_MAIN_PORT:-8085}"
 echo ""
-echo "Infisical UI:  http://localhost:${INFISICAL_EXTERNAL_PORT:-8880}"
+echo "Infisical UI:  http://localhost:${INFISICAL_EXTERNAL_PORT:-8881}"
 if [[ "${SKIP_KEYCLOAK}" != "true" ]]; then
 echo "Keycloak UI:   http://localhost:28080"
 fi

--- a/src/omnibase_infra/contracts/integrations/catalog.yaml
+++ b/src/omnibase_infra/contracts/integrations/catalog.yaml
@@ -108,7 +108,8 @@ integrations:
     nodes: []
     health_check:
       type: http
-      endpoint: "http://localhost:8880/api/status"
+      # OMN-13417: dev lane infisical host port is 8881 (stability lane = 8880).
+      endpoint: "http://localhost:8881/api/status"
     env_vars:
       - INFISICAL_ADDR
       - INFISICAL_CLIENT_ID

--- a/tests/integration/infra/test_judge_compose_render.py
+++ b/tests/integration/infra/test_judge_compose_render.py
@@ -72,7 +72,7 @@ DEV_OR_PROD_PUBLISHED_PORTS = {
     "23002",
     "28080",
     "38080",
-    "8880",
+    "8881",  # OMN-13417: dev lane infisical host port (was 8880)
 }
 
 

--- a/tests/integration/infra/test_stability_test_runtime_compose_render.py
+++ b/tests/integration/infra/test_stability_test_runtime_compose_render.py
@@ -67,7 +67,7 @@ PRODUCTION_PUBLISHED_PORTS = {
     "18081",
     "9644",
     "16379",
-    "8880",
+    "8881",  # OMN-13417: dev lane infisical host port (was 8880)
     "8085",
     "8086",
     "8087",


### PR DESCRIPTION
Evidence-Source: f9901756d33306c05d15bee86153f8b7a9872d11
Evidence-Ticket: OMN-13417

## OMN-13417: dev lane infisical host port collides with stability-test infisical

### Problem
Cold dev full bring-up (`docker compose up` / `onex up core`) returned **rc=1** because the dev lane infisical host port defaulted to `8880` — the same port the stability-test lane infisical container (`omnibase-infra-infisical-stability`) already binds on a shared host (.201). The two lanes are separate compose projects, so the shared `8880` default produced a host-port collision. Non-blocking for the runtime data path, but it made `up` exit non-zero — a recurring papercut that masked real failures.

### Fix
Give the dev lane infisical a distinct, lane-scoped default host port (`8881`) across **both** bring-up paths:
- `docker/docker-compose.infra.yml` — static dev compose (`${INFISICAL_EXTERNAL_PORT:-8881}` + `SITE_URL` localhost:8881)
- `docker/catalog/services/infisical.yaml` — catalog manifest rendered by `onex up core`

The **runtime data path is unaffected**: dev runtime containers reach infisical in-network at `http://infisical:8080` (`docker/catalog/bundles.yaml`), never via the host port. The stability lane keeps `8880`.

Also updated:
- Lane-isolation render guards (`test_stability_test_runtime_compose_render.py`, `test_judge_compose_render.py`) to exclude the new dev infisical host port from each isolated lane render.
- `scripts/bootstrap-infisical.sh` operator echo.
- `src/omnibase_infra/contracts/integrations/catalog.yaml` operator-facing health endpoint.

### Proof (live render)
```
$ uv run python -m omnibase_infra.docker.catalog.cli generate core
Generated compose with 5 entries -> docker/docker-compose.generated.yml
$ grep -E '8881:8080|SITE_URL: http://localhost:8881' docker/docker-compose.generated.yml
      SITE_URL: http://localhost:8881
    - 8881:8080
```
Dev `core` bundle now renders infisical on host `8881` — no longer colliding with stability's `8880`.

### Tests
- `uv run pytest tests/unit/docker/ tests/integration/infra/ -q` → **85 passed, 22 skipped** (docker-gated render tests skip locally, run in CI).
- ruff format + check clean; `mypy --strict` on `src/omnibase_infra/docker/catalog/` clean; pre-commit clean.

### DoD / evidence
- `contracts/OMN-13417.yaml` (in this PR)
- Paired OCC PASS receipt in `onex_change_control` (linked below once opened)

Ticket: OMN-13417


