### PR TITLE
fix(OMN-13124): vendor omnimarket node migrations to unwedge infra CI node-migration-sync

### DIFF
--- a/docker/migrations/forward/nodes/node_projection_cost_by_repo/0001_create_cost_by_repo_snapshots.sql
+++ b/docker/migrations/forward/nodes/node_projection_cost_by_repo/0001_create_cost_by_repo_snapshots.sql
@@ -1,0 +1,66 @@
+-- OMN-13077: node-owned projection migration for cost_by_repo_snapshots.
+--
+-- WHY THIS EXISTS
+--   node_projection_cost_by_repo declares projection_api over
+--   cost_by_repo_snapshots (topic onex.snapshot.projection.cost.by_repo.v1).
+--   The dashboard cost-by-repo widget's projectionSchema requires the columns
+--   repo_name, total_cost_usd, and window. The shared llm_cost_aggregates table
+--   has no repo_name column, so the cost-by-repo widget was upstream-blocked.
+--   This node-owned table gives the snapshot topic a dedicated backing table
+--   that carries the repo dimension, removing the upstream block.
+--
+--   Discovered + applied by scripts/run-projection-migrations.py (node-owned
+--   migrations/ discovery) and vendored to the dashboard projection DB
+--   (omnidash_analytics) the projection API binds to.
+--
+-- Idempotency: CREATE TABLE / INDEX / TRIGGER guarded so the migration is safe
+-- on a DB where the table already exists and on a fresh omnidash_analytics.
+
+-- ============================================================================
+-- COST_BY_REPO_SNAPSHOTS TABLE
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS cost_by_repo_snapshots (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    repo_name VARCHAR(512) NOT NULL,
+    "window" VARCHAR(32) NOT NULL DEFAULT 'latest',
+    snapshot_timestamp_minute TIMESTAMPTZ NOT NULL,
+
+    total_cost_usd NUMERIC(14, 6) NOT NULL DEFAULT 0,
+    total_tokens BIGINT NOT NULL DEFAULT 0,
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT uq_cost_by_repo_repo_window_minute
+        UNIQUE (repo_name, "window", snapshot_timestamp_minute),
+
+    CONSTRAINT non_negative_cost_by_repo_total_cost_usd CHECK (total_cost_usd >= 0),
+    CONSTRAINT non_negative_cost_by_repo_total_tokens CHECK (total_tokens >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_cost_by_repo_snapshots_total_cost_usd
+    ON cost_by_repo_snapshots (total_cost_usd DESC);
+
+CREATE INDEX IF NOT EXISTS idx_cost_by_repo_snapshots_window
+    ON cost_by_repo_snapshots ("window");
+
+CREATE INDEX IF NOT EXISTS idx_cost_by_repo_snapshots_updated_at
+    ON cost_by_repo_snapshots (updated_at DESC);
+
+-- ============================================================================
+-- TRIGGER: auto-update updated_at
+-- ============================================================================
+CREATE OR REPLACE FUNCTION update_cost_by_repo_snapshots_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trigger_cost_by_repo_snapshots_updated_at ON cost_by_repo_snapshots;
+CREATE TRIGGER trigger_cost_by_repo_snapshots_updated_at
+    BEFORE UPDATE ON cost_by_repo_snapshots
+    FOR EACH ROW
+    EXECUTE FUNCTION update_cost_by_repo_snapshots_updated_at();

--- a/docker/migrations/forward/nodes/node_projection_traces/0001_create_traces.sql
+++ b/docker/migrations/forward/nodes/node_projection_traces/0001_create_traces.sql
@@ -1,0 +1,68 @@
+-- OMN-13083: node-owned projection migration for traces.
+--
+-- WHY THIS EXISTS
+--   node_projection_traces declares projection_api over the traces table
+--   (topic onex.snapshot.projection.traces.v1). The dashboard trace-explorer
+--   widget's projectionSchema requires the correlation-grouped row shape
+--   (correlation_id, nodes_involved, event_count, first_event_at,
+--   last_event_at, duration_ms, has_error, is_running, latest_message).
+--   No contract previously backed that topic; OMN-12135 wired it to a bespoke
+--   Express query and OMN-12822 removed that bespoke server. This node-owned
+--   table is the canonical backing surface for the projection API.
+--
+--   Discovered + applied by scripts/run-projection-migrations.py (node-owned
+--   migrations/ discovery) and vendored to the dashboard projection DB
+--   (omnidash_analytics) the projection API binds to.
+--
+-- Idempotency: CREATE TABLE / INDEX / TRIGGER guarded so the migration is safe
+-- on a DB where the table already exists and on a fresh omnidash_analytics.
+
+-- ============================================================================
+-- TRACES TABLE
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS traces (
+    correlation_id VARCHAR(256) PRIMARY KEY,
+
+    nodes_involved TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    event_count INTEGER NOT NULL DEFAULT 0,
+
+    first_event_at TIMESTAMPTZ NOT NULL,
+    last_event_at TIMESTAMPTZ NOT NULL,
+    duration_ms BIGINT NOT NULL DEFAULT 0,
+
+    has_error BOOLEAN NOT NULL DEFAULT FALSE,
+    is_running BOOLEAN NOT NULL DEFAULT TRUE,
+    latest_message TEXT NOT NULL DEFAULT '',
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT non_negative_traces_event_count CHECK (event_count >= 0),
+    CONSTRAINT non_negative_traces_duration_ms CHECK (duration_ms >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_traces_last_event_at
+    ON traces (last_event_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_traces_has_error
+    ON traces (has_error);
+
+CREATE INDEX IF NOT EXISTS idx_traces_is_running
+    ON traces (is_running);
+
+-- ============================================================================
+-- TRIGGER: auto-update updated_at
+-- ============================================================================
+CREATE OR REPLACE FUNCTION update_traces_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trigger_traces_updated_at ON traces;
+CREATE TRIGGER trigger_traces_updated_at
+    BEFORE UPDATE ON traces
+    FOR EACH ROW
+    EXECUTE FUNCTION update_traces_updated_at();


### PR DESCRIPTION
## OMN-13124 — vendor drifted omnimarket node migrations to unwedge infra CI

The required `node-migration-sync` gate is failing on **every** infra dev PR (verified on sibling env PR #2098, job 83286659159; and OMN-13558 OTEL PR #2104) because two omnimarket node migrations shipped to omnimarket@dev without their vendored copies under `docker/migrations/forward/nodes/`:

- `node_projection_cost_by_repo/0001_create_cost_by_repo_snapshots.sql`
- `node_projection_traces/0001_create_traces.sql`

This is the exact failure class OMN-13124's gate exists to catch (an omnimarket node migration merging without its vendored copy → projection table absent on clean redeploy).

### Fix
Ran `scripts/sync-node-migrations.sh` to mirror both 1:1 from the omnimarket source tree. Verified the vendored SQL is byte-identical to omnimarket@origin/dev tip (the ref CI checks against).

### dod_evidence
- `scripts/sync-node-migrations.sh --check` exits 0 (in sync) on this branch.
- Both vendored files confirmed `git diff`-clean against `omnimarket@origin/dev`.
- Unblocks the infra dev PR queue (PR #2098 + OMN-13558 OTEL PR #2104 both fail this same gate today).
- The `node-migration-sync` CI gate on this PR is GREEN (run 28138381245, conclusion=success) — the authoritative proof the vendored tree is byte-identical to omnimarket@origin/dev.
- Vendor-sync DoD for OMN-13124 is recorded in the OCC contract `contracts/OMN-13124.yaml` (receipt `dod-infra-vendor-pr-2103`, binds `pr_number: 2103` + `commit_sha: bc5918c2`), merged to OCC dev via OCC#3098. Evidence-Source below points at that OCC merge-commit.

OMN-13124
Evidence-Source: b7fb7adfb9bddedd0aa967704a71a088fabe5768
Evidence-Ticket: OMN-13124
