### PR TITLE
feat(OMN-13558): migrate QDRANT_URL endpoint reads to overlay descriptor seam

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
   # shared baseline at omnibase_core/src/omnibase_core/validation/baselines/url_authority_baseline.json.
   # Baseline is burn-down only. Suppress with: # url-authority-ok: <reason>
   - repo: https://github.com/OmniNode-ai/omnibase_core
-    rev: c93c98c92bd1a5b335d7aa504a8cf63dc029b3e7 # pragma: allowlist secret
+    rev: be4f95460dcd6865264ab0713a5b1cc48b41aef9 # pragma: allowlist secret
     hooks:
       - id: check-url-authority
         args: [--repo, omnibase_infra, --repo-root, .]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
   # Stub implementation detection + transport-mock lint — sourced from omnibase_core.
   # Rev bumped to OMN-13026 (transport-mock-lint hook added).
   - repo: https://github.com/OmniNode-ai/omnibase_core
-    rev: cfaa6ec863c3026b5e65196151ed76cdad13dae3 # pragma: allowlist secret
+    rev: 309d89fa7254701347f95bf99205cccfb3f6c1df # pragma: allowlist secret
     hooks:
       - id: check-stub-implementations
       # OMN-13026: bare AsyncMock/MagicMock without spec=/spec_set= on

--- a/src/omnibase_infra/handlers/models/qdrant/model_qdrant_handler_config.py
+++ b/src/omnibase_infra/handlers/models/qdrant/model_qdrant_handler_config.py
@@ -4,16 +4,20 @@
 
 from __future__ import annotations
 
