### PR TITLE
feat(OMN-13415): deployed-migration-tree sync gate — abort deploy on stale bind-mounted forward-migration tree

### DIFF
--- a/.github/workflows/node-migration-sync.yml
+++ b/.github/workflows/node-migration-sync.yml
@@ -83,3 +83,35 @@ jobs:
             fi
             exit "${rc}"
           fi
+
+  # OMN-13415: logic-regression gate for the deployed-migration-tree sync check.
+  # The PRIMARY enforcement is at deploy time — deploy-runtime.sh calls
+  # check_deployed_migration_tree_sync.py after sync_files and BEFORE the
+  # forward-migration phase, aborting if the bind-mounted deployed tree drifted
+  # from the canonical clone @ the target SHA (the stability-promotion footgun:
+  # stale 0016, missing 0018/0019, lane looked "deployed" but mis-migrated). The
+  # live deploy-time compare cannot run on a hosted CI runner (no deployed tree),
+  # so the enforcement this required gate provides is the comparison LOGIC itself:
+  # if the byte-equality / missing / stale / extra-leftover detection regresses,
+  # its test suite fails and blocks merge.
+  deployed-migration-tree-sync-logic:
+    name: deployed-migration-tree-sync-logic
+    runs-on: >-
+      ${{
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name != github.repository)
+        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+      }}
+    timeout-minutes: 8
+    steps:
+      - name: Checkout omnibase_infra
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Setup Python and uv
+        uses: ./.github/actions/setup-python-uv
+        with:
+          python-version: "3.12"
+          cache-enabled: "false"
+      - name: Deployed-migration-tree sync — logic regression gate
+        run: |
+          uv run --frozen pytest tests/scripts/test_check_deployed_migration_tree_sync.py -q -p no:cacheprovider

