### PR TITLE
feat(OMN-13558): migrate OTEL_EXPORTER_OTLP_ENDPOINT endpoint read to overlay descriptor seam

### DIFF
--- a/docker/migrations/forward/nodes/node_projection_cost_by_repo/0001_create_cost_by_repo_snapshots.sql
+++ b/docker/migrations/forward/nodes/node_projection_cost_by_repo/0001_create_cost_by_repo_snapshots.sql
@@ -1,0 +1,66 @@
+-- OMN-13077: node-owned projection migration for cost_by_repo_snapshots.
+--
+-- WHY THIS EXISTS
+--   node_projection_cost_by_repo declares projection_api over
+--   cost_by_repo_snapshots (topic onex.snapshot.projection.cost.by_repo.v1).
+--   The dashboard cost-by-repo widget's projectionSchema requires the columns
+--   repo_name, total_cost_usd, and window. The shared llm_cost_aggregates table
+--   has no repo_name column, so the cost-by-repo widget was upstream-blocked.
+--   This node-owned table gives the snapshot topic a dedicated backing table
+--   that carries the repo dimension, removing the upstream block.
+--
+--   Discovered + applied by scripts/run-projection-migrations.py (node-owned
+--   migrations/ discovery) and vendored to the dashboard projection DB
+--   (omnidash_analytics) the projection API binds to.
+--
+-- Idempotency: CREATE TABLE / INDEX / TRIGGER guarded so the migration is safe
+-- on a DB where the table already exists and on a fresh omnidash_analytics.
+
+-- ============================================================================
+-- COST_BY_REPO_SNAPSHOTS TABLE
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS cost_by_repo_snapshots (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    repo_name VARCHAR(512) NOT NULL,
+    "window" VARCHAR(32) NOT NULL DEFAULT 'latest',
+    snapshot_timestamp_minute TIMESTAMPTZ NOT NULL,
+
+    total_cost_usd NUMERIC(14, 6) NOT NULL DEFAULT 0,
+    total_tokens BIGINT NOT NULL DEFAULT 0,
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT uq_cost_by_repo_repo_window_minute
+        UNIQUE (repo_name, "window", snapshot_timestamp_minute),
+
+    CONSTRAINT non_negative_cost_by_repo_total_cost_usd CHECK (total_cost_usd >= 0),
+    CONSTRAINT non_negative_cost_by_repo_total_tokens CHECK (total_tokens >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_cost_by_repo_snapshots_total_cost_usd
+    ON cost_by_repo_snapshots (total_cost_usd DESC);
+
+CREATE INDEX IF NOT EXISTS idx_cost_by_repo_snapshots_window
+    ON cost_by_repo_snapshots ("window");
+
+CREATE INDEX IF NOT EXISTS idx_cost_by_repo_snapshots_updated_at
+    ON cost_by_repo_snapshots (updated_at DESC);
+
+-- ============================================================================
+-- TRIGGER: auto-update updated_at
+-- ============================================================================
+CREATE OR REPLACE FUNCTION update_cost_by_repo_snapshots_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trigger_cost_by_repo_snapshots_updated_at ON cost_by_repo_snapshots;
+CREATE TRIGGER trigger_cost_by_repo_snapshots_updated_at
+    BEFORE UPDATE ON cost_by_repo_snapshots
+    FOR EACH ROW
+    EXECUTE FUNCTION update_cost_by_repo_snapshots_updated_at();

--- a/docker/migrations/forward/nodes/node_projection_traces/0001_create_traces.sql
+++ b/docker/migrations/forward/nodes/node_projection_traces/0001_create_traces.sql
@@ -1,0 +1,68 @@
+-- OMN-13083: node-owned projection migration for traces.
+--
+-- WHY THIS EXISTS
+--   node_projection_traces declares projection_api over the traces table
+--   (topic onex.snapshot.projection.traces.v1). The dashboard trace-explorer
+--   widget's projectionSchema requires the correlation-grouped row shape
+--   (correlation_id, nodes_involved, event_count, first_event_at,
+--   last_event_at, duration_ms, has_error, is_running, latest_message).
+--   No contract previously backed that topic; OMN-12135 wired it to a bespoke
+--   Express query and OMN-12822 removed that bespoke server. This node-owned
+--   table is the canonical backing surface for the projection API.
+--
+--   Discovered + applied by scripts/run-projection-migrations.py (node-owned
+--   migrations/ discovery) and vendored to the dashboard projection DB
+--   (omnidash_analytics) the projection API binds to.
+--
+-- Idempotency: CREATE TABLE / INDEX / TRIGGER guarded so the migration is safe
+-- on a DB where the table already exists and on a fresh omnidash_analytics.
+
+-- ============================================================================
+-- TRACES TABLE
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS traces (
+    correlation_id VARCHAR(256) PRIMARY KEY,
+
+    nodes_involved TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    event_count INTEGER NOT NULL DEFAULT 0,
+
+    first_event_at TIMESTAMPTZ NOT NULL,
+    last_event_at TIMESTAMPTZ NOT NULL,
+    duration_ms BIGINT NOT NULL DEFAULT 0,
+
+    has_error BOOLEAN NOT NULL DEFAULT FALSE,
+    is_running BOOLEAN NOT NULL DEFAULT TRUE,
+    latest_message TEXT NOT NULL DEFAULT '',
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT non_negative_traces_event_count CHECK (event_count >= 0),
+    CONSTRAINT non_negative_traces_duration_ms CHECK (duration_ms >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_traces_last_event_at
+    ON traces (last_event_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_traces_has_error
+    ON traces (has_error);
+
+CREATE INDEX IF NOT EXISTS idx_traces_is_running
+    ON traces (is_running);
+
+-- ============================================================================
+-- TRIGGER: auto-update updated_at
+-- ============================================================================
+CREATE OR REPLACE FUNCTION update_traces_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trigger_traces_updated_at ON traces;
+CREATE TRIGGER trigger_traces_updated_at
+    BEFORE UPDATE ON traces
+    FOR EACH ROW
+    EXECUTE FUNCTION update_traces_updated_at();

--- a/src/omnibase_infra/runtime/tracing.py
+++ b/src/omnibase_infra/runtime/tracing.py
@@ -3,17 +3,25 @@
 """Opt-in OpenTelemetry tracing configuration for the ONEX runtime.
 
 Exports traces to an OTLP HTTP endpoint (e.g. Arize Phoenix on port 6006).
-Activation is controlled entirely by environment variables — if
-``OTEL_EXPORTER_OTLP_ENDPOINT`` is unset or empty, tracing is silently
-skipped and the runtime operates without any OTEL overhead.
+The exporter endpoint is resolved from the contract-declared
+``descriptor.otel_exporter_otlp_endpoint`` overlay value (OMN-13558 Wave-1
+endpoint→overlay migration) rather than read directly from ``os.environ`` — if
+the overlay resolves it empty (the var unset), tracing is silently skipped and
+the runtime operates without any OTEL overhead. The ``${env.VAR}`` resolution
+goes through the sanctioned overlay package, so this module no longer reads
+``os.environ`` for the endpoint itself.
 
-Environment Variables:
-    OTEL_EXPORTER_OTLP_ENDPOINT: OTLP HTTP endpoint URL (e.g. ``http://phoenix:6006``).
-        When empty or unset, tracing is disabled.
+Configuration:
+    descriptor.otel_exporter_otlp_endpoint: OTLP HTTP endpoint URL
+        (e.g. ``http://phoenix:6006``), contract-declared as
+        ``${env.OTEL_EXPORTER_OTLP_ENDPOINT:}`` in ``tracing_contract.yaml``.
+        When it resolves empty, tracing is disabled.
     OTEL_SERVICE_NAME: Logical service name attached to all spans.
-        Defaults to ``onex-runtime``.
+        Defaults to ``onex-runtime`` (operator-local span-naming knob, not a
+        service endpoint — Wave-2 config, retained as a direct read for now).
     OTEL_TRACES_EXPORTER: Exporter type. Only ``otlp`` (the default) is
-        currently supported; set to ``none`` to explicitly disable.
+        currently supported; set to ``none`` to explicitly disable (operator-local
+        toggle, not an endpoint — Wave-2 config).
 
 OMN-3811: Initial instrumentation for Phoenix OTEL traces.
 """
@@ -22,6 +30,10 @@ from __future__ import annotations
 
 import logging
 import os
+
+from omnibase_infra.runtime.tracing_contract_descriptor import (
+    contract_otel_exporter_endpoint,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -33,9 +45,12 @@ def configure_tracing() -> bool:
         ``True`` if tracing was successfully configured, ``False`` if skipped
         (no endpoint configured) or if an error occurred during setup.
     """
-    endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "").strip()
+    endpoint = contract_otel_exporter_endpoint()
     if not endpoint:
-        logger.debug("OTEL_EXPORTER_OTLP_ENDPOINT not set — tracing disabled")
+        logger.debug(
+            "descriptor.otel_exporter_otlp_endpoint resolved empty "
+            "(OTEL_EXPORTER_OTLP_ENDPOINT not set) — tracing disabled"
+        )
         return False
 
     exporter_type = os.environ.get("OTEL_TRACES_EXPORTER", "otlp").strip()

--- a/src/omnibase_infra/runtime/tracing_contract.yaml
+++ b/src/omnibase_infra/runtime/tracing_contract.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# Runtime observability (OTEL tracing) endpoint descriptor.
+#
+# OMN-13558 Wave-1 endpoint→overlay migration. The OTLP exporter endpoint the
+# ONEX kernel ships spans to is contract-declared here via the ${env.VAR}
+# overlay convention rather than read directly from os.environ in
+# runtime/tracing.py. An operator overlay / the per-lane `tracing` bundle env
+# supplies the real endpoint per lane (e.g. http://phoenix:6006). Resolution
+# goes through the overlay package's expand_contract_env_refs — the one
+# sanctioned env-reading boundary.
+#
+# Tracing is opt-in by design (OMN-3811): an unset endpoint resolves to the
+# empty string and the kernel skips tracing entirely. The descriptor therefore
+# uses an empty inline default (`${env.OTEL_EXPORTER_OTLP_ENDPOINT:}`) and does
+# NOT fail closed on absence — absence is a valid "tracing disabled" state, not
+# a misconfigured deploy.
+name: runtime_observability_tracing
+descriptor:
+  # OTLP HTTP endpoint the kernel exports spans to. Empty => tracing disabled.
+  otel_exporter_otlp_endpoint: "${env.OTEL_EXPORTER_OTLP_ENDPOINT:}"

--- a/src/omnibase_infra/runtime/tracing_contract_descriptor.py
+++ b/src/omnibase_infra/runtime/tracing_contract_descriptor.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Read the contract-declared OTEL exporter endpoint for the ONEX kernel.
+
+The kernel's ``descriptor.otel_exporter_otlp_endpoint`` is the single source of
+truth for the OTLP HTTP endpoint ``configure_tracing`` exports spans to
+(OMN-13558 Wave-1 endpoint→overlay migration). It is declared with the
+``${env.VAR}`` overlay convention so an operator overlay / the per-lane
+``tracing`` bundle env supplies the real endpoint per lane (e.g.
+``http://phoenix:6006``) — never read directly from ``os.environ`` in
+``runtime/tracing.py``.
+
+Resolution goes through ``expand_contract_env_refs`` — the one sanctioned
+env-reading boundary in the overlay package — so ``configure_tracing`` never
+reads ``os.environ`` for the endpoint directly.
+
+Unlike the fail-closed service endpoints (QDRANT_URL / GRAPH_BOLT_URI), OTEL
+tracing is **opt-in** by design (OMN-3811): an unset endpoint is a valid
+"tracing disabled" state, not a misconfigured deploy. The descriptor therefore
+returns the resolved value (empty string when unset, via the contract's empty
+inline default) and leaves the enable/disable decision to the caller — it does
+NOT raise on absence.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from omnibase_infra.runtime.overlay.contract_env_ref import expand_contract_env_refs
+
+_CONTRACT = Path(__file__).resolve().parent / "tracing_contract.yaml"
+
+
+def _load_contract(contract_path: Path) -> dict[str, object]:
+    # ONEX_EXCLUDE: io_audit - Module-level contract load keeps tracing policy contract-owned
+    with contract_path.open(encoding="utf-8") as contract_file:
+        raw = yaml.safe_load(contract_file)
+    if not isinstance(raw, dict):
+        raise ValueError(f"contract {contract_path} must contain a mapping")
+    return raw
+
+
+def contract_otel_exporter_endpoint(contract_path: Path = _CONTRACT) -> str:
+    """Return the resolved ``descriptor.otel_exporter_otlp_endpoint`` (may be empty).
+
+    The value is contract-declared (overridable by an operator overlay contract)
+    via the ``${env.OTEL_EXPORTER_OTLP_ENDPOINT:}`` convention — never read from
+    ``os.environ`` directly in ``runtime/tracing.py``. Returns the resolved,
+    stripped endpoint, or the empty string when the var is unset (preserving the
+    opt-in "tracing disabled" semantics of OMN-3811). The caller treats empty as
+    "tracing disabled".
+
+    Raises ``ValueError`` only on a structurally malformed contract (missing
+    descriptor mapping or non-string field) — a deploy-time wiring bug, distinct
+    from the runtime opt-out of an unset endpoint.
+    """
+    raw = _load_contract(contract_path)
+    descriptor = raw.get("descriptor")
+    if not isinstance(descriptor, dict):
+        raise ValueError(
+            f"contract {contract_path} must declare a descriptor mapping with "
+            "otel_exporter_otlp_endpoint"
+        )
+    declared = descriptor.get("otel_exporter_otlp_endpoint")
+    if not isinstance(declared, str):
+        raise ValueError(
+            f"contract {contract_path} must declare a string "
+            "descriptor.otel_exporter_otlp_endpoint (the "
+            "${env.OTEL_EXPORTER_OTLP_ENDPOINT:} overlay value the kernel uses "
+            "as the OTLP exporter endpoint)"
+        )
+    return expand_contract_env_refs(declared).strip()
+
+
+__all__: list[str] = ["contract_otel_exporter_endpoint"]

--- a/tests/unit/runtime/test_tracing_contract_descriptor.py
+++ b/tests/unit/runtime/test_tracing_contract_descriptor.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Resolution-equivalence tests for the OTEL tracing endpoint descriptor.
+
+OMN-13558 Wave-1 endpoint→overlay migration. Proves the overlay-resolved
+``descriptor.otel_exporter_otlp_endpoint`` returns exactly the value the old
+direct ``os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "")`` read returned for
+the same env, across dev / stability / prod lane values, and that an unset var
+resolves to the empty string (preserving the opt-in "tracing disabled"
+semantics of OMN-3811 — NOT a fail-closed raise).
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from omnibase_infra.runtime.tracing_contract_descriptor import (
+    contract_otel_exporter_endpoint,
+)
+
+_ENV = "OTEL_EXPORTER_OTLP_ENDPOINT"
+
+# Per-lane values that the old `os.environ` read would have returned.
+_LANE_ENDPOINTS = [
+    pytest.param("http://phoenix:6006", id="dev"),
+    pytest.param("http://omninode-infra-stability-test-phoenix:6006", id="stability"),
+    pytest.param("http://omninode-infra-prod-phoenix:6006", id="prod"),
+]
+
+
+@pytest.fixture(autouse=True)
+def _clean_otel_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure each test starts from an unset endpoint var."""
+    monkeypatch.delenv(_ENV, raising=False)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("endpoint", _LANE_ENDPOINTS)
+def test_descriptor_resolves_same_value_as_direct_env_read(
+    endpoint: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Overlay-resolved endpoint == the old direct os.environ read, per lane."""
+    monkeypatch.setenv(_ENV, endpoint)
+
+    # Old behavior reproduced inline for equivalence.
+    legacy = os.environ.get(_ENV, "").strip()
+    resolved = contract_otel_exporter_endpoint()
+
+    assert resolved == legacy
+    assert resolved == endpoint
+
+
+@pytest.mark.unit
+def test_descriptor_strips_whitespace_like_legacy_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The descriptor strips like the legacy ``.strip()`` call did."""
+    monkeypatch.setenv(_ENV, "  http://phoenix:6006  ")
+    assert contract_otel_exporter_endpoint() == "http://phoenix:6006"
+
+
+@pytest.mark.unit
+def test_descriptor_returns_empty_when_unset_opt_in_semantics() -> None:
+    """Unset endpoint resolves to '' (tracing disabled) — NOT a raise.
+
+    OTEL tracing is opt-in; absence is a valid disabled state, distinct from the
+    fail-closed QDRANT/GRAPH endpoints. The descriptor returns '' so
+    ``configure_tracing`` takes its existing "empty => disabled" branch.
+    """
+    # _clean_otel_env fixture guarantees the var is unset.
+    assert contract_otel_exporter_endpoint() == ""
+
+
+@pytest.mark.unit
+def test_descriptor_returns_empty_for_empty_string_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicitly-empty env value also resolves to '' (disabled)."""
+    monkeypatch.setenv(_ENV, "")
+    assert contract_otel_exporter_endpoint() == ""
+
+
+@pytest.mark.unit
+def test_descriptor_raises_on_structurally_malformed_contract(
+    tmp_path,
+) -> None:
+    """A contract missing the descriptor mapping is a wiring bug — raise."""
+    bad = tmp_path / "bad_contract.yaml"
+    bad.write_text("name: x\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="descriptor mapping"):
+        contract_otel_exporter_endpoint(bad)
+
+
+@pytest.mark.unit
+def test_descriptor_raises_on_non_string_field(tmp_path) -> None:
+    """A non-string descriptor field is a wiring bug — raise."""
+    bad = tmp_path / "bad_contract.yaml"
+    bad.write_text(
+        "name: x\ndescriptor:\n  otel_exporter_otlp_endpoint: 123\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="string"):
+        contract_otel_exporter_endpoint(bad)
+
+
+@pytest.mark.unit
+def test_configure_tracing_disabled_when_endpoint_unset() -> None:
+    """End-to-end: configure_tracing returns False via the descriptor when unset."""
+    from omnibase_infra.runtime.tracing import configure_tracing
+
+    # _clean_otel_env fixture guarantees the endpoint var is unset.
+    assert configure_tracing() is False


### PR DESCRIPTION
## Summary
- Migrates OTEL_EXPORTER_OTLP_ENDPOINT reads to the deploy overlay descriptor path.
- Keeps the runtime endpoint source aligned with the OMN-13558 OCC evidence.

Evidence-Source: OCC#3090
Evidence-Ticket: OMN-13558

## Verification
- CI / deploy-gate / receipt-gate are expected to validate against OCC#3090.