### PR TITLE
fix(OMN-13580): forwarder handle() deserializes raw-dict envelope before .payload

### DIFF
--- a/src/omnibase_infra/nodes/node_bus_forwarder_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_bus_forwarder_effect/contract.yaml
@@ -20,7 +20,9 @@ runtime_profiles:
 input_model:
   name: "ModelGatewayEnvelope"
   module: "omnibase_infra.nodes.node_bus_forwarder_effect.models.model_gateway_envelope"
-  description: "Canonical gateway envelope with tenant binding and topic transform fields."
+  description: >
+    Canonical gateway envelope with tenant binding and topic transform fields. Runtime dispatch may wrap this payload in a ModelEventEnvelope instance or its serialized dict form; handlers normalize that outer envelope before reading payload.
+
 output_model:
   name: "ModelGatewayEnvelope"
   module: "omnibase_infra.nodes.node_bus_forwarder_effect.models.model_gateway_envelope"
@@ -74,13 +76,17 @@ handler_routing:
         name: "HandlerForwardOutbound"
         module: "omnibase_infra.nodes.node_bus_forwarder_effect.handlers.handler_forward_outbound"
         handler_type: "COMPUTE"
-      description: "Canonical handle() dispatch entrypoint validates local bare topic and delegates to the tenant cloud wire-prefix transform."
+      description: >
+        Canonical handle() dispatch entrypoint accepts a typed or serialized outer event envelope, normalizes it, validates the local bare topic, and delegates to the tenant cloud wire-prefix transform.
+
     - operation: "gateway.consume_inbound"
       handler:
         name: "HandlerConsumeInbound"
         module: "omnibase_infra.nodes.node_bus_forwarder_effect.handlers.handler_consume_inbound"
         handler_type: "COMPUTE"
-      description: "Canonical handle() dispatch entrypoint validates tenant-prefixed cloud topic and delegates to the bare local-topic transform."
+      description: >
+        Canonical handle() dispatch entrypoint accepts a typed or serialized outer event envelope, normalizes it, validates the tenant-prefixed cloud topic, and delegates to the bare local-topic transform.
+
 capabilities:
   - name: "tenant_prefix_transform"
     description: "Adds and strips tenant wire prefixes with envelope validation."
@@ -88,6 +94,8 @@ capabilities:
     description: "Rejects any canonical topic not declared in mirror topic sets."
   - name: "node_owned_publish"
     description: "Handlers never publish; the effect node owns both bus legs."
+  - name: "raw_dispatch_envelope_normalization"
+    description: "Handlers deserialize serialized outer event envelopes before reading payload."
 metadata:
   description: "Hybrid gateway local runtime bus forwarder"
   author: "OmniNode Team"

--- a/src/omnibase_infra/nodes/node_bus_forwarder_effect/handlers/handler_consume_inbound.py
+++ b/src/omnibase_infra/nodes/node_bus_forwarder_effect/handlers/handler_consume_inbound.py
@@ -36,9 +36,15 @@ class HandlerConsumeInbound:
 
     async def handle(
         self,
-        envelope: ModelEventEnvelope[object],
+        envelope: object,
     ) -> ModelHandlerOutput[ModelGatewayEnvelope]:
-        """Dispatch entrypoint: extract gateway envelope, apply inbound transform, return compute output."""
+        """Dispatch entrypoint: extract gateway envelope, apply inbound transform, return compute output.
+
+        ``envelope`` is typed ``object`` because the runtime dispatcher delivers
+        either a ``ModelEventEnvelope`` instance or its serialized ``dict`` form
+        (OMN-13580); ``_coerce_dispatch_input`` normalizes both to the typed
+        envelope before reading ``.payload``.
+        """
         gateway_envelope, envelope_id, correlation_id = _coerce_dispatch_input(envelope)
         transformed = self.consume_inbound(gateway_envelope)
         return ModelHandlerOutput.for_compute(
@@ -82,9 +88,19 @@ class HandlerConsumeInbound:
 
 
 def _coerce_dispatch_input(
-    envelope: ModelEventEnvelope[object],
+    envelope: object,
 ) -> tuple[ModelGatewayEnvelope, UUID, UUID]:
-    payload = envelope.payload
+    # OMN-13580: the runtime dispatcher delivers the OUTER envelope as a raw
+    # dict, not a ModelEventEnvelope instance. Deserialize to the typed envelope
+    # BEFORE reading ``.payload`` (matching the OMN-12001/12940 dict-vs-typed
+    # coercion pattern) so the handler does not crash with
+    # ``AttributeError: 'dict' object has no attribute 'payload'``.
+    typed_envelope = (
+        envelope
+        if isinstance(envelope, ModelEventEnvelope)
+        else ModelEventEnvelope[object].model_validate(envelope)
+    )
+    payload = typed_envelope.payload
     gateway_envelope = (
         payload
         if isinstance(payload, ModelGatewayEnvelope)
@@ -92,6 +108,6 @@ def _coerce_dispatch_input(
     )
     return (
         gateway_envelope,
-        envelope.envelope_id,
-        envelope.correlation_id or gateway_envelope.correlation_id,
+        typed_envelope.envelope_id,
+        typed_envelope.correlation_id or gateway_envelope.correlation_id,
     )

--- a/src/omnibase_infra/nodes/node_bus_forwarder_effect/handlers/handler_forward_outbound.py
+++ b/src/omnibase_infra/nodes/node_bus_forwarder_effect/handlers/handler_forward_outbound.py
@@ -35,9 +35,15 @@ class HandlerForwardOutbound:
 
     async def handle(
         self,
-        envelope: ModelEventEnvelope[object],
+        envelope: object,
     ) -> ModelHandlerOutput[ModelGatewayEnvelope]:
-        """Dispatch entrypoint: extract gateway envelope, apply outbound transform, return compute output."""
+        """Dispatch entrypoint: extract gateway envelope, apply outbound transform, return compute output.
+
+        ``envelope`` is typed ``object`` because the runtime dispatcher delivers
+        either a ``ModelEventEnvelope`` instance or its serialized ``dict`` form
+        (OMN-13580); ``_coerce_dispatch_input`` normalizes both to the typed
+        envelope before reading ``.payload``.
+        """
         gateway_envelope, envelope_id, correlation_id = _coerce_dispatch_input(envelope)
         transformed = self.forward_outbound(gateway_envelope)
         return ModelHandlerOutput.for_compute(
@@ -78,9 +84,19 @@ class HandlerForwardOutbound:
 
 
 def _coerce_dispatch_input(
-    envelope: ModelEventEnvelope[object],
+    envelope: object,
 ) -> tuple[ModelGatewayEnvelope, UUID, UUID]:
-    payload = envelope.payload
+    # OMN-13580: the runtime dispatcher delivers the OUTER envelope as a raw
+    # dict, not a ModelEventEnvelope instance. Deserialize to the typed envelope
+    # BEFORE reading ``.payload`` (matching the OMN-12001/12940 dict-vs-typed
+    # coercion pattern) so the handler does not crash with
+    # ``AttributeError: 'dict' object has no attribute 'payload'``.
+    typed_envelope = (
+        envelope
+        if isinstance(envelope, ModelEventEnvelope)
+        else ModelEventEnvelope[object].model_validate(envelope)
+    )
+    payload = typed_envelope.payload
     gateway_envelope = (
         payload
         if isinstance(payload, ModelGatewayEnvelope)
@@ -88,6 +104,6 @@ def _coerce_dispatch_input(
     )
     return (
         gateway_envelope,
-        envelope.envelope_id,
-        envelope.correlation_id or gateway_envelope.correlation_id,
+        typed_envelope.envelope_id,
+        typed_envelope.correlation_id or gateway_envelope.correlation_id,
     )

--- a/tests/unit/nodes/node_bus_forwarder_effect/test_handler_dispatch_entrypoints.py
+++ b/tests/unit/nodes/node_bus_forwarder_effect/test_handler_dispatch_entrypoints.py
@@ -101,6 +101,20 @@ def _make_dispatch_envelope(
     )
 
 
+def _make_dispatch_envelope_dict(
+    gateway_envelope: ModelGatewayEnvelope,
+) -> dict[str, object]:
+    """Raw-dict envelope as the live runtime dispatcher actually delivers it.
+
+    OMN-13580: on stability-test the dispatcher passes the OUTER envelope as a
+    serialized ``dict`` (not a ``ModelEventEnvelope`` instance). The handler
+    must deserialize this dict to the typed envelope before reading ``.payload``
+    or it crashes with ``AttributeError: 'dict' object has no attribute
+    'payload'`` (the defect that fired 24x against CID-terminal steps).
+    """
+    return _make_dispatch_envelope(gateway_envelope).model_dump()
+
+
 @pytest.mark.asyncio
 async def test_handler_forward_outbound_handle_returns_model_handler_output() -> None:
     """HandlerForwardOutbound.handle() returns a valid ModelHandlerOutput (no AttributeError)."""
@@ -129,6 +143,48 @@ async def test_handler_consume_inbound_handle_returns_model_handler_output() -> 
 
     assert isinstance(result, ModelHandlerOutput)
     assert result.result is not None
+    assert isinstance(result.result, ModelGatewayEnvelope)
+    assert result.result.canonical_topic == INBOUND_TOPIC
+    assert result.result.source_topic == WIRE_INBOUND_TOPIC
+    assert result.correlation_id == gw_envelope.correlation_id
+
+
+@pytest.mark.asyncio
+async def test_handler_forward_outbound_handle_accepts_raw_dict_envelope() -> None:
+    """OMN-13580: handle() deserializes a raw-dict envelope before reading .payload.
+
+    Reproduces the live stability-test crash where the dispatcher delivers the
+    outer envelope as a serialized dict. Pre-fix this raised
+    ``AttributeError: 'dict' object has no attribute 'payload'``.
+    """
+    handler = HandlerForwardOutbound(config=_config())
+    gw_envelope = _outbound_gateway_envelope()
+    dispatch_envelope_dict = _make_dispatch_envelope_dict(gw_envelope)
+
+    result = await handler.handle(dispatch_envelope_dict)
+
+    assert isinstance(result, ModelHandlerOutput)
+    assert isinstance(result.result, ModelGatewayEnvelope)
+    assert result.result.wire_topic == WIRE_OUTBOUND_TOPIC
+    assert result.result.source_topic == OUTBOUND_TOPIC
+    assert result.correlation_id == gw_envelope.correlation_id
+
+
+@pytest.mark.asyncio
+async def test_handler_consume_inbound_handle_accepts_raw_dict_envelope() -> None:
+    """OMN-13580: handle() deserializes a raw-dict envelope before reading .payload.
+
+    Reproduces the live stability-test crash where the dispatcher delivers the
+    outer envelope as a serialized dict. Pre-fix this raised
+    ``AttributeError: 'dict' object has no attribute 'payload'``.
+    """
+    handler = HandlerConsumeInbound(config=_config())
+    gw_envelope = _inbound_gateway_envelope()
+    dispatch_envelope_dict = _make_dispatch_envelope_dict(gw_envelope)
+
+    result = await handler.handle(dispatch_envelope_dict)
+
+    assert isinstance(result, ModelHandlerOutput)
     assert isinstance(result.result, ModelGatewayEnvelope)
     assert result.result.canonical_topic == INBOUND_TOPIC
     assert result.result.source_topic == WIRE_INBOUND_TOPIC


### PR DESCRIPTION
## OMN-13580 — forwarder handle() crashes on raw-dict envelope (AttributeError: 'dict' object has no attribute 'payload')

### Problem
The OMN-13546 `handle()` entrypoints on `node_bus_forwarder_effect` read `envelope.payload` directly inside `_coerce_dispatch_input`. The runtime dispatcher delivers the OUTER envelope as a raw `dict` (its serialized form), so `.payload` raised `AttributeError: 'dict' object has no attribute 'payload'`. This fired 24x on stability-test interleaved with the delegation CID-terminal step, so no `delegation-completed.v1` was published and zero `delegation_events` rows were written for escalated CIDs (blocks OMN-13335).

### Root cause
`handler_forward_outbound.py` / `handler_consume_inbound.py` → `_coerce_dispatch_input` accessed `.payload` on the outer envelope without first deserializing the dict to `ModelEventEnvelope[T]`. Same class as the already-fixed OMN-12001 / OMN-12940 dict-vs-typed deserialization defect, but in the forwarder handlers.

### Fix
- `_coerce_dispatch_input` now coerces the outer envelope to `ModelEventEnvelope[object]` via `model_validate` when it is not already a typed instance (mirrors the OMN-12001/12940 pattern), BEFORE reading `.payload`.
- `handle()` / `_coerce_dispatch_input` params typed `object` — honest about what the dispatcher delivers (typed envelope OR serialized dict). Avoids adding a counted non-optional union (the infra union budget was at its ceiling, 154).

### TDD
`tests/unit/nodes/node_bus_forwarder_effect/test_handler_dispatch_entrypoints.py` adds raw-dict regression tests for both handlers. RED before fix (reproduced `AttributeError: 'dict' object has no attribute 'payload'` at `handler_forward_outbound.py:83`); GREEN after.

### Local proof
- `uv run pytest tests/unit/nodes/node_bus_forwarder_effect/` → 23 passed (was 21; +2 dict regression tests)
- `uv run pytest tests/integration/gateway/test_bus_forwarder_contract_integration.py` → passed
- `uv run mypy --strict` on both handlers → clean
- ruff format + check → clean
- `pre-commit run --files <changed>` → all hooks pass (incl. ONEX Union Usage Validation back at 154)

### DoD / Receipt
Evidence-Source: OCC#3063
Evidence-Ticket: OMN-13580
OCC contract + receipt: onex_change_control PR (paired).

Closes phase-1 of OMN-13580. Phase 2 proves the terminal lands live on dev.