### PR TITLE
fix(OMN-13581): deploy-runtime.sh layers the lane overlay on all compose invocations

### DIFF
--- a/contracts/OMN-13581.yaml
+++ b/contracts/OMN-13581.yaml
@@ -1,0 +1,43 @@
+# OMN-13581 contract file for omnibase_infra deploy-gate.
+# The canonical ticket contract and PASS receipts live in onex_change_control.
+schema_version: "1.0.0"
+ticket_id: "OMN-13581"
+title: "fix(OMN-13581): deploy-runtime.sh layers the lane overlay on all compose invocations"
+summary: >-
+  deploy-runtime.sh invoked every docker compose call with only -f docker-compose.infra.yml, never layering the lane overlay (docker-compose.<lane>.yml). The base infra compose hardcodes container_name omnibase-infra-redpanda (the DEV name) and the dev network, so warm_broker_topic_provisioning's 'up redpanda' step recreated redpanda as the DEV-named container on any non-dev lane, collided with the live dev broker, got a Docker hash prefix, and landed in 'created' -- destroying the lane's own correctly-named broker (the ~3-day stability outage). The fix adds resolve_lane_overlay_filename()/resolve_compose_file_args() which derive the lane from the compose project suffix and layer the matching overlay onto infra.yml for stability-test/prod/judge projects; unknown non-dev projects fail closed. All compose call sites route through the resolver.
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: "tests"
+    description: "Lane-overlay layering tests pass (dev no overlay; stability/prod/judge layer their overlay; unknown lane fails closed; no bare-infra call site)."
+    command: "uv run pytest tests/scripts/test_deploy_runtime_lane_overlay.py -v"
+  - kind: "tests"
+    description: "Full deploy-runtime.sh script test suite remains green."
+    command: "uv run pytest tests/scripts/ -q"
+  - kind: "ci"
+    description: "Central OCC evidence for OMN-13581 is carried by the onex_change_control OCC PR."
+    command: "gh pr view <occ-pr> --repo OmniNode-ai/onex_change_control --json state"
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-lane-overlay-tests"
+    description: "Lane-overlay layering tests pass: dev gets infra.yml only; stability-test/prod/judge layer their overlay; an unknown non-dev project fails closed."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/scripts/test_deploy_runtime_lane_overlay.py -v"
+  - id: "dod-script-suite"
+    description: "The full deploy-runtime.sh script test suite passes (no regression)."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "uv run pytest tests/scripts/ -q"
+  - id: "dod-shellcheck"
+    description: "shellcheck reports no findings on the modified deploy-runtime.sh."
+    source: "manual"
+    checks:
+      - check_type: "command"
+        check_value: "shellcheck scripts/deploy-runtime.sh"

--- a/scripts/deploy-runtime.sh
+++ b/scripts/deploy-runtime.sh
@@ -350,6 +350,84 @@ resolve_compose_project() {
     echo "${compose_project}"
 }
 
