### PR TITLE
fix(OMN-13555): wire broker env into publication probe + db_query_fn into --all/--contract-path

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
   # shared baseline at omnibase_core/src/omnibase_core/validation/baselines/url_authority_baseline.json.
   # Baseline is burn-down only. Suppress with: # url-authority-ok: <reason>
   - repo: https://github.com/OmniNode-ai/omnibase_core
-    rev: c93c98c92bd1a5b335d7aa504a8cf63dc029b3e7 # pragma: allowlist secret
+    rev: be4f95460dcd6865264ab0713a5b1cc48b41aef9 # pragma: allowlist secret
     hooks:
       - id: check-url-authority
         args: [--repo, omnibase_infra, --repo-root, .]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
   # Stub implementation detection + transport-mock lint — sourced from omnibase_core.
   # Rev bumped to OMN-13026 (transport-mock-lint hook added).
   - repo: https://github.com/OmniNode-ai/omnibase_core
-    rev: cfaa6ec863c3026b5e65196151ed76cdad13dae3 # pragma: allowlist secret
+    rev: 309d89fa7254701347f95bf99205cccfb3f6c1df # pragma: allowlist secret
     hooks:
       - id: check-stub-implementations
       # OMN-13026: bare AsyncMock/MagicMock without spec=/spec_set= on

--- a/src/omnibase_infra/verification/cli.py
+++ b/src/omnibase_infra/verification/cli.py
@@ -124,6 +124,18 @@ def _make_runtime_db_query_fn() -> RuntimeDbQueryFn | None:
     return _query
 
 
+def _make_runtime_config() -> VerificationConfig:
+    """Build a VerificationConfig wired for live runtime verification.
+
+    Wires ``db_query_fn`` from ``OMNIBASE_INFRA_DB_URL`` so projection_state
+    probes run against the runtime DB instead of auto-QUARANTINE. ``kafka_admin_fn``
+    and ``watermark_fn`` are intentionally left ``None`` so the publication and
+    subscription probes use their rpk fallbacks, which honor ``RPK_BROKERS`` /
+    ``~/.omnibase/.env`` via the shared ``rpk_env`` helper.
+    """
+    return VerificationConfig(db_query_fn=_make_runtime_db_query_fn())
+
+
 def _aggregate_verdict(
     reports: list[ModelContractVerificationReport],
 ) -> EnumValidationVerdict:
@@ -272,7 +284,7 @@ def main(argv: list[str] | None = None) -> int:
         if not args.contract_path.is_file():
             logger.error("Contract not found: %s", args.contract_path)
             return 1
-        config = VerificationConfig()
+        config = _make_runtime_config()
         report = run_contract_verification(args.contract_path, config)
         return _output_reports([report], args.output_path)
 
@@ -283,7 +295,7 @@ def main(argv: list[str] | None = None) -> int:
             logger.error("No contracts found in %s", contracts_dir)
             return 1
 
-        config = VerificationConfig()
+        config = _make_runtime_config()
         reports: list[ModelContractVerificationReport] = []
         for path in contract_paths:
             report = run_contract_verification(path, config)

--- a/src/omnibase_infra/verification/probes/probe_publication.py
+++ b/src/omnibase_infra/verification/probes/probe_publication.py
@@ -24,6 +24,7 @@ from omnibase_infra.verification.contract_parser import (
 from omnibase_infra.verification.models.model_contract_check_result import (
     ModelContractCheckResult,
 )
+from omnibase_infra.verification.probes.util_rpk_env import rpk_env
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +68,7 @@ def _rpk_watermark_fallback(topic: str) -> tuple[int, int]:
             text=True,
             timeout=10,
             check=False,
+            env=rpk_env(),
         )
     except FileNotFoundError as exc:
         raise RuntimeError("rpk not found on PATH") from exc

--- a/src/omnibase_infra/verification/probes/probe_subscription.py
+++ b/src/omnibase_infra/verification/probes/probe_subscription.py
@@ -12,10 +12,8 @@ compute_consumer_group_id() -- never hardcoded.
 from __future__ import annotations
 
 import logging
-import os
 import subprocess
 from collections.abc import Callable
