### PR TITLE
ci(OMN-13332): wire occ-preflight / eligibility gate via call-occ-preflight

### DIFF
--- a/.github/workflows/call-occ-preflight.yml
+++ b/.github/workflows/call-occ-preflight.yml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# OCC Preflight caller — gates auto-merge and merge_group on OCC eligibility.
+# (OMN-10485 / OMN-10482 epic; required-everywhere wiring: OMN-13332)
+#
+# This workflow wires the reusable occ-preflight check (hosted in omnibase_core)
+# as a required status check in this repo. Every auto-merging repo follows the
+# same pattern: a `call-occ-preflight.yml` that delegates to the reusable.
+#
+# Required status check name: "occ-preflight / eligibility"
+#
+# Invariants enforced by the reusable workflow (do NOT modify here):
+#   I2: merge_group events re-run eligibility fully (cache disabled in reusable).
+#   I3: OCC's own PRs validate against in-tree checkout (handled inside reusable).
+#   I4: OCC fetch failure is a hard FAIL.
+
+name: OCC Preflight
+
+on:
+  pull_request:
+    branches: [main, dev, "hotfix/**"]
+    types: [opened, synchronize, reopened, ready_for_review]
+  merge_group:
+    types: [checks_requested]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  occ-preflight:
+    uses: OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main
+    with:
+      contracts-dir: contracts
+      receipts-dir: drift/dod_receipts


### PR DESCRIPTION
Wires the reusable OCC preflight eligibility gate as a fired status check in this repo by
adding `.github/workflows/call-occ-preflight.yml`, which delegates to
`OmniNode-ai/omnibase_core/.github/workflows/occ-preflight.yml@main` via `workflow_call`.
This produces the `occ-preflight / eligibility` status context on PRs to dev. After this
PR merges, that context is added to `required_status_checks` on dev so auto-merge cannot
arm without an OCC preflight pass (OMN-13332; strengthens the OCC-autobind chain OMN-13317).

Ticket: OMN-13332
Evidence-Source: OCC#3137
Evidence-Ticket: OMN-13332

dod_evidence: per-repo `call-occ-preflight.yml` presence + the live `occ-preflight / eligibility`
required-context readback are attested in `onex_change_control` contract `contracts/OMN-13332.yaml`
with paired receipts under `drift/dod_receipts/OMN-13332/` (Evidence-Source OCC#3137).

CI-config-only change: no runtime contract, node, topic, or migration; no live deploy.