+# Compose project -> lane (overlay) mapping. The dev lane (bare omnibase-infra
+# project) runs from docker-compose.infra.yml alone; every non-dev lane LAYERS
+# its overlay so the overlay's container_name + project name + lane network win.
+#
+# OMN-13581: deploy-runtime.sh historically passed ONLY `-f infra.yml` on every
+# `docker compose` call, including warm_broker_topic_provisioning's `up redpanda`
+# step. The base infra compose hardcodes `container_name: omnibase-infra-redpanda`
+# (the DEV name) and the dev network, so running the warmup against a non-dev
+# project (e.g. omnibase-infra-stability-test) makes compose try to (re)create
+# redpanda as the DEV-named container, which collides with the live dev broker,
+# gets a Docker hash prefix, and lands in 'created' -- DESTROYING the lane's own
+# correctly-named broker. That left the stability lane broker-less for ~3 days.
+# Layering the matching overlay gives redpanda the lane-prefixed container_name +
+# lane network, so the lane's broker is targeted and never displaced.
+#
+# This mirrors the authoritative, tested lane->compose-file mapping in
+# scripts/deploy-agent/deploy_agent/executor.py (_LANE_CONFIGS): stability-test
+# layers docker-compose.stability-test.yml, prod layers docker-compose.prod.yml,
+# judge layers docker-compose.judge.yml. The dev project gets no overlay.
+resolve_lane_overlay_filename() {
+    # Echo the overlay compose FILENAME (relative to docker/) for a compose
+    # project, or nothing for the bare dev project. Fails closed: an unknown
+    # non-dev project aborts rather than silently running on the dev config (the
+    # exact failure mode that displaced the lane broker).
+    local compose_project="$1"
+
+    # Lane = compose project suffix after the canonical "omnibase-infra" prefix.
+    # omnibase-infra                -> "" (dev, no overlay)
+    # omnibase-infra-stability-test -> "stability-test"
+    # omnibase-infra-prod           -> "prod"
+    # omnibase-infra-judge          -> "judge"
+    local lane="${compose_project#omnibase-infra}"
+    lane="${lane#-}"
+
+    case "${lane}" in
+        "")
+            # Dev lane: infra.yml alone (fixed dev container names are correct here).
+            return 0
+            ;;
+        stability-test|prod|judge)
+            echo "docker-compose.${lane}.yml"
+            return 0
+            ;;
+        *)
+            log_error "Unknown lane '${lane}' derived from compose project '${compose_project}'."
+            log_error "  deploy-runtime.sh only knows the dev / stability-test / prod / judge lanes."
+            log_error "  Refusing to deploy: running a non-dev lane on the bare infra.yml config"
+            log_error "  would recreate the DEV-named redpanda and displace this lane's broker"
+            log_error "  (OMN-13581). Add the lane's overlay mapping before deploying it."
+            exit 1
+            ;;
+    esac
+}
+
+resolve_compose_file_args() {
+    # Populate a caller-provided array (passed by name) with the full
+    # `-f <file>` token sequence for a deployment: always
+    # docker-compose.infra.yml, plus the lane overlay (docker-compose.<lane>.yml)
+    # for any non-dev compose project (OMN-13581).
+    #
+    # Usage:
+    #   local -a compose_args
+    #   resolve_compose_file_args compose_args "${deploy_target}" "${compose_project}"
+    #   docker compose -p "${compose_project}" "${compose_args[@]}" ...
+    local -n _out_args="$1"
+    local deploy_target="$2"
+    local compose_project="$3"
+
+    local docker_dir="${deploy_target}/docker"
+    _out_args=("-f" "${docker_dir}/docker-compose.infra.yml")
+
+    local overlay_filename
+    overlay_filename="$(resolve_lane_overlay_filename "${compose_project}")"
+    if [[ -n "${overlay_filename}" ]]; then
+        _out_args+=("-f" "${docker_dir}/${overlay_filename}")
+    fi
+}
+
 # =============================================================================
 # Prerequisites
 # =============================================================================