-from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
@@ -30,24 +28,9 @@ from omnibase_infra.verification.contract_parser import (
 from omnibase_infra.verification.models.model_contract_check_result import (
     ModelContractCheckResult,
 )
+from omnibase_infra.verification.probes.util_rpk_env import rpk_env
 
 logger = logging.getLogger(__name__)
-
-_OMNIBASE_ENV = Path.home() / ".omnibase" / ".env"
-
-
-def _rpk_env() -> dict[str, str]:
-    """Return os.environ merged with ~/.omnibase/.env for rpk subprocess calls."""
-    env = dict(os.environ)
-    if _OMNIBASE_ENV.exists():
-        with open(_OMNIBASE_ENV) as f:
-            for line in f:
-                line = line.strip()
-                if not line or line.startswith("#") or "=" not in line:
-                    continue
-                key, _, value = line.partition("=")
-                env.setdefault(key.strip(), value.strip())
-    return env
 
 
 # Type alias: given a consumer group ID, return the set of topics it subscribes to.
@@ -85,7 +68,7 @@ def _list_topic_scoped_groups(base_group_id: str) -> list[str]:
             text=True,
             timeout=10,
             check=False,
-            env=_rpk_env(),
+            env=rpk_env(),
         )
     except FileNotFoundError as exc:
         raise RuntimeError("rpk not found on PATH") from exc
@@ -131,7 +114,7 @@ def _rpk_fallback(group_id: str) -> set[str]:
             text=True,
             timeout=10,
             check=False,
-            env=_rpk_env(),
+            env=rpk_env(),
         )
     except FileNotFoundError as exc:
         raise RuntimeError("rpk not found on PATH") from exc
@@ -154,7 +137,7 @@ def _rpk_fallback(group_id: str) -> set[str]:
             text=True,
             timeout=10,
             check=False,
-            env=_rpk_env(),
+            env=rpk_env(),
         )
         if scoped_result.returncode != 0:
             continue

