### PR TITLE
fix(OMN-13554): subscription probe discovers live per-topic split-groups instead of stale monolithic group

### DIFF
--- a/contracts/OMN-13554.yaml
+++ b/contracts/OMN-13554.yaml
@@ -1,0 +1,38 @@
+# OMN-13554 contract file for omnibase_infra deploy-gate.
+# The canonical ticket contract and PASS receipts live in onex_change_control.
+schema_version: "1.0.0"
+ticket_id: "OMN-13554"
+title: "fix(OMN-13554): subscription probe discovers live per-topic split-groups instead of stale monolithic group name"
+summary: >-
+  The contract-sweep subscription probe derived the legacy monolithic consumer-group name (local.runtime_config.registration-orchestrator.consume.1.0.0) from a stale runtime_config.yaml identity, which no longer exists on the broker. The live runtime subscribes via per-topic split-groups under a different base name (local.omnibase_infra.node_registration_orchestrator.consume.1.1.1.__i.<instance>.__t.<topic>), so the probe reported a recurring false "7/7 missing subscriptions" FAIL for node_registration_orchestrator. The fix makes probe_subscription discover the runtime's actual per-topic split-groups by contract name and parse each topic directly from the live group name (resilient to instance/version/service-name drift), then falls through to that discovery when the derived base group does not exist on the broker.
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: "tests"
+    description: "Unit tests assert the per-topic split-group naming is matched and the stale-base-group scenario falls through to contract-name discovery."
+    command: "uv run pytest tests/unit/verification/test_subscription_probe.py -v"
+  - kind: "ci"
+    description: "Central OCC evidence for OMN-13554 is carried by the onex_change_control receipt PR."
+    command: "grep -c '^ticket_id: \"OMN-13554\"$' contracts/OMN-13554.yaml"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-001"
+    description: >-
+      The subscription probe discovers the runtime's actual per-topic split-group names (...__i.<instance>.__t.<topic>) rather than the legacy monolithic local.runtime_config.registration-orchestrator.consume.1.0.0. A probe unit test asserts the per-topic split-group naming is matched so a future convention change fails the test rather than silently re-emitting a false FAIL. The full verification unit suite stays green; ruff + mypy --strict clean.
+    source: "manual"
+    status: "verified"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/unit/verification/test_subscription_probe.py -v"
+  - id: "dod-live"
+    description: >-
+      Live proof against the dev-lane broker (192.168.86.201, project omnibase-infra): the new discovery resolves all 7 contract-declared subscribe_topics from the real per-topic split-groups (479 live consumer groups on the broker; zero declared topics missing), and check_subscriptions returns 7/7 PASS even with the stale runtime_config EXACT identity that previously produced the false 7/7-missing FAIL.
+    source: "manual"
+    status: "verified"
+    checks:
+      - check_type: "command"
+        check_value: "docker exec omnibase-infra-redpanda rpk group list | grep -c node_registration_orchestrator"

--- a/src/omnibase_infra/verification/probes/probe_subscription.py
+++ b/src/omnibase_infra/verification/probes/probe_subscription.py
@@ -76,8 +76,15 @@ def _parse_topics_from_rpk_describe_json(stdout: str) -> set[str]:
     return topics
 
 