@@ -1554,17 +1632,18 @@ sanity_check() {
     # Validate that docker compose config resolves cleanly from the deployed directory.
     local deploy_target="$1"
     local compose_project="$2"
-    local compose_file="${deploy_target}/docker/docker-compose.infra.yml"
+    local -a compose_args
+    resolve_compose_file_args compose_args "${deploy_target}" "${compose_project}"
 
     log_step "Post-Sync Sanity Check"
 
     log_info "Validating compose configuration from deployed directory..."
-    log_cmd "docker compose -p ${compose_project} -f ${compose_file} config --quiet"
+    log_cmd "docker compose -p ${compose_project} ${compose_args[*]} config --quiet"
 
     local config_output
     if ! config_output="$(docker compose \
         -p "${compose_project}" \
-        -f "${compose_file}" \
+        "${compose_args[@]}" \
         config --quiet 2>&1)"; then
         log_error "Compose configuration validation failed."
         if [[ -n "${config_output}" ]]; then
@@ -1649,7 +1728,8 @@ build_images() {
     local deploy_target="$1"
     local compose_project="$2"
     local git_sha="$3"
-    local compose_file="${deploy_target}/docker/docker-compose.infra.yml"
+    local -a compose_args
+    resolve_compose_file_args compose_args "${deploy_target}" "${compose_project}"
 
     log_step "Build Images"
 
@@ -1682,7 +1762,7 @@ build_images() {
     local cmd=(
         docker compose
         -p "${compose_project}"
-        -f "${compose_file}"
+        "${compose_args[@]}"
         --profile "${COMPOSE_PROFILE}"
         build
         --progress=plain
@@ -1787,7 +1867,8 @@ warm_broker_topic_provisioning() {
     # deploy — apply it here, explicitly, before the kernel boots.
     local deploy_target="$1"
     local compose_project="$2"
-    local compose_file="${deploy_target}/docker/docker-compose.infra.yml"
+    local -a compose_args
+    resolve_compose_file_args compose_args "${deploy_target}" "${compose_project}"
 
     log_step "Broker Topic-Provisioning Warmup"
 
@@ -1808,7 +1889,7 @@ warm_broker_topic_provisioning() {
     local broker_up_cmd=(
         docker compose
         -p "${compose_project}"
-        -f "${compose_file}"
+        "${compose_args[@]}"
         --profile "${COMPOSE_PROFILE}"
         up -d --no-deps --wait
         "${BROKER_READINESS_SERVICE}"
@@ -1834,7 +1915,7 @@ warm_broker_topic_provisioning() {
     local cap_up_cmd=(
         docker compose
         -p "${compose_project}"
-        -f "${compose_file}"
+        "${compose_args[@]}"
         --profile "${COMPOSE_PROFILE}"
         up -d --no-deps --force-recreate
         "${BROKER_PARTITION_CAP_SERVICE}"
@@ -1858,7 +1939,8 @@ run_runtime_migration_preflight() {
     # Run bounded migration services before --no-deps runtime restarts.
     local deploy_target="$1"
     local compose_project="$2"
-    local compose_file="${deploy_target}/docker/docker-compose.infra.yml"
+    local -a compose_args
+    resolve_compose_file_args compose_args "${deploy_target}" "${compose_project}"
 
     log_step "Runtime Migration Preflight"
 
@@ -1866,7 +1948,7 @@ run_runtime_migration_preflight() {
         local cmd=(
             docker compose
             -p "${compose_project}"
-            -f "${compose_file}"
+            "${compose_args[@]}"
             --profile "${COMPOSE_PROFILE}"
             up -d --no-deps --force-recreate
             "${service}"
@@ -1930,14 +2012,15 @@ restart_services() {
     # Restart runtime containers via docker compose up --force-recreate.
     local deploy_target="$1"
     local compose_project="$2"
-    local compose_file="${deploy_target}/docker/docker-compose.infra.yml"
+    local -a compose_args
+    resolve_compose_file_args compose_args "${deploy_target}" "${compose_project}"
 
     log_step "Restart Runtime Services"
 
     local cmd=(
         docker compose
         -p "${compose_project}"
-        -f "${compose_file}"
+        "${compose_args[@]}"
         --profile "${COMPOSE_PROFILE}"
         up -d --no-deps --force-recreate
         "${RUNTIME_SERVICES[@]}"
@@ -2057,7 +2140,12 @@ print_compose_commands() {
     local deploy_target="$1"
     local compose_project="$2"
     local git_sha="$3"
-    local compose_file="${deploy_target}/docker/docker-compose.infra.yml"
+    # OMN-13581: print the SAME `-f` token sequence the script executes, including
+    # the lane overlay for non-dev projects, so copy-pasted operator commands do
+    # not silently run on the bare infra.yml config (which displaces the broker).
+    local -a compose_args
+    resolve_compose_file_args compose_args "${deploy_target}" "${compose_project}"
+    local compose_f="${compose_args[*]}"
     local omni_home="${OMNI_HOME:-}"
     local build_source
     build_source="$(resolve_build_source)"
@@ -2080,7 +2168,7 @@ print_compose_commands() {
     log_info "Build:"
     log_info "  docker compose \\"
     log_info "    -p ${compose_project} \\"
-    log_info "    -f ${compose_file} \\"
+    log_info "    ${compose_f} \\"
     log_info "    --profile ${COMPOSE_PROFILE} \\"
     log_info "    build \\"
     log_info "    --build-arg VCS_REF=${git_sha} \\"
@@ -2097,7 +2185,7 @@ print_compose_commands() {
     log_info "Restart runtime services:"
     log_info "  docker compose \\"
     log_info "    -p ${compose_project} \\"
-    log_info "    -f ${compose_file} \\"
+    log_info "    ${compose_f} \\"
     log_info "    --profile ${COMPOSE_PROFILE} \\"
     log_info "    up -d --no-deps --force-recreate \\"
     log_info "    ${RUNTIME_SERVICES[*]}"
@@ -2105,28 +2193,28 @@ print_compose_commands() {
     log_info "Full stack up (infra + runtime):"
     log_info "  docker compose \\"
     log_info "    -p ${compose_project} \\"
-    log_info "    -f ${compose_file} \\"
+    log_info "    ${compose_f} \\"
     log_info "    --profile ${COMPOSE_PROFILE} \\"
     log_info "    up -d"
     log_info ""
     log_info "Stop all:"
     log_info "  docker compose \\"
     log_info "    -p ${compose_project} \\"
-    log_info "    -f ${compose_file} \\"
+    log_info "    ${compose_f} \\"
     log_info "    --profile ${COMPOSE_PROFILE} \\"
     log_info "    down"
     log_info ""
     log_info "Logs:"
     log_info "  docker compose \\"
     log_info "    -p ${compose_project} \\"
-    log_info "    -f ${compose_file} \\"
+    log_info "    ${compose_f} \\"
     log_info "    --profile ${COMPOSE_PROFILE} \\"
     log_info "    logs -f"
     log_info ""
     log_info "Status:"
     log_info "  docker compose \\"
     log_info "    -p ${compose_project} \\"
-    log_info "    -f ${compose_file} \\"
+    log_info "    ${compose_f} \\"
     log_info "    --profile ${COMPOSE_PROFILE} \\"
     log_info "    ps"
 }
@@ -2141,6 +2229,11 @@ show_summary() {
     local version="$2"
     local git_sha="$3"
     local compose_project="$4"
+    # OMN-13581: surface the lane-overlay-aware `-f` sequence in operator
+    # next-step commands too, so a copy-paste does not run the lane on infra.yml.
+    local -a compose_args
+    resolve_compose_file_args compose_args "${deploy_target}" "${compose_project}"
+    local compose_f="${compose_args[*]}"
 
     log_step "Deployment Summary"
 
@@ -2157,14 +2250,14 @@ show_summary() {
         log_info "  To start containers, run:"
         log_info "    docker compose \\"
         log_info "      -p ${compose_project} \\"
-        log_info "      -f ${deploy_target}/docker/docker-compose.infra.yml \\"
+        log_info "      ${compose_f} \\"
         log_info "      --profile ${COMPOSE_PROFILE} \\"
         log_info "      up -d"
     else
         log_info "  Containers are running. Check status:"
         log_info "    docker compose \\"
         log_info "      -p ${compose_project} \\"
-        log_info "      -f ${deploy_target}/docker/docker-compose.infra.yml \\"
+        log_info "      ${compose_f} \\"
         log_info "      --profile ${COMPOSE_PROFILE} \\"
         log_info "      ps"
     fi

--- a/tests/scripts/test_deploy_runtime_lane_overlay.py
+++ b/tests/scripts/test_deploy_runtime_lane_overlay.py
@@ -1,0 +1,207 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""deploy-runtime.sh must layer the lane overlay on every compose invocation.
+
+OMN-13581: deploy-runtime.sh historically passed ONLY ``-f docker-compose.infra.yml``
+on every ``docker compose`` call -- including ``warm_broker_topic_provisioning``'s
+``up redpanda`` step. The base infra compose hardcodes
+``container_name: omnibase-infra-redpanda`` (the DEV name) and the dev network.
+Running the warmup against a non-dev compose project (e.g.
+``omnibase-infra-stability-test``) therefore made compose try to recreate redpanda
+as the DEV-named container, which collided with the live dev broker, got a Docker
+hash prefix, and landed in ``created`` -- DESTROYING the lane's own correctly-named
+broker. That left the stability lane broker-less for ~3 days.
+
+The fix introduces ``resolve_lane_overlay_filename`` / ``resolve_compose_file_args``
+which derive the lane from the compose project suffix and LAYER the matching overlay
+(``docker-compose.<lane>.yml``) onto ``docker-compose.infra.yml`` for every non-dev
+project, mirroring the authoritative lane->compose-file mapping in
+``scripts/deploy-agent/deploy_agent/executor.py`` (_LANE_CONFIGS).
+
+These tests assert:
+  - the helper functions exist,
+  - the dev / stability-test / prod / judge lane mapping is correct (behavioral,
+    by extracting + executing the pure helper functions -- no docker required),
+  - an unknown non-dev project fails CLOSED (refuses to run on the bare dev config),
+  - NO compose-invoking function passes a bare ``-f .../docker-compose.infra.yml``
+    string anymore; every call site routes through ``resolve_compose_file_args``.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+DEPLOY_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "deploy-runtime.sh"
+
+
+def _script_text() -> str:
+    return DEPLOY_SCRIPT.read_text(encoding="utf-8")
+
+
+def _extract_function(name: str) -> str:
+    """Return the source text of a single top-level bash function ``name()``.
+
+    The helper functions under test are pure (no top-level deps), so they can be
+    extracted and executed in isolation -- giving a real behavioral assertion
+    without sourcing the whole script (which runs main and needs docker).
+    """
+    text = _script_text()
+    match = re.search(
+        rf"^{re.escape(name)}\s*\(\)\s*\{{.*?\n\}}",
+        text,
+        re.DOTALL | re.MULTILINE,
+    )
+    assert match is not None, (
+        f"could not extract function {name}() from deploy-runtime.sh"
+    )
+    return match.group(0)
+
+
+def _run_overlay_resolver(compose_project: str) -> subprocess.CompletedProcess[str]:
+    """Execute the extracted resolver functions for one compose project.
+
+    Stubs ``log_error`` so the fail-closed path does not depend on the script's
+    logging helpers, then echoes the resolved ``-f`` token sequence.
+    """
+    harness = "\n".join(
+        [
+            "set -euo pipefail",
+            "log_error() { printf 'ERR: %s\\n' \"$*\" >&2; }",
+            _extract_function("resolve_lane_overlay_filename"),
+            _extract_function("resolve_compose_file_args"),
+            "declare -a out",
+            f'resolve_compose_file_args out "/DEPLOY" "{compose_project}"',
+            'printf "%s\\n" "${out[*]}"',
+        ]
+    )
+    return subprocess.run(
+        ["bash", "-c", harness],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.mark.unit
+def test_defines_lane_overlay_resolver_functions() -> None:
+    text = _script_text()
+    assert re.search(r"^resolve_lane_overlay_filename\s*\(\)", text, re.MULTILINE), (
+        "deploy-runtime.sh must define resolve_lane_overlay_filename()"
+    )
+    assert re.search(r"^resolve_compose_file_args\s*\(\)", text, re.MULTILINE), (
+        "deploy-runtime.sh must define resolve_compose_file_args()"
+    )
+
+
+@pytest.mark.unit
+def test_dev_project_gets_no_overlay() -> None:
+    """The bare dev project runs from infra.yml alone (fixed dev names are correct)."""
+    result = _run_overlay_resolver("omnibase-infra")
+    assert result.returncode == 0, result.stderr
+    out = result.stdout.strip()
+    assert out == "-f /DEPLOY/docker/docker-compose.infra.yml", out
+    assert "stability-test" not in out
+    assert "prod" not in out
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("compose_project", "lane"),
+    [
+        ("omnibase-infra-stability-test", "stability-test"),
+        ("omnibase-infra-prod", "prod"),
+        ("omnibase-infra-judge", "judge"),
+    ],
+)
+def test_non_dev_project_layers_matching_overlay(
+    compose_project: str, lane: str
+) -> None:
+    """Every non-dev lane LAYERS its overlay onto infra.yml, in order."""
+    result = _run_overlay_resolver(compose_project)
+    assert result.returncode == 0, result.stderr
+    out = result.stdout.strip()
+    expected = (
+        "-f /DEPLOY/docker/docker-compose.infra.yml "
+        f"-f /DEPLOY/docker/docker-compose.{lane}.yml"
+    )
+    assert out == expected, out
+    # infra.yml must come FIRST so the overlay's container_name/project/network win.
+    assert out.index("docker-compose.infra.yml") < out.index(
+        f"docker-compose.{lane}.yml"
+    )
+
+
+@pytest.mark.unit
+def test_unknown_non_dev_project_fails_closed() -> None:
+    """An unrecognized non-dev project must abort, not silently run on dev config.
+
+    This is the whole point of the fix: running a non-dev lane on the bare
+    infra.yml config recreates the DEV-named redpanda and displaces the lane's
+    broker (OMN-13581). An unknown lane must therefore fail CLOSED.
+    """
+    result = _run_overlay_resolver("omnibase-infra-mystery-lane")
+    assert result.returncode != 0, (
+        "unknown non-dev compose project must fail closed, got: "
+        f"stdout={result.stdout!r} rc={result.returncode}"
+    )
+    assert "mystery-lane" in result.stderr or "Unknown lane" in result.stderr
+
+
+@pytest.mark.unit
+def test_no_compose_invocation_uses_bare_infra_only() -> None:
+    """No active code path may pass a single bare ``-f infra.yml`` to docker compose.
+
+    Every compose call site must route its ``-f`` flags through
+    ``resolve_compose_file_args`` so the lane overlay is always layered. A bare
+    ``compose_file="${...}/docker-compose.infra.yml"`` local re-introduces the
+    broker-displacement bug.
+    """
+    lines = [
+        line
+        for line in _script_text().splitlines()
+        if not line.lstrip().startswith("#")
+    ]
+    # The old anti-pattern: a per-function local pinning the single infra compose
+    # file, then passing it as the sole -f flag.
+    offenders = [
+        (i + 1, line)
+        for i, line in enumerate(lines)
+        if re.search(r"compose_file=.*docker-compose\.infra\.yml", line)
+    ]
+    assert offenders == [], (
+        "Found bare single-compose-file locals in deploy-runtime.sh; every compose "
+        f"call must layer the lane overlay via resolve_compose_file_args: {offenders}"
+    )
+
+
+@pytest.mark.unit
+def test_compose_call_sites_route_through_resolver() -> None:
+    """Each compose-invoking function must call resolve_compose_file_args.
+
+    Guards against a future function being added that re-pins a bare infra.yml.
+    """
+    text = _script_text()
+    # Functions that issue `docker compose` with `-f`.
+    for func in (
+        "sanity_check",
+        "build_images",
+        "warm_broker_topic_provisioning",
+        "run_runtime_migration_preflight",
+        "restart_services",
+    ):
+        match = re.search(
+            rf"^{func}\s*\(\)\s*\{{.*?\n\}}",
+            text,
+            re.DOTALL | re.MULTILINE,
+        )
+        assert match is not None, f"could not find function {func}()"
+        body = match.group(0)
+        assert "resolve_compose_file_args" in body, (
+            f"{func}() must resolve its -f flags via resolve_compose_file_args "
+            "(so the lane overlay is layered)"
+        )


### PR DESCRIPTION
## OMN-13581 — deploy-runtime.sh never layers the lane overlay (broker outage root cause)

### Root cause
`scripts/deploy-runtime.sh` invoked every `docker compose` call with only `-f docker/docker-compose.infra.yml`, never layering the lane overlay (`docker-compose.<lane>.yml`). The base infra compose hardcodes `container_name: omnibase-infra-redpanda` (the DEV name) + the dev network. So `warm_broker_topic_provisioning()`'s `up -d --wait redpanda` step, run against a non-dev compose project (e.g. `omnibase-infra-stability-test`), made compose try to **recreate redpanda as the DEV-named container** — colliding with the live dev broker, getting a Docker hash prefix, and landing in `created` (never started). That displaced the lane's own correctly-named broker and left the stability lane broker-less for ~3 days. Every `deploy-runtime.sh --restart` on a non-dev lane re-broke it.

### Fix
- New `resolve_lane_overlay_filename()` derives the lane from the compose-project suffix (`omnibase-infra-stability-test` → `stability-test`) and returns the matching overlay filename; the bare dev project gets no overlay. **Unknown non-dev projects fail CLOSED** (refuse to run on the dev config — the exact failure mode that displaced the broker).
- New `resolve_compose_file_args()` builds the full `-f docker-compose.infra.yml [-f docker-compose.<lane>.yml]` token sequence and is threaded through **all 6 compose call sites** (`sanity_check`, `build_images`, `warm_broker_topic_provisioning` x2, `run_runtime_migration_preflight`, `restart_services`) plus the operator-facing `print_compose_commands` and `show_summary` display paths.
- Mirrors the authoritative, tested lane→compose-file mapping in `scripts/deploy-agent/deploy_agent/executor.py` (`_LANE_CONFIGS`): stability-test → `docker-compose.stability-test.yml`, prod → `docker-compose.prod.yml`, judge → `docker-compose.judge.yml`.

### Tests (TDD — guard added)
`tests/scripts/test_deploy_runtime_lane_overlay.py` (8 tests): dev gets infra.yml only; stability-test/prod/judge each layer their overlay (infra.yml first); unknown lane fails closed; no compose call site uses a bare single infra.yml; every compose function routes through the resolver. Confirmed RED against `origin/dev` (6 bare-infra offenders, no resolver) and GREEN after the fix.

### Local proof
- `uv run pytest tests/scripts/test_deploy_runtime_lane_overlay.py -v` → 8 passed
- `uv run pytest tests/scripts/ -q` → 179 passed (no regression)
- `shellcheck scripts/deploy-runtime.sh` → no findings
- pre-commit (changed files) → clean

No live stability redeploy run this round (stability is off-limits; the targeted-recreate workaround already recovered the lane). Dev-lane proof only.

Evidence-Source: OCC#3061
Evidence-Ticket: OMN-13581