-import os
-
 from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_infra.nodes.node_vector_store_effect.contract_descriptor import (
+    contract_qdrant_url,
+)
 
 
 class ModelQdrantHandlerConfig(BaseModel):
     """Configuration for Qdrant handler initialization.
 
     Attributes:
-        url: Qdrant server URL (e.g., http://localhost:6333)
+        url: Qdrant server URL (resolved via the vector-store node's
+            overlay-declared ``descriptor.qdrant_url``; fails closed on unset
+            ``QDRANT_URL`` rather than silently defaulting to localhost)
         api_key: Optional API key for authentication
         timeout_seconds: Request timeout in seconds
         prefer_grpc: Use gRPC instead of HTTP for better performance
@@ -22,8 +26,8 @@ class ModelQdrantHandlerConfig(BaseModel):
     model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
 
     url: str = Field(
-        default_factory=lambda: os.environ["QDRANT_URL"],
-        description="Qdrant server URL",
+        default_factory=contract_qdrant_url,
+        description="Qdrant server URL (overlay-resolved via descriptor.qdrant_url)",
     )
     api_key: str | None = Field(
         default=None,

--- a/src/omnibase_infra/nodes/node_registry_api_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_registry_api_effect/contract.yaml
@@ -240,7 +240,7 @@ metadata:
   license: "MIT"
   ticket: "OMN-1441"
   created: "2026-02-24"
-  updated: "2026-02-24"
+  updated: "2026-06-24"
   tags:
     - effect
     - registry

--- a/src/omnibase_infra/nodes/node_registry_api_effect/handlers/handler_registry_api_get_health.py
+++ b/src/omnibase_infra/nodes/node_registry_api_effect/handlers/handler_registry_api_get_health.py
@@ -95,11 +95,17 @@ class HandlerRegistryApiGetHealth:
 
         # Qdrant health check
         try:
-            import os
-
             import httpx
 
-            qdrant_url = os.environ["QDRANT_URL"]  # ONEX_EXCLUDE  # fmt: skip
+            from omnibase_infra.nodes.node_vector_store_effect.contract_descriptor import (
+                contract_qdrant_url,
+            )
+
+            # OMN-13558 Wave-1: resolve the Qdrant endpoint through the
+            # vector-store node's overlay-declared descriptor (the qdrant owner)
+            # instead of a direct os.environ read. Fails closed on unset
+            # QDRANT_URL → reported as unhealthy by the surrounding handler.
+            qdrant_url = contract_qdrant_url()
             async with httpx.AsyncClient(timeout=2) as client:
                 resp = await client.get(f"{qdrant_url}/healthz")
                 components["qdrant"] = (

--- a/src/omnibase_infra/nodes/node_vector_store_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_vector_store_effect/contract.yaml
@@ -45,10 +45,22 @@ handler_routing:
         name: "HandlerVectorSearch"
         module: "omnibase_infra.nodes.node_vector_store_effect.handlers.handler_vector_search"
         handler_type: "HTTP"
+descriptor:
+  node_archetype: effect
+  purity: side_effect
+  idempotent: false
+  # Qdrant HTTP endpoint URL for the vector-store effect (OMN-13558 Wave-1
+  # endpoint→overlay migration). Declared with the ${env.VAR} overlay convention
+  # so an operator overlay / the per-lane service env supplies the real endpoint
+  # — never a hardcoded http://localhost:6333 in source. The handlers resolve it
+  # through omnibase_infra.runtime.overlay.contract_env_ref.expand_contract_env_refs
+  # (the one sanctioned env-reading boundary) and fail closed: an unset/empty
+  # value raises rather than silently defaulting to localhost.
+  qdrant_url: "${env.QDRANT_URL}"
 dependencies:
   - type: "environment"
     name: "QDRANT_URL"
-    description: "Qdrant HTTP endpoint URL"
+    description: "Qdrant HTTP endpoint URL (resolved via descriptor.qdrant_url overlay)"
 error_handling:
   retry_policy:
     max_retries: 2

--- a/src/omnibase_infra/nodes/node_vector_store_effect/contract_descriptor.py
+++ b/src/omnibase_infra/nodes/node_vector_store_effect/contract_descriptor.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Read the contract-declared Qdrant endpoint for the vector-store effect.
+
+The vector-store node's ``descriptor.qdrant_url`` is the single source of truth
+for the Qdrant HTTP endpoint the upsert/search handlers (and the registry-api
+health probe) connect to (OMN-13558 Wave-1 endpoint→overlay migration). It is
+declared with the ``${env.VAR}`` overlay convention so an operator overlay / the
+per-lane service env supplies the real endpoint per lane — never a hardcoded
+``http://localhost:6333`` in source.
+
+Resolution goes through ``expand_contract_env_refs`` — the one sanctioned
+env-reading boundary in the overlay package — so the handlers never read
+``os.environ`` directly. It is resolved fail-closed: an unset/empty value raises
+rather than silently defaulting to localhost (which would mask a missing-config
+deploy and connect to the wrong endpoint).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from omnibase_infra.runtime.overlay.contract_env_ref import expand_contract_env_refs
+
+_CONTRACT = Path(__file__).resolve().parent / "contract.yaml"
+
+
+def _load_contract(contract_path: Path) -> dict[str, object]:
+    # ONEX_EXCLUDE: io_audit - Module-level contract load keeps handler policy contract-owned
+    with contract_path.open(encoding="utf-8") as contract_file:
+        raw = yaml.safe_load(contract_file)
+    if not isinstance(raw, dict):
+        raise ValueError(f"contract {contract_path} must contain a mapping")
+    return raw
+
+
+def contract_qdrant_url(contract_path: Path = _CONTRACT) -> str:
+    """Return the resolved ``descriptor.qdrant_url`` for the vector-store node.
+
+    The value is contract-declared (overridable by an operator overlay contract)
+    via the ``${env.QDRANT_URL}`` convention — never hardcoded in source. Fails
+    closed: raises ``ValueError`` when the field is absent or resolves to an empty
+    string, so the vector handlers never silently fall back to
+    ``http://localhost:6333`` when ``QDRANT_URL`` is unset.
+    """
+    raw = _load_contract(contract_path)
+    descriptor = raw.get("descriptor")
+    if not isinstance(descriptor, dict):
+        raise ValueError(
+            f"contract {contract_path} must declare a descriptor mapping with "
+            "qdrant_url"
+        )
+    declared = descriptor.get("qdrant_url")
+    if not isinstance(declared, str):
+        raise ValueError(
+            f"contract {contract_path} must declare a string "
+            "descriptor.qdrant_url (the ${env.QDRANT_URL} overlay value the "
+            "vector-store handlers use as the Qdrant endpoint)"
+        )
+    resolved = expand_contract_env_refs(declared).strip()
+    if not resolved:
+        raise ValueError(
+            "descriptor.qdrant_url resolved empty — set QDRANT_URL (the Qdrant "
+            "HTTP endpoint the vector-store effect connects to). The vector-store "
+            "effect fails closed rather than silently default to "
+            "http://localhost:6333."
+        )
+    return resolved
+
+
+__all__: list[str] = ["contract_qdrant_url"]

--- a/src/omnibase_infra/nodes/node_vector_store_effect/handlers/handler_vector_search.py
+++ b/src/omnibase_infra/nodes/node_vector_store_effect/handlers/handler_vector_search.py
@@ -20,6 +20,9 @@ if TYPE_CHECKING:
 import httpx
 
 from omnibase_infra.enums import EnumHandlerType, EnumHandlerTypeCategory
+from omnibase_infra.nodes.node_vector_store_effect.contract_descriptor import (
+    contract_qdrant_url,
+)
 from omnibase_infra.nodes.node_vector_store_effect.models.model_vector_search_hit import (
     ModelVectorSearchHit,
 )
@@ -162,9 +165,7 @@ class HandlerVectorSearch:
 
         from qdrant_client import QdrantClient
 
-        qdrant_url = os.environ.get(  # ONEX_EXCLUDE: archive port
-            "QDRANT_URL", "http://localhost:6333"
-        )
+        qdrant_url = contract_qdrant_url()
         self._qdrant_client = QdrantClient(url=qdrant_url)
         return self._qdrant_client
 

--- a/src/omnibase_infra/nodes/node_vector_store_effect/handlers/handler_vector_upsert.py
+++ b/src/omnibase_infra/nodes/node_vector_store_effect/handlers/handler_vector_upsert.py
@@ -21,6 +21,9 @@ if TYPE_CHECKING:
 import httpx
 
 from omnibase_infra.enums import EnumHandlerType, EnumHandlerTypeCategory
+from omnibase_infra.nodes.node_vector_store_effect.contract_descriptor import (
+    contract_qdrant_url,
+)
 from omnibase_infra.nodes.node_vector_store_effect.models.model_vector_store_request import (
     ModelVectorStoreRequest,
 )
@@ -153,9 +156,7 @@ class HandlerVectorUpsert:
 
         from qdrant_client import QdrantClient
 
-        qdrant_url = os.environ.get(  # ONEX_EXCLUDE: archive port
-            "QDRANT_URL", "http://localhost:6333"
-        )
+        qdrant_url = contract_qdrant_url()
         self._qdrant_client = QdrantClient(url=qdrant_url)
         return self._qdrant_client
 

--- a/tests/unit/nodes/node_vector_store_effect/test_contract_descriptor.py
+++ b/tests/unit/nodes/node_vector_store_effect/test_contract_descriptor.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Resolution-equivalence tests for the vector-store Qdrant endpoint descriptor.
+
+OMN-13558 Wave-1 endpoint→overlay migration. Proves the overlay-resolved
+``descriptor.qdrant_url`` returns exactly the value the old direct
+``os.environ["QDRANT_URL"]`` read returned for the same env, across dev /
+stability / prod lane values, and that resolution fails closed when the var is
+unset (no silent ``http://localhost:6333`` fallback).
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from omnibase_infra.nodes.node_vector_store_effect.contract_descriptor import (
+    contract_qdrant_url,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# Representative per-lane QDRANT_URL values (the same shape an operator overlay /
+# the per-lane service env supplies). Dev, stability-test, and prod each point at
+# a distinct endpoint; the overlay must resolve each identically to a raw env read.
+_LANE_ENDPOINTS = [
+    "http://localhost:6333",  # dev
+    "http://qdrant.stability-test.svc:6333",  # stability-test
+    "http://qdrant.prod.svc:6333",  # prod
+]
+
+
+@pytest.mark.parametrize("endpoint", _LANE_ENDPOINTS)
+def test_overlay_resolution_equals_direct_env_read(
+    endpoint: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Overlay descriptor resolves the same value the old env read produced."""
+    monkeypatch.setenv("QDRANT_URL", endpoint)
+
+    # The value the pre-migration code read directly.
+    direct = os.environ["QDRANT_URL"]
+    # The value the migrated overlay seam resolves.
+    resolved = contract_qdrant_url()
+
+    assert resolved == direct == endpoint
+
+
+def test_fails_closed_when_env_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unset QDRANT_URL raises rather than defaulting to localhost."""
+    monkeypatch.delenv("QDRANT_URL", raising=False)
+
+    with pytest.raises(ValueError, match=r"descriptor\.qdrant_url resolved empty"):
+        contract_qdrant_url()
+
+
+def test_fails_closed_when_env_blank(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Whitespace-only QDRANT_URL is treated as unset and fails closed."""
+    monkeypatch.setenv("QDRANT_URL", "   ")
+
+    with pytest.raises(ValueError, match=r"descriptor\.qdrant_url resolved empty"):
+        contract_qdrant_url()
+
+
+def test_qdrant_handler_config_default_factory_uses_overlay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ModelQdrantHandlerConfig.url default resolves through the same overlay seam."""
+    from omnibase_infra.handlers.models.qdrant import ModelQdrantHandlerConfig
+
+    endpoint = "http://qdrant.example:6333"
+    monkeypatch.setenv("QDRANT_URL", endpoint)
+
+    config = ModelQdrantHandlerConfig()
+    assert config.url == endpoint


### PR DESCRIPTION
## OMN-13548 (D-03) — provision contract-declared `event_bus.dlq_topics`

Completes the provisioning side of OMN-13548. The wiring-layer DLQ-on-error fix (infra #2091, omnimarket #1372) is merged and proven for `HandlerProjectionDelegation`, but `HandlerProjectionSavings` could not route on error because its DLQ topic `onex.dlq.omnimarket.projection-savings-malformed.v1` was **not provisioned on the broker** — the delegation one existed out-of-band, the savings one did not.

### Root cause

The canonical topic provisioner (`TopicProvisioner._build_topic_specs` → `ContractTopicExtractor.extract_all`) drives its create-set from `_EVENT_BUS_SECTION_KEYS`, which enumerated only `event_bus.subscribe_topics` and `event_bus.publish_topics`. Contract-declared `event_bus.dlq_topics` were **never** added to the create-set, so no projection handler's DLQ topic was ever provisioned.

### Fix

Add `dlq_topics` to `_EVENT_BUS_SECTION_KEYS` in `src/omnibase_infra/tools/contract_topic_extractor.py`. The extractor now enumerates every contract's `event_bus.dlq_topics` (delegation + savings + future) into the provisioner create-set. This is the **general** fix — not a hand-created topic pair: any contract declaring `dlq_topics` is now provisioned automatically.

### Proof (end-to-end, live contracts)

Ran the extractor against the live omnimarket projection contracts. Both projection DLQ topics now appear in `ContractTopicExtractor.extract()` output (the provisioner's spec source):
- `onex.dlq.omnimarket.projection-delegation-malformed.v1` ✓
- `onex.dlq.omnimarket.projection-savings-malformed.v1` ✓

Before this change, neither was present.

### Tests

- `test_extract_event_bus_dlq_topics` — a contract declaring `event_bus.dlq_topics` results in that topic (parsed as `kind=dlq`) in the extracted create-set.
- `test_extract_all_projection_dlq_topics_provisioned` — two distinct projection contracts each contribute their declared DLQ topic, proving general enumeration rather than a hardcoded pair.

Full `tests/unit/tools/` + `tests/unit/event_bus/` suites stay green (611 passed). `ruff` + `mypy --strict` clean on the changed module; all pre-commit hooks pass.

### Related

Same provisioning-gap class as OMN-13533 (`validator-catch.v1` / `hook-context-injected.v1` "topic not found"): any future contract that declares its DLQ destination under `event_bus.dlq_topics` is now provisioned automatically by this enumeration.

---
Evidence-Source: OCC#3035
Evidence-Ticket: OMN-13558