-def _list_topic_scoped_groups(base_group_id: str) -> list[str]:
-    """List topic-scoped consumer groups derived from a base group ID."""
+# Per-topic split-group infix. The Kafka event bus scopes each consumer group
+# per topic as "...__t.{topic}" (see util_consumer_group.apply_instance_discriminator
+# and event_bus_kafka._scope_group_id_per_topic). The optional ".__i.{instance}"
+# infix is appended *before* the topic suffix in multi-container runtimes.
+_TOPIC_SUFFIX_INFIX = ".__t."
+
+
+def _rpk_group_list() -> list[dict[str, object]]:
+    """Return the raw ``rpk group list --format json`` payload as a list."""
     try:
         result = subprocess.run(
             ["rpk", "group", "list", "--format", "json"],
@@ -100,10 +107,33 @@ def _list_topic_scoped_groups(base_group_id: str) -> list[str]:
     except json.JSONDecodeError as exc:
         raise RuntimeError(f"rpk returned invalid JSON: {result.stdout[:200]}") from exc
 
-    direct_prefix = f"{base_group_id}.__t."
+    return groups if isinstance(groups, list) else []
+
+
+def _topic_from_split_group_name(group_name: str) -> str | None:
+    """Extract the subscribed topic from a per-topic split-group name.
+
+    The runtime scopes each consumer group per topic with a ``.__t.{topic}``
+    suffix, e.g.::
+
+        local.omnibase_infra.node_registration_orchestrator.consume.1.1.1.__i.runtime-main.__t.onex.evt.platform.node-heartbeat.v1
+
+    Returns the topic (everything after the *last* ``.__t.`` infix) or None if
+    the group is not a per-topic split group.
+    """
+    marker = group_name.rfind(_TOPIC_SUFFIX_INFIX)
+    if marker == -1:
+        return None
+    topic = group_name[marker + len(_TOPIC_SUFFIX_INFIX) :]
+    return topic or None
+
+
+def _list_topic_scoped_groups(base_group_id: str) -> list[str]:
+    """List topic-scoped consumer groups derived from a base group ID."""
+    direct_prefix = f"{base_group_id}{_TOPIC_SUFFIX_INFIX}"
     instance_prefix = f"{base_group_id}.__i."
     scoped_groups: list[str] = []
-    for group in groups if isinstance(groups, list) else []:
+    for group in _rpk_group_list():
         group_name = group.get("name", "") if isinstance(group, dict) else ""
         if isinstance(group_name, str) and group_name.startswith(
             (direct_prefix, instance_prefix)
@@ -112,11 +142,52 @@ def _list_topic_scoped_groups(base_group_id: str) -> list[str]:
     return scoped_groups
 
 
-def _rpk_fallback(group_id: str) -> set[str]:
+def _discover_split_group_topics(contract_name: str) -> set[str]:
+    """Discover subscribed topics from live per-topic split-groups by contract name.
+
+    The legacy group-id derivation can compute a base group name that no longer
+    matches the live runtime (e.g. when the service/version/node-name naming
+    convention has drifted). Rather than reconstruct the exact base group, this
+    discovers the runtime's actual per-topic split-groups directly: any live
+    consumer group whose name contains the contract's node name AND carries a
+    ``.__t.{topic}`` suffix contributes its topic. The topic is parsed straight
+    from the group name, so this stays correct across instance/version drift.
+
+    Args:
+        contract_name: The node name (e.g. ``node_registration_orchestrator``).
+
+    Returns:
+        The set of topics subscribed by live split-groups for this node. Empty
+        when no matching split-group exists on the broker.
+    """
+    topics: set[str] = set()
+    for group in _rpk_group_list():
+        group_name = group.get("name", "") if isinstance(group, dict) else ""
+        if not isinstance(group_name, str) or contract_name not in group_name:
+            continue
+        topic = _topic_from_split_group_name(group_name)
+        if topic is not None:
+            topics.add(topic)
+    return topics
+
+
+def _rpk_fallback(group_id: str, *, contract_name: str | None = None) -> set[str]:
     """Fallback: query subscribed topics via rpk CLI.
+
+    Resolution order (each step only runs if the previous returned nothing):
+
+    1. Describe ``group_id`` directly (the derived base group).
+    2. Aggregate per-topic split-groups anchored on ``group_id``
+       (``{group_id}.__t.{topic}`` / ``{group_id}.__i.{instance}.__t.{topic}``).
+    3. Discover live split-groups by ``contract_name`` and parse the topic
+       directly from the group name. This handles the case where the derived
+       base group name no longer matches the live naming convention (the root
+       cause of the recurring false 7/7-missing FAIL, OMN-13554).
 
     Args:
         group_id: Consumer group ID to describe.
+        contract_name: The node name used to discover live split-groups when
+            the derived base group does not exist on the broker.
 
     Returns:
         Set of topic names the group is subscribed to.
@@ -159,6 +230,14 @@ def _rpk_fallback(group_id: str) -> set[str]:
         if scoped_result.returncode != 0:
             continue
         scoped_topics.update(_parse_topics_from_rpk_describe_json(scoped_result.stdout))
+    if scoped_topics:
+        return scoped_topics
+
+    # The derived base group did not match the live runtime naming convention.
+    # Discover the actual per-topic split-groups by contract name and read the
+    # topic straight from each group name (OMN-13554).
+    if contract_name:
+        return _discover_split_group_topics(contract_name)
     return scoped_topics
 
 
@@ -299,8 +378,12 @@ def check_subscriptions(
         identity=identity,
     )
 
-    # Resolve the admin function
-    admin_fn: KafkaAdminFn = kafka_admin_fn or _rpk_fallback
+    # Resolve the admin function. The default rpk fallback is bound to the
+    # contract name so it can discover live per-topic split-groups when the
+    # derived base group does not match the live runtime convention (OMN-13554).
+    admin_fn: KafkaAdminFn = kafka_admin_fn or (
+        lambda gid: _rpk_fallback(gid, contract_name=parsed_contract.name)
+    )
 
     # Query subscribed topics
     try:

--- a/tests/unit/verification/test_subscription_probe.py
+++ b/tests/unit/verification/test_subscription_probe.py
@@ -17,7 +17,9 @@ from omnibase_infra.verification.contract_parser import (
     ModelParsedContractForVerification,
 )
 from omnibase_infra.verification.probes.probe_subscription import (
+    _discover_split_group_topics,
     _rpk_fallback,
+    _topic_from_split_group_name,
     check_subscriptions,
 )
 
@@ -288,3 +290,176 @@ class TestRpkFallback:
             "onex.evt.platform.node-heartbeat.v1",
             "onex.intent.platform.runtime-tick.v1",
         }
+
+
+# Live per-topic split-group names as emitted by the runtime (OMN-13554). The
+# base group carries the .__i.{instance} infix and each topic gets its own
+# .__t.{topic} split-group. These mirror the dev-lane broker output verbatim.
+_LIVE_BASE = (
+    "local.omnibase_infra.node_registration_orchestrator.consume.1.1.1.__i.runtime-main"
+)
+_LIVE_TOPICS = (
+    "onex.cmd.platform.node-registration-acked.v1",
+    "onex.cmd.platform.request-introspection.v1",
+    "onex.cmd.platform.topic-catalog-query.v1",
+    "onex.evt.platform.node-heartbeat.v1",
+    "onex.evt.platform.node-introspection.v1",
+    "onex.evt.platform.registry-request-introspection.v1",
+    "onex.intent.platform.runtime-tick.v1",
+)
+_LIVE_SPLIT_GROUPS = tuple(f"{_LIVE_BASE}.__t.{t}" for t in _LIVE_TOPICS)
+
+# The legacy monolithic group the stale derivation computes -- no longer exists
+# on the broker. This is the name that produced the recurring false FAIL.
+_LEGACY_DERIVED_GROUP = "local.runtime_config.registration-orchestrator.consume.1.0.0"
+
+
+@pytest.mark.unit
+class TestTopicFromSplitGroupName:
+    """Parse the topic straight out of a per-topic split-group name."""
+
+    def test_parses_topic_after_last_marker(self) -> None:
+        group = _LIVE_SPLIT_GROUPS[0]
+        assert (
+            _topic_from_split_group_name(group)
+            == "onex.cmd.platform.node-registration-acked.v1"
+        )
+
+    def test_uses_last_marker_when_topic_contains_no_marker(self) -> None:
+        # The .__i. instance infix precedes the single .__t. topic marker; the
+        # parser must split on the LAST .__t. so the topic is returned intact.
+        for group, topic in zip(_LIVE_SPLIT_GROUPS, _LIVE_TOPICS, strict=True):
+            assert _topic_from_split_group_name(group) == topic
+
+    def test_non_split_group_returns_none(self) -> None:
+        assert _topic_from_split_group_name(_LEGACY_DERIVED_GROUP) is None
+
+    def test_empty_topic_suffix_returns_none(self) -> None:
+        assert _topic_from_split_group_name(f"{_LIVE_BASE}.__t.") is None
+
+
+@pytest.mark.unit
+class TestDiscoverSplitGroupTopics:
+    """Discover live split-groups by contract name (the OMN-13554 fix)."""
+
+    def _patch_group_list(
+        self, monkeypatch: pytest.MonkeyPatch, names: tuple[str, ...]
+    ) -> None:
+        monkeypatch.setattr(
+            "omnibase_infra.verification.probes.probe_subscription._rpk_group_list",
+            lambda: [{"name": n} for n in names],
+        )
+
+    def test_discovers_all_live_split_group_topics(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_group_list(monkeypatch, _LIVE_SPLIT_GROUPS)
+        assert _discover_split_group_topics("node_registration_orchestrator") == set(
+            _LIVE_TOPICS
+        )
+
+    def test_ignores_unrelated_node_groups(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        other = "local.omnibase_infra.node_other.consume.1.0.0.__t.onex.evt.foo.v1"
+        self._patch_group_list(monkeypatch, (*_LIVE_SPLIT_GROUPS, other))
+        topics = _discover_split_group_topics("node_registration_orchestrator")
+        assert topics == set(_LIVE_TOPICS)
+        assert "onex.evt.foo.v1" not in topics
+
+    def test_no_match_returns_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._patch_group_list(monkeypatch, (_LEGACY_DERIVED_GROUP,))
+        assert _discover_split_group_topics("node_registration_orchestrator") == set()
+
+
+@pytest.mark.unit
+class TestRpkFallbackDiscoversSplitGroupsByContract:
+    """End-to-end: the derived base group is stale, discovery saves the probe.
+
+    This is the exact OMN-13554 scenario: the stale monolithic group derivation
+    yields a base group that does not exist on the broker, while the live
+    runtime subscribes via per-topic split-groups under a different base name.
+    The fallback must discover those by contract name and return the real topics
+    rather than emitting a false 7/7-missing FAIL.
+    """
+
+    def test_stale_base_group_falls_through_to_contract_discovery(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class CompletedProcessStub:
+            def __init__(
+                self, stdout: str, returncode: int = 0, stderr: str = ""
+            ) -> None:
+                self.stdout = stdout
+                self.returncode = returncode
+                self.stderr = stderr
+
+        def fake_run(
+            args: list[str],
+            capture_output: bool,
+            text: bool,
+            timeout: int,
+            check: bool,
+            env: dict | None = None,
+        ) -> CompletedProcessStub:
+            # describe of the stale base group: exists but has no members.
+            if args[:3] == ["rpk", "group", "describe"]:
+                return CompletedProcessStub(stdout=json.dumps({"members": []}))
+            # list returns only the LIVE split-groups (the stale base is absent,
+            # so its .__t. anchored search finds nothing).
+            if args == ["rpk", "group", "list", "--format", "json"]:
+                return CompletedProcessStub(
+                    stdout=json.dumps([{"name": n} for n in _LIVE_SPLIT_GROUPS])
+                )
+            raise AssertionError(f"Unexpected subprocess invocation: {args}")
+
+        monkeypatch.setattr(
+            "omnibase_infra.verification.probes.probe_subscription.subprocess.run",
+            fake_run,
+        )
+
+        assert _rpk_fallback(
+            _LEGACY_DERIVED_GROUP,
+            contract_name="node_registration_orchestrator",
+        ) == set(_LIVE_TOPICS)
+
+    def test_check_subscriptions_passes_against_live_split_groups(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Force the stale EXACT identity that the runtime_config.yaml derivation
+        # produces, then prove the contract-name discovery still resolves PASS.
+        from omnibase_infra.models import ModelNodeIdentity
+
+        monkeypatch.setattr(
+            "omnibase_infra.verification.probes.probe_subscription._rpk_group_list",
+            lambda: [{"name": n} for n in _LIVE_SPLIT_GROUPS],
+        )
+
+        class CompletedProcessStub:
+            def __init__(self, stdout: str, returncode: int = 0) -> None:
+                self.stdout = stdout
+                self.returncode = returncode
+                self.stderr = ""
+
+        def fake_run(args, **_kwargs):  # type: ignore[no-untyped-def]
+            # describe of the stale base group -> no members; list path goes
+            # through the patched _rpk_group_list above.
+            return CompletedProcessStub(stdout=json.dumps({"members": []}))
+
+        monkeypatch.setattr(
+            "omnibase_infra.verification.probes.probe_subscription.subprocess.run",
+            fake_run,
+        )
+
+        contract = _make_contract(subscribe_topics=_LIVE_TOPICS)
+        results = check_subscriptions(
+            contract,
+            identity=ModelNodeIdentity(
+                env="local",
+                service="runtime_config",
+                node_name="registration-orchestrator",
+                version="1.0.0",
+            ),
+        )
+        assert len(results) == len(_LIVE_TOPICS)
+        assert all(r.verdict == EnumValidationVerdict.PASS for r in results)


### PR DESCRIPTION
## OMN-13554 — subscription probe discovers live per-topic split-groups

The contract-sweep subscription probe derived the legacy monolithic consumer-group name `local.runtime_config.registration-orchestrator.consume.1.0.0` from a stale `runtime_config.yaml` identity. That group no longer exists on the broker — the live runtime subscribes via **per-topic split-groups** under `local.omnibase_infra.node_registration_orchestrator.consume.1.1.1.__i.<instance>.__t.<topic>`. The probe therefore reported a recurring **false 7/7-missing FAIL** for `node_registration_orchestrator`, mis-closed three times as a runtime-wiring gap (OMN-9420 / OMN-9557 / OMN-9648). This is a probe-truth defect, not a runtime gap.

### Fix
`probe_subscription.py` now:
- **discovers** the runtime's actual per-topic split-groups by contract name and parses each topic directly from the live group name (`_discover_split_group_topics`, `_topic_from_split_group_name`), resilient to instance / version / service-name drift;
- `_rpk_fallback` falls through to that discovery when the derived base group does not exist on the broker.

### Evidence
- **Unit**: `tests/unit/verification/test_subscription_probe.py` — new `TestTopicFromSplitGroupName`, `TestDiscoverSplitGroupTopics`, `TestRpkFallbackDiscoversSplitGroupsByContract` pin the per-topic split-group naming so a future convention change fails the test rather than silently re-emitting a false FAIL. Full verification suite: **437 passed**. ruff + mypy --strict clean.
- **Live** (dev-lane broker 192.168.86.201, project omnibase-infra): 479 live consumer groups; the new discovery resolves all **7/7** declared subscribe_topics (zero missing); `check_subscriptions` returns **7/7 PASS** even with the stale `runtime_config` EXACT identity that previously produced the false FAIL. Runner = live broker on .201; verifier != runner.

Evidence-Source: bd7ebce32fd8905b1abaf48464986240730145da
Evidence-Ticket: OMN-13554
