### PR TITLE
feat(OMN-13558): migrate GRAPH_BOLT_URI endpoint reads to overlay descriptor seam

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
   # shared baseline at omnibase_core/src/omnibase_core/validation/baselines/url_authority_baseline.json.
   # Baseline is burn-down only. Suppress with: # url-authority-ok: <reason>
   - repo: https://github.com/OmniNode-ai/omnibase_core
-    rev: c93c98c92bd1a5b335d7aa504a8cf63dc029b3e7 # pragma: allowlist secret
+    rev: be4f95460dcd6865264ab0713a5b1cc48b41aef9 # pragma: allowlist secret
     hooks:
       - id: check-url-authority
         args: [--repo, omnibase_infra, --repo-root, .]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
   # Stub implementation detection + transport-mock lint — sourced from omnibase_core.
   # Rev bumped to OMN-13026 (transport-mock-lint hook added).
   - repo: https://github.com/OmniNode-ai/omnibase_core
-    rev: cfaa6ec863c3026b5e65196151ed76cdad13dae3 # pragma: allowlist secret
+    rev: 309d89fa7254701347f95bf99205cccfb3f6c1df # pragma: allowlist secret
     hooks:
       - id: check-stub-implementations
       # OMN-13026: bare AsyncMock/MagicMock without spec=/spec_set= on

--- a/src/omnibase_infra/contracts/handlers/graph/handler_contract.yaml
+++ b/src/omnibase_infra/contracts/handlers/graph/handler_contract.yaml
@@ -13,6 +13,14 @@ descriptor:
   node_archetype: effect
   purity: side_effecting
   idempotent: false
+  # Bolt endpoint URL for the graph handler (Memgraph/Neo4j) — OMN-13558 Wave-1
+  # endpoint→overlay migration. Declared with the ${env.VAR} overlay convention so
+  # an operator overlay / the per-lane service env supplies the real endpoint per
+  # lane; the handler resolves it via expand_contract_env_refs (the one sanctioned
+  # env boundary) and fails closed when GRAPH_BOLT_URI is unset — never a hardcoded
+  # bolt://localhost:7687 in source. Explicit connection_uri/bolt_uri config-dict
+  # keys still override this descriptor when supplied.
+  graph_bolt_uri: "${env.GRAPH_BOLT_URI}"
   timeout_ms: 30000
   retry_policy:
     enabled: true

--- a/src/omnibase_infra/handlers/handler_graph.py
+++ b/src/omnibase_infra/handlers/handler_graph.py
@@ -33,7 +33,6 @@ Circuit Breaker Pattern:
 from __future__ import annotations
 
 import logging
-import os
 import re
 import time
 from collections.abc import Mapping
