### PR TITLE
fix(OMN-13548): provision contract-declared event_bus.dlq_topics (D-03)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
   # shared baseline at omnibase_core/src/omnibase_core/validation/baselines/url_authority_baseline.json.
   # Baseline is burn-down only. Suppress with: # url-authority-ok: <reason>
   - repo: https://github.com/OmniNode-ai/omnibase_core
-    rev: c93c98c92bd1a5b335d7aa504a8cf63dc029b3e7 # pragma: allowlist secret
+    rev: be4f95460dcd6865264ab0713a5b1cc48b41aef9 # pragma: allowlist secret
     hooks:
       - id: check-url-authority
         args: [--repo, omnibase_infra, --repo-root, .]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
   # Stub implementation detection + transport-mock lint — sourced from omnibase_core.
   # Rev bumped to OMN-13026 (transport-mock-lint hook added).
   - repo: https://github.com/OmniNode-ai/omnibase_core
-    rev: cfaa6ec863c3026b5e65196151ed76cdad13dae3 # pragma: allowlist secret
+    rev: 309d89fa7254701347f95bf99205cccfb3f6c1df # pragma: allowlist secret
     hooks:
       - id: check-stub-implementations
       # OMN-13026: bare AsyncMock/MagicMock without spec=/spec_set= on