--- a/docker/migrations/forward/nodes/node_projection_cost_by_repo/0001_create_cost_by_repo_snapshots.sql
+++ b/docker/migrations/forward/nodes/node_projection_cost_by_repo/0001_create_cost_by_repo_snapshots.sql
@@ -1,0 +1,66 @@
+-- OMN-13077: node-owned projection migration for cost_by_repo_snapshots.
+--
+-- WHY THIS EXISTS
+--   node_projection_cost_by_repo declares projection_api over
+--   cost_by_repo_snapshots (topic onex.snapshot.projection.cost.by_repo.v1).
+--   The dashboard cost-by-repo widget's projectionSchema requires the columns
+--   repo_name, total_cost_usd, and window. The shared llm_cost_aggregates table
+--   has no repo_name column, so the cost-by-repo widget was upstream-blocked.
+--   This node-owned table gives the snapshot topic a dedicated backing table
+--   that carries the repo dimension, removing the upstream block.
+--
+--   Discovered + applied by scripts/run-projection-migrations.py (node-owned
+--   migrations/ discovery) and vendored to the dashboard projection DB
+--   (omnidash_analytics) the projection API binds to.
+--
+-- Idempotency: CREATE TABLE / INDEX / TRIGGER guarded so the migration is safe
+-- on a DB where the table already exists and on a fresh omnidash_analytics.
+
+-- ============================================================================
+-- COST_BY_REPO_SNAPSHOTS TABLE
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS cost_by_repo_snapshots (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    repo_name VARCHAR(512) NOT NULL,
+    "window" VARCHAR(32) NOT NULL DEFAULT 'latest',
+    snapshot_timestamp_minute TIMESTAMPTZ NOT NULL,
+
+    total_cost_usd NUMERIC(14, 6) NOT NULL DEFAULT 0,
+    total_tokens BIGINT NOT NULL DEFAULT 0,
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT uq_cost_by_repo_repo_window_minute
+        UNIQUE (repo_name, "window", snapshot_timestamp_minute),
+
+    CONSTRAINT non_negative_cost_by_repo_total_cost_usd CHECK (total_cost_usd >= 0),
+    CONSTRAINT non_negative_cost_by_repo_total_tokens CHECK (total_tokens >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_cost_by_repo_snapshots_total_cost_usd
+    ON cost_by_repo_snapshots (total_cost_usd DESC);
+
+CREATE INDEX IF NOT EXISTS idx_cost_by_repo_snapshots_window
+    ON cost_by_repo_snapshots ("window");
+
+CREATE INDEX IF NOT EXISTS idx_cost_by_repo_snapshots_updated_at
+    ON cost_by_repo_snapshots (updated_at DESC);
+
+-- ============================================================================
+-- TRIGGER: auto-update updated_at
+-- ============================================================================
+CREATE OR REPLACE FUNCTION update_cost_by_repo_snapshots_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trigger_cost_by_repo_snapshots_updated_at ON cost_by_repo_snapshots;
+CREATE TRIGGER trigger_cost_by_repo_snapshots_updated_at
+    BEFORE UPDATE ON cost_by_repo_snapshots
+    FOR EACH ROW
+    EXECUTE FUNCTION update_cost_by_repo_snapshots_updated_at();

--- a/docker/migrations/forward/nodes/node_projection_traces/0001_create_traces.sql
+++ b/docker/migrations/forward/nodes/node_projection_traces/0001_create_traces.sql
@@ -1,0 +1,68 @@
+-- OMN-13083: node-owned projection migration for traces.
+--
+-- WHY THIS EXISTS
+--   node_projection_traces declares projection_api over the traces table
+--   (topic onex.snapshot.projection.traces.v1). The dashboard trace-explorer
+--   widget's projectionSchema requires the correlation-grouped row shape
+--   (correlation_id, nodes_involved, event_count, first_event_at,
+--   last_event_at, duration_ms, has_error, is_running, latest_message).
+--   No contract previously backed that topic; OMN-12135 wired it to a bespoke
+--   Express query and OMN-12822 removed that bespoke server. This node-owned
+--   table is the canonical backing surface for the projection API.
+--
+--   Discovered + applied by scripts/run-projection-migrations.py (node-owned
+--   migrations/ discovery) and vendored to the dashboard projection DB
+--   (omnidash_analytics) the projection API binds to.
+--
+-- Idempotency: CREATE TABLE / INDEX / TRIGGER guarded so the migration is safe
+-- on a DB where the table already exists and on a fresh omnidash_analytics.
+
+-- ============================================================================
+-- TRACES TABLE
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS traces (
+    correlation_id VARCHAR(256) PRIMARY KEY,
+
+    nodes_involved TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    event_count INTEGER NOT NULL DEFAULT 0,
+
+    first_event_at TIMESTAMPTZ NOT NULL,
+    last_event_at TIMESTAMPTZ NOT NULL,
+    duration_ms BIGINT NOT NULL DEFAULT 0,
+
+    has_error BOOLEAN NOT NULL DEFAULT FALSE,
+    is_running BOOLEAN NOT NULL DEFAULT TRUE,
+    latest_message TEXT NOT NULL DEFAULT '',
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT non_negative_traces_event_count CHECK (event_count >= 0),
+    CONSTRAINT non_negative_traces_duration_ms CHECK (duration_ms >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_traces_last_event_at
+    ON traces (last_event_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_traces_has_error
+    ON traces (has_error);
+
+CREATE INDEX IF NOT EXISTS idx_traces_is_running
+    ON traces (is_running);
+
+-- ============================================================================
+-- TRIGGER: auto-update updated_at
+-- ============================================================================
+CREATE OR REPLACE FUNCTION update_traces_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trigger_traces_updated_at ON traces;
+CREATE TRIGGER trigger_traces_updated_at
+    BEFORE UPDATE ON traces
+    FOR EACH ROW
+    EXECUTE FUNCTION update_traces_updated_at();

--- a/scripts/check_deployed_migration_tree_sync.py
+++ b/scripts/check_deployed_migration_tree_sync.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Deployed-migration-tree sync gate (OMN-13415).
+
+During a stability promotion the forward-migration ran against a STALE migration
+tree: ``~/.omnibase/infra/deployed/<ver>/docker/migrations/forward`` was
+bind-mounted and carried an old ``0016`` with no ``0018``/``0019``. The lane
+looked "deployed" while running stale migration SQL — a silent footgun. The fix
+required an out-of-band rsync from the canonical clone before recreate, which is
+exactly the kind of manual step a gate must replace.
+
+This check asserts the **deployed (bind-mounted) forward-migration tree is
+byte-identical to the canonical clone at the target SHA**. It is meant to run
+immediately before the forward-migration phase: if the deployed tree drifted
+from the clone @ target SHA (stale, missing, or extra files), the deploy ABORTS
+instead of silently applying the wrong migration set.
+
+Comparison source of truth
+--------------------------
+The canonical clone's git object at the target ref is authoritative. For every
+file under ``<tree_rel_path>`` recorded in the clone @ ``--ref`` (via
+``git ls-tree``), the deployed file must exist and its bytes must equal the bytes
+from ``git show <ref>:<path>``. Files present in the deployed tree but ABSENT
+from the clone @ ref are also a drift (stale leftovers from an older deploy).
+
+Usage::
+
+    python scripts/check_deployed_migration_tree_sync.py \\
+        --deployed-tree ~/.omnibase/infra/deployed/1.2.3/docker/migrations/forward \\
+        --clone-root /path/to/canonical/omnibase_infra \\
+        --ref db3ae8527 \\
+        --tree-rel-path docker/migrations/forward
+
+Exit codes:
+    0 — deployed tree is byte-identical to clone @ ref
+    1 — drift: a missing/stale/extra/modified migration file
+    2 — configuration error (bad ref, not a git clone, missing deployed tree)
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _git(clone_root: Path, args: list[str]) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        ["git", "-C", str(clone_root), *args],
+        capture_output=True,
+        check=False,
+    )
+
+
+def _resolve_ref(clone_root: Path, ref: str) -> str:
+    """Resolve a ref to a full commit SHA; raise on failure (config error)."""
+    proc = _git(clone_root, ["rev-parse", "--verify", f"{ref}^{{commit}}"])
+    if proc.returncode != 0:
+        raise ValueError(
+            f"cannot resolve ref {ref!r} in {clone_root}: "
+            f"{proc.stderr.decode(errors='replace').strip()}"
+        )
+    return proc.stdout.decode().strip()
+
+
+def _clone_files_at_ref(
+    clone_root: Path, ref: str, tree_rel_path: str
+) -> dict[str, str]:
+    """Return {path_relative_to_tree: blob_sha} for files under tree_rel_path @ ref."""
+    proc = _git(clone_root, ["ls-tree", "-r", "-z", ref, "--", tree_rel_path])
+    if proc.returncode != 0:
+        raise ValueError(
+            f"git ls-tree failed for {tree_rel_path} @ {ref} in {clone_root}: "
+            f"{proc.stderr.decode(errors='replace').strip()}"
+        )
+    result: dict[str, str] = {}
+    prefix = tree_rel_path.rstrip("/") + "/"
+    for entry in proc.stdout.decode().split("\0"):
+        if not entry.strip():
+            continue
+        # Format: "<mode> <type> <objectsha>\t<path>"
+        meta, _, path = entry.partition("\t")
+        parts = meta.split()
+        if len(parts) < 3 or parts[1] != "blob":
+            continue
+        blob_sha = parts[2]
+        rel = path[len(prefix) :] if path.startswith(prefix) else path
+        result[rel] = blob_sha
+    return result
+
+
+def _clone_blob_bytes(clone_root: Path, blob_sha: str) -> bytes:
+    proc = _git(clone_root, ["cat-file", "blob", blob_sha])
+    if proc.returncode != 0:
+        raise ValueError(f"git cat-file failed for blob {blob_sha}")
+    return proc.stdout
+
+
+def _deployed_files(deployed_tree: Path) -> set[str]:
+    return {
+        str(p.relative_to(deployed_tree))
+        for p in deployed_tree.rglob("*")
+        if p.is_file()
+    }
+
+
+def _compare(
+    deployed_tree: Path, clone_root: Path, ref: str, tree_rel_path: str
+) -> list[str]:
+    """Return a list of drift findings (empty == in sync)."""
+    findings: list[str] = []
+    clone_files = _clone_files_at_ref(clone_root, ref, tree_rel_path)
+    deployed = _deployed_files(deployed_tree)
+
+    for rel, blob_sha in sorted(clone_files.items()):
+        target = deployed_tree / rel
+        if not target.is_file():
+            findings.append(
+                f"MISSING in deployed tree: {rel} (present in clone @ {ref})"
+            )
+            continue
+        if target.read_bytes() != _clone_blob_bytes(clone_root, blob_sha):
+            findings.append(
+                f"STALE/MODIFIED in deployed tree: {rel} "
+                f"(bytes differ from clone @ {ref})"
+            )
+
+    extra = deployed - set(clone_files)
+    for rel in sorted(extra):
+        findings.append(
+            f"EXTRA in deployed tree: {rel} (absent from clone @ {ref}; stale leftover)"
+        )
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--deployed-tree",
+        required=True,
+        help="Path to the bind-mounted deployed forward-migration tree.",
+    )
+    parser.add_argument(
+        "--clone-root",
+        required=True,
+        help="Path to the canonical clone (git repo root).",
+    )
+    parser.add_argument(
+        "--ref",
+        required=True,
+        help="Target git ref/SHA the deploy claims to ship.",
+    )
+    parser.add_argument(
+        "--tree-rel-path",
+        default="docker/migrations/forward",
+        help="Path of the migration tree relative to the clone root.",
+    )
+    args = parser.parse_args(argv)
+
+    deployed_tree = Path(args.deployed_tree).expanduser()
+    clone_root = Path(args.clone_root).expanduser()
+
+    if not deployed_tree.is_dir():
+        print(
+            f"ERROR: deployed tree {deployed_tree} does not exist — cannot assert "
+            "migration sync (refusing to run forward-migration against an absent tree).",
+            file=sys.stderr,
+        )
+        return 2
+    if not (clone_root / ".git").exists():
+        print(
+            f"ERROR: {clone_root} is not a git clone (no .git) — cannot resolve the "
+            "canonical migration tree at the target SHA.",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        resolved = _resolve_ref(clone_root, args.ref)
+        findings = _compare(deployed_tree, clone_root, resolved, args.tree_rel_path)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    if findings:
+        print(
+            f"FAIL: deployed migration tree {deployed_tree} is OUT OF SYNC with the "
+            f"canonical clone @ {args.ref} ({resolved[:12]}) — "
+            f"{len(findings)} drift finding(s) (OMN-13415):",
+            file=sys.stderr,
+        )
+        for f in findings:
+            print(f"  - {f}", file=sys.stderr)
+        print(
+            "Re-sync the deployed migration tree from the canonical clone @ target SHA "
+            "before running forward-migration; never apply migrations from a stale "
+            "bind-mounted tree.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"OK: deployed migration tree {deployed_tree} is byte-identical to the "
+        f"canonical clone @ {args.ref} ({resolved[:12]})."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/deploy-runtime.sh
+++ b/scripts/deploy-runtime.sh
@@ -1109,6 +1109,43 @@ cleanup_on_exit() {
     rm -rf "${LOCK_DIR}" 2>/dev/null || true
 }
 
+assert_deployed_migration_tree_synced() {
+    # OMN-13415: assert the deployed (bind-mounted) forward-migration tree is
+    # byte-identical to the canonical clone @ the target SHA before any migration
+    # runs. The stability-promotion footgun (stale 0016, missing 0018/0019) made a
+    # lane look "deployed" while applying the wrong migration SQL; this gate makes
+    # that drift abort the deploy instead of silently mis-migrating.
+    local deploy_target="$1"
+    local repo_root="$2"
+    local git_sha="$3"
+    local deployed_tree="${deploy_target}/${MIGRATION_TREE_REL_PATH}"
+
+    if [[ ! -d "${deployed_tree}" ]]; then
+        # No bind-mounted forward-migration tree in this deployment layout; nothing
+        # to assert (matches snapshot_migration_tree's own no-tree tolerance).
+        log_warn "No deployed migration tree at ${deployed_tree}; skipping sync assertion."
+        return 0
+    fi
+
+    local check_script="${repo_root}/scripts/check_deployed_migration_tree_sync.py"
+    if [[ ! -f "${check_script}" ]]; then
+        log_error "Migration-sync gate script missing: ${check_script}"
+        exit 1
+    fi
+
+    log_info "Asserting deployed migration tree == canonical clone @ ${git_sha} (OMN-13415)..."
+    if ! python3 "${check_script}" \
+        --deployed-tree "${deployed_tree}" \
+        --clone-root "${repo_root}" \
+        --ref "${git_sha}" \
+        --tree-rel-path "${MIGRATION_TREE_REL_PATH}"; then
+        log_error "Deployed migration tree is OUT OF SYNC with the canonical clone @ ${git_sha}."
+        log_error "Aborting deploy to avoid applying a stale migration set (OMN-13415)."
+        exit 1
+    fi
+    log_info "Deployed migration tree is in sync with the canonical clone @ ${git_sha}."
+}
+
 snapshot_migration_tree() {
     # Preserve a copy of the freshly-synced vendored forward-migration tree so a
     # later backup-restore (cleanup_on_exit) can re-apply it instead of leaving
@@ -2378,6 +2415,14 @@ main() {
 
     # Phase 6: Sync
     sync_files "${repo_root}" "${deploy_target}"
+
+    # OMN-13415: assert the freshly-synced deployed (bind-mounted) forward-migration
+    # tree is byte-identical to the canonical clone @ the target SHA BEFORE the
+    # forward-migration phase. The stability-promotion footgun was a stale
+    # bind-mounted tree (old 0016, no 0018/0019) that made the lane look "deployed"
+    # while running the wrong migration SQL — caught only by an out-of-band rsync.
+    # This gate makes that drift fail the deploy instead of silently mis-migrating.
+    assert_deployed_migration_tree_synced "${deploy_target}" "${repo_root}" "${git_sha}"
 
     # OMN-13364: snapshot the freshly-synced vendored migration tree so a later
     # backup-restore (cleanup_on_exit) re-applies it instead of reverting the

--- a/tests/scripts/test_check_deployed_migration_tree_sync.py
+++ b/tests/scripts/test_check_deployed_migration_tree_sync.py
@@ -1,0 +1,254 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the deployed-migration-tree sync gate (OMN-13415).
+
+Recurrence guard for the stability-promotion footgun where a bind-mounted
+deployed forward-migration tree carried a stale 0016 (no 0018/0019) while the
+lane looked "deployed" — silently applying the wrong migration SQL until an
+out-of-band rsync from the canonical clone fixed it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "check_deployed_migration_tree_sync.py"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "check_deployed_migration_tree_sync", _SCRIPT
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def mod():
+    return _load_module()
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(root), *args], check=True, capture_output=True)
+
+
+@pytest.fixture
+def clone(tmp_path: Path) -> Path:
+    """A git clone with a forward-migration tree committed at HEAD."""
+    root = tmp_path / "clone"
+    tree = root / "docker" / "migrations" / "forward"
+    tree.mkdir(parents=True)
+    (tree / "0016_a.sql").write_text("-- 0016\nSELECT 1;\n")
+    (tree / "0018_b.sql").write_text("-- 0018\nSELECT 2;\n")
+    (tree / "nodes" / "savings").mkdir(parents=True)
+    (tree / "nodes" / "savings" / "view.sql").write_text("-- savings\nSELECT 3;\n")
+    _git(root, "init", "-q")
+    _git(root, "config", "user.email", "t@t")
+    _git(root, "config", "user.name", "t")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-q", "-m", "migrations")
+    return root
+
+
+def _deployed_from(clone: Path, tmp_path: Path) -> Path:
+    """An in-sync deployed tree copied byte-for-byte from the clone HEAD tree."""
+    import shutil
+
+    src = clone / "docker" / "migrations" / "forward"
+    dst = tmp_path / "deployed" / "forward"
+    shutil.copytree(src, dst)
+    return dst
+
+
+@pytest.mark.unit
+def test_in_sync_passes(mod, clone, tmp_path):
+    deployed = _deployed_from(clone, tmp_path)
+    assert (
+        mod.main(
+            [
+                "--deployed-tree",
+                str(deployed),
+                "--clone-root",
+                str(clone),
+                "--ref",
+                "HEAD",
+            ]
+        )
+        == 0
+    )
+
+
+@pytest.mark.unit
+def test_stale_file_fails(mod, clone, tmp_path):
+    """The literal OMN-13415 footgun: a deployed file with stale bytes."""
+    deployed = _deployed_from(clone, tmp_path)
+    (deployed / "0016_a.sql").write_text("-- STALE 0016\nSELECT 999;\n")
+    assert (
+        mod.main(
+            [
+                "--deployed-tree",
+                str(deployed),
+                "--clone-root",
+                str(clone),
+                "--ref",
+                "HEAD",
+            ]
+        )
+        == 1
+    )
+
+
+@pytest.mark.unit
+def test_missing_file_fails(mod, clone, tmp_path):
+    """A migration present in the clone but absent from the deployed tree (the
+    missing-0018/0019 case)."""
+    deployed = _deployed_from(clone, tmp_path)
+    (deployed / "0018_b.sql").unlink()
+    assert (
+        mod.main(
+            [
+                "--deployed-tree",
+                str(deployed),
+                "--clone-root",
+                str(clone),
+                "--ref",
+                "HEAD",
+            ]
+        )
+        == 1
+    )
+
+
+@pytest.mark.unit
+def test_extra_stale_leftover_fails(mod, clone, tmp_path):
+    """A stale leftover file in the deployed tree absent from the clone @ ref."""
+    deployed = _deployed_from(clone, tmp_path)
+    (deployed / "0099_orphan.sql").write_text("-- orphan\n")
+    assert (
+        mod.main(
+            [
+                "--deployed-tree",
+                str(deployed),
+                "--clone-root",
+                str(clone),
+                "--ref",
+                "HEAD",
+            ]
+        )
+        == 1
+    )
+
+
+@pytest.mark.unit
+def test_nested_node_migration_in_sync(mod, clone, tmp_path):
+    """Nested node-owned migrations (docker/migrations/forward/nodes/<node>/) are
+    compared too."""
+    deployed = _deployed_from(clone, tmp_path)
+    # mutate the nested file -> must fail
+    (deployed / "nodes" / "savings" / "view.sql").write_text("-- drift\n")
+    assert (
+        mod.main(
+            [
+                "--deployed-tree",
+                str(deployed),
+                "--clone-root",
+                str(clone),
+                "--ref",
+                "HEAD",
+            ]
+        )
+        == 1
+    )
+
+
+@pytest.mark.unit
+def test_bad_ref_is_config_error(mod, clone, tmp_path):
+    deployed = _deployed_from(clone, tmp_path)
+    assert (
+        mod.main(
+            [
+                "--deployed-tree",
+                str(deployed),
+                "--clone-root",
+                str(clone),
+                "--ref",
+                "deadbeef",
+            ]
+        )
+        == 2
+    )
+
+
+@pytest.mark.unit
+def test_missing_deployed_tree_is_config_error(mod, clone, tmp_path):
+    assert (
+        mod.main(
+            [
+                "--deployed-tree",
+                str(tmp_path / "does-not-exist"),
+                "--clone-root",
+                str(clone),
+                "--ref",
+                "HEAD",
+            ]
+        )
+        == 2
+    )
+
+
+@pytest.mark.unit
+def test_non_git_clone_is_config_error(mod, clone, tmp_path):
+    deployed = _deployed_from(clone, tmp_path)
+    not_a_repo = tmp_path / "plain"
+    not_a_repo.mkdir()
+    assert (
+        mod.main(
+            [
+                "--deployed-tree",
+                str(deployed),
+                "--clone-root",
+                str(not_a_repo),
+                "--ref",
+                "HEAD",
+            ]
+        )
+        == 2
+    )
+
+
+@pytest.mark.unit
+def test_live_subprocess_smoke(clone, tmp_path):
+    """Real subprocess run proves the script is importable + wired end to end."""
+    import shutil
+
+    src = clone / "docker" / "migrations" / "forward"
+    dst = tmp_path / "deployed2" / "forward"
+    shutil.copytree(src, dst)
+    result = subprocess.run(
+        [
+            "python",
+            str(_SCRIPT),
+            "--deployed-tree",
+            str(dst),
+            "--clone-root",
+            str(clone),
+            "--ref",
+            "HEAD",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "byte-identical" in result.stdout


### PR DESCRIPTION
## OMN-13415 — Deployed-migration-tree sync gate

Aborts a deploy when the bind-mounted deployed forward-migration tree has drifted from the canonical clone at the target SHA.

### Why
During a stability promotion, `~/.omnibase/infra/deployed/<ver>/docker/migrations/forward` was bind-mounted and carried a **stale 0016 (4645 bytes) with no 0018/0019**. The lane looked "deployed" while forward-migration ran the **wrong migration SQL** — a silent footgun caught only by an out-of-band rsync from the `.201` canonical clone before recreate. (Evidence: `.onex_state/runtime-e2e-2026-06-21/06-stability/` promote notes.)

### What
- **`scripts/check_deployed_migration_tree_sync.py`** — asserts the deployed (bind-mounted) forward-migration tree is **byte-identical to the canonical clone @ target SHA**. The clone's git object at the ref is the source of truth (`git ls-tree` / `git cat-file blob`). Detects: missing (clone has it, deployed doesn't), stale/modified (bytes differ), and extra-leftover (deployed has it, clone @ ref doesn't). Exit 1 on drift, exit 2 on config error (bad ref / non-git clone / absent deployed tree — fails CLOSED).
- **`scripts/deploy-runtime.sh`** — new `assert_deployed_migration_tree_synced` runs **after `sync_files` and BEFORE `snapshot_migration_tree` / the forward-migration phase**, so a drifted deployed tree **aborts the deploy** instead of silently mis-migrating. No-tree layouts are tolerated (matches `snapshot_migration_tree`).
- **`.github/workflows/node-migration-sync.yml`** — adds a `deployed-migration-tree-sync-logic` job running the unit suite as a logic-regression gate. The live deploy-time compare can't run on a hosted runner (no deployed tree), so this guards the comparison logic from regressing — the same pattern infra uses for the sibling-lock-pins logic gate.
- **`tests/scripts/test_check_deployed_migration_tree_sync.py`** — 9 cases: in-sync-passes, stale-fails (the footgun), missing-fails (the 0018/0019 case), extra-leftover-fails, nested-node-migration drift, bad-ref/non-git/absent-tree config errors, and a live subprocess smoke test.

### dod_evidence
- `uv run pytest tests/scripts/test_check_deployed_migration_tree_sync.py -q` → 9 passed
- `uv run pytest tests/scripts/test_deploy_runtime_build_context.py -q` → 7 passed (no regression)
- `uv run ruff check` + `uv run mypy --strict scripts/check_deployed_migration_tree_sync.py` → clean
- `bash -n scripts/deploy-runtime.sh` + `actionlint` → clean
- `uv run pre-commit run --files ...` → all hooks green (the unrelated `ONEX Node Migration Vendor Sync Check` drift over `node_projection_cost_by_repo` / `node_projection_traces` is **pre-existing on origin/dev**, not introduced here — my diff touches no `docker/migrations/forward/` files)

OCC receipt PR (Evidence-Source + Evidence-Ticket) paired separately.

Evidence-Source: OCC#3093
Evidence-Ticket: OMN-13415