@@ -80,6 +79,9 @@ from omnibase_infra.handlers.models.graph import (
     ModelGraphHandlerPayload,
     ModelGraphQueryPayload,
     ModelGraphRecord,
+)
+from omnibase_infra.handlers.models.graph.contract_descriptor import (
+    contract_graph_bolt_uri,
 )
 from omnibase_infra.handlers.models.model_graph_handler_response import (
     ModelGraphHandlerResponse,
@@ -262,24 +264,20 @@ class HandlerGraph(
         # (passed by _populate_handlers_from_registry via initialize(effective_config)).
         resolved_uri: str
         if isinstance(connection_uri, dict):
-            # Resolve URI from dict keys, then env vars, then hard-coded default.
-            _env_memgraph = os.environ.get("MEMGRAPH_BOLT_URI")  # ONEX_EXCLUDE: env
-            _env_graph = os.environ.get("GRAPH_BOLT_URI")  # ONEX_EXCLUDE: env
-            # Build from OMNIMEMORY_MEMGRAPH_HOST/PORT (compose-aligned) [OMN-5357]
-            _env_host = os.environ.get("OMNIMEMORY_MEMGRAPH_HOST")  # ONEX_EXCLUDE: env
-            _env_port = os.environ.get(
-                "OMNIMEMORY_MEMGRAPH_PORT", "7687"
-            )  # ONEX_EXCLUDE: env
-            _env_composed = f"bolt://{_env_host}:{_env_port}" if _env_host else None
+            # Resolve URI from explicit dict-key overrides, else the
+            # contract-declared overlay endpoint (OMN-13558 Wave-1
+            # endpoint→overlay migration). The descriptor binds
+            # ``descriptor.graph_bolt_uri == ${env.GRAPH_BOLT_URI}`` through the
+            # sanctioned overlay boundary (``expand_contract_env_refs``) and fails
+            # closed when GRAPH_BOLT_URI is unset — never a silent
+            # ``bolt://localhost:7687`` default. Explicit ``connection_uri`` /
+            # ``bolt_uri`` keys still win when supplied by the caller.
             resolved_uri = (
                 str(connection_uri["connection_uri"])
                 if "connection_uri" in connection_uri
                 else str(connection_uri["bolt_uri"])
                 if "bolt_uri" in connection_uri
-                else _env_memgraph
-                or _env_graph
-                or _env_composed
-                or "bolt://localhost:7687"
+                else contract_graph_bolt_uri()
             )
             dict_auth = connection_uri.get("auth")
             if (

--- a/src/omnibase_infra/handlers/handler_graph.py
+++ b/src/omnibase_infra/handlers/handler_graph.py
@@ -232,10 +232,10 @@ class HandlerGraph(
                 the URI is resolved from the following keys in priority order:
                   1. ``connection_uri``
                   2. ``bolt_uri``
-                  3. ``MEMGRAPH_BOLT_URI`` environment variable
-                  4. ``GRAPH_BOLT_URI`` environment variable
-                  5. ``OMNIMEMORY_MEMGRAPH_HOST``/``OMNIMEMORY_MEMGRAPH_PORT`` env vars
-                  6. Hard-coded default ``bolt://localhost:7687``
+                  3. the contract-declared ``descriptor.graph_bolt_uri`` (``${env.GRAPH_BOLT_URI}``),
+                     resolved through the overlay seam (``expand_contract_env_refs``) and
+                     failing closed when unset — no silent ``bolt://localhost:7687`` default
+                     (OMN-13558 Wave-1 endpoint→overlay migration).
                 Additional dict keys ``auth`` and ``options`` are also extracted.
             auth: Optional tuple of (username, password) for authentication.
                 Ignored when connection_uri is a dict that contains an ``auth`` key.

--- a/src/omnibase_infra/handlers/models/graph/contract_descriptor.py
+++ b/src/omnibase_infra/handlers/models/graph/contract_descriptor.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Read the contract-declared graph (Bolt) endpoint for the graph handler.
+
+The graph handler's ``descriptor.graph_bolt_uri`` is the single source of truth
+for the Bolt endpoint the Cypher operations (Memgraph/Neo4j) connect to when no
+explicit ``connection_uri`` / ``bolt_uri`` override is supplied in the handler
+config dict (OMN-13558 Wave-1 endpoint→overlay migration). It is declared with
+the ``${env.VAR}`` overlay convention so an operator overlay / the per-lane
+service env supplies the real endpoint per lane — never a hardcoded
+``bolt://localhost:7687`` in source.
+
+Resolution goes through ``expand_contract_env_refs`` — the one sanctioned
+env-reading boundary in the overlay package — so the handler never reads
+``os.environ`` directly. It is resolved fail-closed: an unset/empty value raises
+rather than silently defaulting to localhost (which would mask a missing-config
+deploy and connect to the wrong endpoint).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from omnibase_infra.runtime.overlay.contract_env_ref import expand_contract_env_refs
+
+# The graph handler's authoritative contract lives under the infra contracts tree.
+# Resolved relative to this module so it is portable across machines / install
+# layouts (no hardcoded absolute path).
+_CONTRACT = (
+    Path(__file__).resolve().parents[3]
+    / "contracts"
+    / "handlers"
+    / "graph"
+    / "handler_contract.yaml"
+)
+
+
+def _load_contract(contract_path: Path) -> dict[str, object]:
+    # ONEX_EXCLUDE: io_audit - Module-level contract load keeps handler policy contract-owned
+    with contract_path.open(encoding="utf-8") as contract_file:
+        raw = yaml.safe_load(contract_file)
+    if not isinstance(raw, dict):
+        raise ValueError(f"contract {contract_path} must contain a mapping")
+    return raw
+
+
+def contract_graph_bolt_uri(contract_path: Path = _CONTRACT) -> str:
+    """Return the resolved ``descriptor.graph_bolt_uri`` for the graph handler.
+
+    The value is contract-declared (overridable by an operator overlay contract)
+    via the ``${env.GRAPH_BOLT_URI}`` convention — never hardcoded in source.
+    Fails closed: raises ``ValueError`` when the field is absent or resolves to
+    an empty string, so the graph handler never silently falls back to
+    ``bolt://localhost:7687`` when ``GRAPH_BOLT_URI`` is unset.
+    """
+    raw = _load_contract(contract_path)
+    descriptor = raw.get("descriptor")
+    if not isinstance(descriptor, dict):
+        raise ValueError(
+            f"contract {contract_path} must declare a descriptor mapping with "
+            "graph_bolt_uri"
+        )
+    declared = descriptor.get("graph_bolt_uri")
+    if not isinstance(declared, str):
+        raise ValueError(
+            f"contract {contract_path} must declare a string "
+            "descriptor.graph_bolt_uri (the ${env.GRAPH_BOLT_URI} overlay value "
+            "the graph handler uses as the Bolt endpoint)"
+        )
+    resolved = expand_contract_env_refs(declared).strip()
+    if not resolved:
+        raise ValueError(
+            "descriptor.graph_bolt_uri resolved empty — set GRAPH_BOLT_URI (the "
+            "Bolt endpoint the graph handler connects to). The graph handler "
+            "fails closed rather than silently default to bolt://localhost:7687."
+        )
+    return resolved
+
+
+__all__: list[str] = ["contract_graph_bolt_uri"]

--- a/src/omnibase_infra/handlers/models/graph/model_graph_handler_config.py
+++ b/src/omnibase_infra/handlers/models/graph/model_graph_handler_config.py
@@ -2,9 +2,11 @@
 # SPDX-License-Identifier: MIT
 """Configuration model for HandlerGraph."""
 
-import os
-
 from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_infra.handlers.models.graph.contract_descriptor import (
+    contract_graph_bolt_uri,
+)
 
 
 class ModelGraphHandlerConfig(BaseModel):
@@ -24,8 +26,11 @@ class ModelGraphHandlerConfig(BaseModel):
     model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
 
     uri: str = Field(
-        default_factory=lambda: os.environ["GRAPH_BOLT_URI"],
-        description="Bolt URI for graph database",
+        default_factory=contract_graph_bolt_uri,
+        description=(
+            "Bolt URI for graph database (contract ${env.GRAPH_BOLT_URI}, "
+            "resolved via the overlay seam — fails closed when unset)"
+        ),
     )
     username: str = Field(
         default="",

--- a/src/omnibase_infra/runtime/handler_contract_source.py
+++ b/src/omnibase_infra/runtime/handler_contract_source.py
@@ -671,6 +671,7 @@ class HandlerContractSource(ProtocolContractSource):
             # Strip extra fields in nested descriptor.retry_policy
             descriptor = validation_data.get("descriptor")
             if isinstance(descriptor, dict):
+                descriptor.pop("graph_bolt_uri", None)
                 retry_policy = descriptor.get("retry_policy")
                 if isinstance(retry_policy, dict):
                     retry_policy.pop("backoff_ms", None)

--- a/tests/unit/handlers/models/graph/__init__.py
+++ b/tests/unit/handlers/models/graph/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for Graph handler models package."""

--- a/tests/unit/handlers/models/graph/test_contract_descriptor.py
+++ b/tests/unit/handlers/models/graph/test_contract_descriptor.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Resolution-equivalence tests for the graph handler Bolt endpoint descriptor.
+
+OMN-13558 Wave-1 endpoint→overlay migration. Proves the overlay-resolved
+``descriptor.graph_bolt_uri`` returns exactly the value the old direct
+``os.environ["GRAPH_BOLT_URI"]`` read returned for the same env, across dev /
+stability / prod lane values, and that resolution fails closed when the var is
+unset (no silent ``bolt://localhost:7687`` fallback).
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from omnibase_infra.handlers.models.graph.contract_descriptor import (
+    contract_graph_bolt_uri,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# Representative per-lane GRAPH_BOLT_URI values (the same shape an operator
+# overlay / the per-lane service env supplies). Dev, stability-test, and prod
+# each point at a distinct Bolt endpoint; the overlay must resolve each
+# identically to a raw env read.
+_LANE_ENDPOINTS = [
+    "bolt://localhost:7687",  # dev
+    "bolt://memgraph.stability-test.svc:7687",  # stability-test
+    "bolt://memgraph.prod.svc:7687",  # prod
+]
+
+
+@pytest.mark.parametrize("endpoint", _LANE_ENDPOINTS)
+def test_overlay_resolution_equals_direct_env_read(
+    endpoint: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Overlay descriptor resolves the same value the old env read produced."""
+    monkeypatch.setenv("GRAPH_BOLT_URI", endpoint)
+
+    # The value the pre-migration code read directly.
+    direct = os.environ["GRAPH_BOLT_URI"]
+    # The value the migrated overlay seam resolves.
+    resolved = contract_graph_bolt_uri()
+
+    assert resolved == direct == endpoint
+
+
+def test_fails_closed_when_env_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unset GRAPH_BOLT_URI raises rather than defaulting to localhost."""
+    monkeypatch.delenv("GRAPH_BOLT_URI", raising=False)
+
+    with pytest.raises(ValueError, match=r"descriptor\.graph_bolt_uri resolved empty"):
+        contract_graph_bolt_uri()
+
+
+def test_fails_closed_when_env_blank(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Whitespace-only GRAPH_BOLT_URI is treated as unset and fails closed."""
+    monkeypatch.setenv("GRAPH_BOLT_URI", "   ")
+
+    with pytest.raises(ValueError, match=r"descriptor\.graph_bolt_uri resolved empty"):
+        contract_graph_bolt_uri()
+
+
+def test_graph_handler_config_default_factory_uses_overlay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ModelGraphHandlerConfig.uri default resolves through the same overlay seam."""
+    from omnibase_infra.handlers.models.graph import ModelGraphHandlerConfig
+
+    endpoint = "bolt://memgraph.example:7687"
+    monkeypatch.setenv("GRAPH_BOLT_URI", endpoint)
+
+    config = ModelGraphHandlerConfig()
+    assert config.uri == endpoint
+
+
+def test_graph_handler_config_fails_closed_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ModelGraphHandlerConfig() with no uri + unset env fails closed."""
+    monkeypatch.delenv("GRAPH_BOLT_URI", raising=False)
+
+    with pytest.raises(ValueError, match=r"descriptor\.graph_bolt_uri resolved empty"):
+        from omnibase_infra.handlers.models.graph import ModelGraphHandlerConfig
+
+        ModelGraphHandlerConfig()


### PR DESCRIPTION
## OMN-13558 / OMN-13556 — GRAPH_BOLT_URI endpoint reads → overlay descriptor seam (Wave-1, cluster 2)

Second Wave-1 endpoint cluster of OMN-13558, following the proven QDRANT_URL template (#2096). Moves the graph/Memgraph Bolt endpoint off scattered direct `os.environ` reads onto the canonical overlay seam.

### Changes
- **`contracts/handlers/graph/handler_contract.yaml`** — declares `descriptor.graph_bolt_uri = "${env.GRAPH_BOLT_URI}"`.
- **`handlers/models/graph/contract_descriptor.py`** (new) — resolves it via `omnibase_infra.runtime.overlay.contract_env_ref.expand_contract_env_refs` (the one sanctioned env boundary), **fail-closed**: unset/blank raises `ValueError` rather than silently defaulting to `bolt://localhost:7687`.
- **`handlers/handler_graph.py`** — the dict-config branch now resolves the endpoint via the descriptor. Removes the `MEMGRAPH_BOLT_URI` / `GRAPH_BOLT_URI` / `OMNIMEMORY_MEMGRAPH_HOST/PORT` / localhost fallback chain **and its 4 `# ONEX_EXCLUDE: env` grandfather suppressions**. Explicit `connection_uri` / `bolt_uri` dict keys still override.
- **`handlers/models/graph/model_graph_handler_config.py`** — `uri` default_factory resolves through the same seam (was direct `os.environ["GRAPH_BOLT_URI"]`); `import os` removed.
- **`tests/unit/handlers/models/graph/test_contract_descriptor.py`** (new) — resolution-equivalence: overlay resolves the same dev/stability/prod value the env read gave; fails closed when unset/blank; `ModelGraphHandlerConfig` default_factory routes through the seam.

### Proof
- `uv run pytest tests/unit/handlers/models/graph tests/unit/handlers/test_handler_graph.py tests/unit/runtime/overlay -q` → **122 passed**; full `tests/unit/handlers/` → **825 passed**.
- `ruff` + `mypy --strict` clean on changed files.
- URL Authority Gate + `check-env-reads` + No-localhost-fallback gates green with **FEWER** grandfathered reads — this migration REMOVES env reads, so the diff-based gates cannot regress.

### Scope note
`OMNIMEMORY_MEMGRAPH_HOST/PORT` (host+port pair: session graph projector `model_config_graph_projector.py` + the compose-aligned host path) is a distinct shape and a separate consumer surface — deferred to a follow-up.

### Evidence
Evidence-Source: OCC#3042
Evidence-Ticket: OMN-13558

Refs OMN-13558, OMN-13556.