--- a/src/omnibase_infra/tools/contract_topic_extractor.py
+++ b/src/omnibase_infra/tools/contract_topic_extractor.py
@@ -71,6 +71,13 @@ _EVENT_SECTION_KEYS: tuple[str, ...] = (
 _EVENT_BUS_SECTION_KEYS: tuple[str, ...] = (
     "subscribe_topics",
     "publish_topics",
+    # OMN-13548: contract-declared DLQ destinations for malformed inbound
+    # events. Projection handlers (delegation, savings, future) declare their
+    # dead-letter topic under ``event_bus.dlq_topics``; the wiring routes to it
+    # on handler error. Those topics must be provisioned on the broker just like
+    # publish/subscribe topics — otherwise the handler cannot route and the
+    # row is silently dropped (the failure mode that motivated this ticket).
+    "dlq_topics",
 )
 
 

--- a/tests/unit/tools/test_contract_topic_extractor.py
+++ b/tests/unit/tools/test_contract_topic_extractor.py
@@ -268,6 +268,85 @@ def test_extract_event_bus_publish_topics(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# event_bus.dlq_topics — contract-declared DLQ destinations (OMN-13548)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_extract_event_bus_dlq_topics(tmp_path: Path) -> None:
+    """event_bus.dlq_topics[] entries reach the provisioner create-set.
+
+    OMN-13548 (D-03): a projection handler's malformed-input DLQ topic is
+    declared under ``event_bus.dlq_topics``. Before this fix the extractor only
+    enumerated subscribe/publish topics, so the DLQ topic was never provisioned
+    on the broker and the handler could not route — silently dropping the row.
+    """
+    write_contract(
+        tmp_path,
+        "node_projection_savings",
+        """
+        event_bus:
+          subscribe_topics:
+            - "onex.evt.omnimarket.savings-estimated.v1"
+          dlq_topics:
+            - "onex.dlq.omnimarket.projection-savings-malformed.v1"
+        """,
+    )
+    extractor = ContractTopicExtractor()
+    results = extractor.extract(tmp_path)
+
+    topics = {e.topic for e in results}
+    assert "onex.dlq.omnimarket.projection-savings-malformed.v1" in topics
+
+    dlq_entry = next(
+        e
+        for e in results
+        if e.topic == "onex.dlq.omnimarket.projection-savings-malformed.v1"
+    )
+    assert dlq_entry.kind == "dlq"
+    assert dlq_entry.producer == "omnimarket"
+    assert dlq_entry.event_name == "projection-savings-malformed"
+    assert dlq_entry.version == "v1"
+
+
+@pytest.mark.unit
+def test_extract_all_projection_dlq_topics_provisioned(tmp_path: Path) -> None:
+    """Both projection DLQ topics (delegation + savings) reach the create-set.
+
+    Proves the general ``dlq_topics`` enumeration — not a hand-listed pair — by
+    declaring two distinct projection contracts and asserting each contract's
+    declared DLQ topic appears in the extracted (i.e. provisioned) topic set.
+    """
+    write_contract(
+        tmp_path,
+        "node_projection_delegation",
+        """
+        event_bus:
+          subscribe_topics:
+            - "onex.evt.omnimarket.delegation-attempted.v1"
+          dlq_topics:
+            - "onex.dlq.omnimarket.projection-delegation-malformed.v1"
+        """,
+    )
+    write_contract(
+        tmp_path,
+        "node_projection_savings",
+        """
+        event_bus:
+          subscribe_topics:
+            - "onex.evt.omnimarket.savings-estimated.v1"
+          dlq_topics:
+            - "onex.dlq.omnimarket.projection-savings-malformed.v1"
+        """,
+    )
+    extractor = ContractTopicExtractor()
+    topics = {e.topic for e in extractor.extract(tmp_path)}
+
+    assert "onex.dlq.omnimarket.projection-delegation-malformed.v1" in topics
+    assert "onex.dlq.omnimarket.projection-savings-malformed.v1" in topics
+
+
+# ---------------------------------------------------------------------------
 # No early break — all sections are always checked
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## OMN-13548 (D-03) — provision contract-declared `event_bus.dlq_topics`

Completes the provisioning side of OMN-13548. The wiring-layer DLQ-on-error fix (infra #2091, omnimarket #1372) is merged and proven for `HandlerProjectionDelegation`, but `HandlerProjectionSavings` could not route on error because its DLQ topic `onex.dlq.omnimarket.projection-savings-malformed.v1` was **not provisioned on the broker** — the delegation one existed out-of-band, the savings one did not.

### Root cause

The canonical topic provisioner (`TopicProvisioner._build_topic_specs` → `ContractTopicExtractor.extract_all`) drives its create-set from `_EVENT_BUS_SECTION_KEYS`, which enumerated only `event_bus.subscribe_topics` and `event_bus.publish_topics`. Contract-declared `event_bus.dlq_topics` were **never** added to the create-set, so no projection handler's DLQ topic was ever provisioned.

### Fix

Add `dlq_topics` to `_EVENT_BUS_SECTION_KEYS` in `src/omnibase_infra/tools/contract_topic_extractor.py`. The extractor now enumerates every contract's `event_bus.dlq_topics` (delegation + savings + future) into the provisioner create-set. This is the **general** fix — not a hand-created topic pair: any contract declaring `dlq_topics` is now provisioned automatically.

### Proof (end-to-end, live contracts)

Ran the extractor against the live omnimarket projection contracts. Both projection DLQ topics now appear in `ContractTopicExtractor.extract()` output (the provisioner's spec source):
- `onex.dlq.omnimarket.projection-delegation-malformed.v1`
- `onex.dlq.omnimarket.projection-savings-malformed.v1`

Before this change, neither was present.

### Tests

- `test_extract_event_bus_dlq_topics` — a contract declaring `event_bus.dlq_topics` results in that topic (parsed as `kind=dlq`) in the extracted create-set.
- `test_extract_all_projection_dlq_topics_provisioned` — two distinct projection contracts each contribute their declared DLQ topic, proving general enumeration rather than a hardcoded pair.

Full `tests/unit/tools/` + `tests/unit/event_bus/` suites stay green (611 passed). `ruff` + `mypy --strict` clean; all pre-commit hooks pass.

### Related

Same provisioning-gap class as OMN-13533 (`validator-catch.v1` / `hook-context-injected.v1` "topic not found"): any future contract that declares its DLQ destination under `event_bus.dlq_topics` is now provisioned automatically by this enumeration.

---
Evidence-Source: 5e6e2f948f78ef88ac365baeb5a2927b7ab2a34a
Evidence-Ticket: OMN-13548