--- a/src/omnibase_infra/verification/probes/util_rpk_env.py
+++ b/src/omnibase_infra/verification/probes/util_rpk_env.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) 2026 OmniNode Team
+"""Shared rpk subprocess environment helper for verification probes.
+
+The publication and subscription probes both shell out to ``rpk``. The broker
+address is provided via ``RPK_BROKERS`` (and friends), which lives in
+``~/.omnibase/.env`` on operator hosts but is not always exported into the
+process environment. Both probes must merge that file so rpk dials the
+configured broker instead of falling back to the rpk default ``127.0.0.1:9092``.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+_OMNIBASE_ENV = Path.home() / ".omnibase" / ".env"
+
+
+def rpk_env() -> dict[str, str]:
+    """Return ``os.environ`` merged with ``~/.omnibase/.env`` for rpk subprocesses.
+
+    Existing process-environment values win over file values, so an explicitly
+    exported ``RPK_BROKERS`` is never overridden by a stale ``.env`` entry.
+    """
+    env = dict(os.environ)
+    if _OMNIBASE_ENV.exists():
+        with open(_OMNIBASE_ENV) as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, _, value = line.partition("=")
+                env.setdefault(key.strip(), value.strip())
+    return env
+
+
+__all__: list[str] = ["rpk_env"]

--- a/tests/unit/verification/test_cli.py
+++ b/tests/unit/verification/test_cli.py
@@ -9,10 +9,12 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 import yaml
 
+from omnibase_infra.enums.enum_validation_verdict import EnumValidationVerdict
 from omnibase_infra.verification import cli
 from omnibase_infra.verification.cli import build_parser, main
 
@@ -251,3 +253,61 @@ class TestCLIMain:
         """--registration-only with empty dir -> exit 1."""
         exit_code = main(["--registration-only", "--contracts-dir", str(tmp_path)])
         assert exit_code == 1
+
+
+@pytest.mark.unit
+class TestCLIWiresDbQueryFn:
+    """Regression for OMN-13555 Defect 2.
+
+    ``--all`` and ``--contract-path`` must build a real ``db_query_fn`` from
+    ``OMNIBASE_INFRA_DB_URL`` (mirroring ``--registration-only``) so projection
+    probes run instead of auto-QUARANTINE.
+    """
+
+    def _capture_configs(self, monkeypatch: pytest.MonkeyPatch) -> list[Any]:
+        captured: list[Any] = []
+        real_report = MagicMock()
+        real_report.model_dump.return_value = {"overall_verdict": "pass", "checks": []}
+        real_report.overall_verdict = EnumValidationVerdict.PASS
+
+        def fake_run(path: Path, config: Any) -> Any:
+            captured.append(config)
+            return real_report
+
+        monkeypatch.setattr(cli, "run_contract_verification", fake_run)
+        # Force a real (non-None) db_query_fn regardless of host DB config.
+        sentinel_fn = lambda sql: []  # noqa: E731
+        monkeypatch.setattr(cli, "_make_runtime_db_query_fn", lambda: sentinel_fn)
+        return captured
+
+    def test_all_builds_non_none_db_query_fn(
+        self, tmp_path: Path, capsys: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured = self._capture_configs(monkeypatch)
+        _write_contract(tmp_path, _make_contract("node_a"), "node_a")
+
+        cli.main(["--all", "--contracts-dir", str(tmp_path)])
+        capsys.readouterr()
+
+        assert captured, "run_contract_verification was never invoked"
+        assert all(cfg.db_query_fn is not None for cfg in captured)
+
+    def test_contract_path_builds_non_none_db_query_fn(
+        self, tmp_path: Path, capsys: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured = self._capture_configs(monkeypatch)
+        path = _write_contract(tmp_path, _make_contract("node_b"), "node_b")
+
+        cli.main(["--contract-path", str(path)])
+        capsys.readouterr()
+
+        assert len(captured) == 1
+        assert captured[0].db_query_fn is not None
+
+    def test_make_runtime_config_wires_db_query_fn(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sentinel_fn = lambda sql: []  # noqa: E731
+        monkeypatch.setattr(cli, "_make_runtime_db_query_fn", lambda: sentinel_fn)
+        config = cli._make_runtime_config()
+        assert config.db_query_fn is sentinel_fn

--- a/tests/unit/verification/test_publication_probe.py
+++ b/tests/unit/verification/test_publication_probe.py
@@ -2,9 +2,11 @@
 # SPDX-License-Identifier: MIT
 
 # Copyright (c) 2026 OmniNode Team
-"""Unit tests for publication verification probe [OMN-7040]."""
+"""Unit tests for publication verification probe [OMN-7040, OMN-13555]."""
 
 from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -14,8 +16,10 @@ from omnibase_infra.enums.enum_validation_verdict import EnumValidationVerdict
 from omnibase_infra.verification.contract_parser import (
     ModelParsedContractForVerification,
 )
+from omnibase_infra.verification.probes import probe_publication
 from omnibase_infra.verification.probes.probe_publication import (
     CORE_REGISTRATION_SUFFIXES,
+    _rpk_watermark_fallback,
     check_publications,
 )
 
@@ -185,3 +189,39 @@ class TestCheckPublicationsOnePerTopic:
         results = check_publications(contract, watermark_fn=_make_watermark_fn())
         assert len(results) == 1
         assert results[0].verdict == EnumValidationVerdict.PASS
+
+
+@pytest.mark.unit
+class TestRpkWatermarkFallbackHonorsBrokerEnv:
+    """Regression for OMN-13555 Defect 1.
+
+    The rpk watermark fallback must pass the broker-merged environment to the
+    subprocess so it dials ``RPK_BROKERS`` instead of the rpk default
+    ``127.0.0.1:9092``.
+    """
+
+    def test_subprocess_receives_broker_env(self) -> None:
+        sentinel_env = {"RPK_BROKERS": "192.0.2.10:9092"}
+
+        fake_result = MagicMock()
+        fake_result.returncode = 0
+        fake_result.stdout = (
+            '{"partitions": [{"log_start_offset": 0, "high_watermark": 7}]}'
+        )
+
+        with (
+            patch.object(
+                probe_publication, "rpk_env", return_value=sentinel_env
+            ) as mock_env,
+            patch.object(
+                probe_publication.subprocess, "run", return_value=fake_result
+            ) as mock_run,
+        ):
+            low, high = _rpk_watermark_fallback("onex.evt.platform.foo.v1")
+
+        assert (low, high) == (0, 7)
+        mock_env.assert_called_once()
+        # The subprocess must be invoked with the broker-merged env, not None.
+        _args, kwargs = mock_run.call_args
+        assert kwargs["env"] is sentinel_env
+        assert kwargs["env"]["RPK_BROKERS"] == "192.0.2.10:9092"


### PR DESCRIPTION
## OMN-13555 — Runtime `--all` mode structurally non-functional: publication probe ignores broker env + `--all` never wires `db_query_fn`

Fixes the two precise wiring defects that made `python -m omnibase_infra.verification --all` (and `--contract-path`) return `108/108 QUARANTINE` from any host without a broker on `localhost:9092`.

### Defect 1 — publication probe ignored the broker env
`probe_publication._rpk_watermark_fallback()` ran the `rpk topic describe` subprocess **without** `env=`, so it ignored `RPK_BROKERS` / `~/.omnibase/.env` and dialed the rpk default `127.0.0.1:9092` (the `127.0.0.1:9092` taint cited in the ticket).

Fix: factored the broker-env merge that already lived (privately) in `probe_subscription._rpk_env` into a shared `verification/probes/util_rpk_env.py::rpk_env()`, and pass `env=rpk_env()` to the publication subprocess. `probe_subscription` now imports the shared util (its private `_rpk_env` is removed — no duplicate).

### Defect 2 — `--all` / `--contract-path` never wired `db_query_fn`
Both paths built `VerificationConfig()` with `db_query_fn=None`, so `orchestrator._run_projection_probe` short-circuited to QUARANTINE for every contract. Only `--registration-only` built a real DB fn.

Fix: added `cli._make_runtime_config()` that wires `db_query_fn` from `OMNIBASE_INFRA_DB_URL` via the existing `_make_runtime_db_query_fn()` (same source `--registration-only` uses), and use it for both `--all` and `--contract-path`. `kafka_admin_fn` / `watermark_fn` are intentionally left `None` so the probes use their rpk fallbacks, which now honor the broker env (Defect 1).

### Tests (DoD #4)
- `tests/unit/verification/test_publication_probe.py::TestRpkWatermarkFallbackHonorsBrokerEnv` — asserts the publication subprocess receives the broker-merged env (`env is rpk_env()`, `RPK_BROKERS` present).
- `tests/unit/verification/test_cli.py::TestCLIWiresDbQueryFn` — asserts `--all` and `--contract-path` build a non-None `db_query_fn`, plus `_make_runtime_config` wiring.
- Full verification suite green: `434 passed`. mypy clean on `verification/`. pre-commit green on all changed files.

### Live proof on the dev lane (DoD #3) — verifier ≠ runner
Run from a `python:3.12-slim` container joined to `omnibase-infra-network` (so the dev broker's advertised address resolves), `RPK_BROKERS=redpanda:9092`, `OMNIBASE_INFRA_DB_URL=…@postgres:5432/omnibase_infra`:

| Check | Ticket baseline (broken) | After this PR (live dev) |
|---|---|---|
| overall | 0 pass / 108 quarantine | **52 pass / 56 quarantine** |
| projection_state | 108 quarantine | **108 PASS** |
| publication | 65 pass / 90 quarantine (all reachability = `127.0.0.1:9092`) | 65 pass / 90 quarantine (broker reachable; remaining quarantines are rpk-JSON-schema drift, see below) |
| subscription | 59 pass / 95 quarantine | 59 pass / 95 quarantine |

Broker reachability independently confirmed: `rpk topic describe onex.evt.platform.node-heartbeat.v1` inside the dev redpanda container reports `HIGH-WATERMARK=4933` (live data). Report: `omni_home/.onex_state/contract-sweep/OMN-13555/runtime-report-all.json`.

DoD #3 satisfied: real PASS/FAIL/QUARANTINE mix, not 100% QUARANTINE. `projection_state` went 108-QUARANTINE → 108-PASS (Defect 2 proven). The publication failure mode moved from "env ignored → dial `127.0.0.1:9092`" to "broker reached" (Defect 1 proven).

### Out of scope (follow-up)
With the broker now reachable, the publication probe surfaces a **separate, pre-existing** defect: the latest `rpk topic describe --format json` returns a top-level JSON list, but `_rpk_watermark_fallback` parses `data.get("partitions")` (older/different schema), producing `'list' object has no attribute 'get'`. That rpk-JSON-schema drift is independent of the two wiring defects this ticket fixes and should be a separate ticket — fixing it here would expand scope beyond OMN-13555.

Evidence-Source: e9e8c1a291af12d8cf54ff13073e77d9e5adb4ce
Evidence-Ticket: OMN-13555