### PR TITLE
feat(OMN-13077): deploy cost.by_repo projection writer service in lane

### DIFF
--- a/docker/catalog/bundles.yaml
+++ b/docker/catalog/bundles.yaml
@@ -137,6 +137,7 @@ omnimarket-projections:
   services:
     - omnimarket-projection-session-outcome
     - omnimarket-projection-llm-cost
+    - omnimarket-projection-cost-by-repo
     - omnimarket-projection-savings
     - omnimarket-projection-delegation
     - omnimarket-projection-baselines

--- a/docker/catalog/services/omnimarket-projection-cost-by-repo.yaml
+++ b/docker/catalog/services/omnimarket-projection-cost-by-repo.yaml
@@ -1,0 +1,35 @@
+name: omnimarket-projection-cost-by-repo
+description: Kafka-to-DB projection consumer for cost-by-repo snapshots (OMN-13077)
+image: omnimarket-projection:latest
+layer: runtime
+container_name: omnimarket-projection-cost-by-repo
+required_env:
+  - OMNIDASH_ANALYTICS_DB_URL
+hardcoded_env:
+  KAFKA_BROKERS: redpanda:9092
+  PYTHONUNBUFFERED: "1"
+operational_defaults:
+  KAFKA_CONSUMER_GROUP: omnimarket-projections-v1
+  ONEX_LOG_LEVEL: INFO
+ports: null
+healthcheck: null
+volumes: []
+depends_on:
+  - service: redpanda
+    condition: service_healthy
+  - service: postgres
+    condition: service_healthy
+restart: unless-stopped
+resources:
+  cpus: "0.5"
+  memory: 256M
+  cpus_reservation: "0.1"
+  memory_reservation: 64M
+stop_grace_period: 30s
+command:
+  - python
+  - -m
+  - omnimarket.nodes.node_projection_cost_by_repo.handlers.handler_cost_by_repo
+labels:
+  com.omninode.service: omnimarket-projection-cost-by-repo
+  com.omninode.layer: runtime


### PR DESCRIPTION
## OMN-13077 — deploy cost.by_repo projection writer service in lane

Adds the `omnimarket-projection-cost-by-repo` catalog service (mirrors `omnimarket-projection-llm-cost`) so the OMN-13077 cost.by_repo writer (`CostByRepoProjectionRunner`) actually runs in the lane. Registered in the `omnimarket-projections` bundle.

- Consumes the LIVE `onex.evt.omnibase-infra.delegation-completed.v1` topic.
- Materializes rows into `cost_by_repo_snapshots` (`omnidash_analytics`) — the dashboard cost-by-repo widget read model (`onex.snapshot.projection.cost.by_repo.v1`).
- The node-owned migration `0001_create_cost_by_repo_snapshots.sql` is auto-vendored by `scripts/sync-node-migrations.sh` (discovers `src/omnimarket/nodes/*/migrations`).

Companion omnimarket PR carries the writer + contract + TDD. No live deploy in this PR (build/PR scope); live bring-up deferred to the serialized dev redeploy workstream.

Pre-commit green (ONEX contract validation, writer-migration coupling).

Evidence-Source: OCC#3119
Evidence-Ticket: OMN-13077

OMN-13077

