### PR TITLE
feat(OMN-13612): canonical MCP register_generated_tool — route SEA tool_registry registration (WS-C Phase 2.2)

### DIFF
--- a/src/omnibase_infra/models/mcp/__init__.py
+++ b/src/omnibase_infra/models/mcp/__init__.py
@@ -3,12 +3,16 @@
 """MCP models for Model Context Protocol integration."""
 
 from omnibase_infra.models.mcp.model_mcp_contract_config import ModelMCPContractConfig
+from omnibase_infra.models.mcp.model_mcp_generated_tool_registration import (
+    ModelMCPGeneratedToolRegistration,
+)
 from omnibase_infra.models.mcp.model_mcp_server_config import ModelMCPServerConfig
 from omnibase_infra.models.mcp.model_mcp_tool_definition import ModelMCPToolDefinition
 from omnibase_infra.models.mcp.model_mcp_tool_parameter import ModelMCPToolParameter
 
 __all__ = [
     "ModelMCPContractConfig",
+    "ModelMCPGeneratedToolRegistration",
     "ModelMCPServerConfig",
     "ModelMCPToolDefinition",
     "ModelMCPToolParameter",

--- a/src/omnibase_infra/models/mcp/model_mcp_generated_tool_registration.py
+++ b/src/omnibase_infra/models/mcp/model_mcp_generated_tool_registration.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Registration record for a generated tool routed onto the canonical MCP registry.
+
+This is the canonical replacement for the bespoke SEA ``ToolRegistration`` record
+(``onex-self-extending-agent/src/agent/tool_registry.py``). It captures the
+evidence-binding fields that prove *which* generated artifact was registered,
+without conflating registration with in-process handler execution (the exec/invoke
+sandbox is the Phase 0 hot-load executor concern, OMN-13605, not MCP registration).
+
+The MCP server in ``omnibase_infra`` is the protocol-infra owner of tool
+registration (feedback_mcp_server_in_omnibase_infra.md); generated tools register
+through ``ServiceMCPToolRegistry.register_generated_tool`` and surface via the
+canonical ``ServiceMCPToolRegistry`` / ``ServiceMCPToolSync`` exposure path.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelMCPGeneratedToolRegistration(BaseModel):
+    """Typed record returned when a generated tool is registered on the MCP registry.
+
+    The artifact-hash fields bind the registration to the exact contract + handler
+    source that produced it, so a later audit can prove provenance. The
+    ``registry_event_version`` is the version key the registry used for the upsert
+    (idempotency / out-of-order resolution).
+
+    Attributes:
+        registration_id: Unique identifier for this registration record.
+        name: Canonical MCP tool name (the generated node name).
+        description: AI-friendly description surfaced to MCP clients.
+        generated_contract_hash: ``sha256:<hex>`` of the generating contract YAML.
+        generated_handler_hash: ``sha256:<hex>`` of the generating handler source.
+        generation_correlation_id: Correlation id of the generation request.
+        registry_event_version: Version key used for the registry upsert.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    registration_id: UUID = Field(
+        description="Unique identifier for this registration record",
+    )
+    name: str = Field(
+        description="Canonical MCP tool name (the generated node name)",
+    )
+    description: str = Field(
+        description="AI-friendly description surfaced to MCP clients",
+    )
+    generated_contract_hash: str = Field(
+        description="sha256:<hex> of the generating contract YAML",
+    )
+    generated_handler_hash: str = Field(
+        description="sha256:<hex> of the generating handler source",
+    )
+    generation_correlation_id: UUID = Field(
+        description="Correlation id of the generation request",
+    )
+    registry_event_version: str = Field(
+        description="Version key used for the registry upsert (idempotency)",
+    )
+
+
+__all__ = ["ModelMCPGeneratedToolRegistration"]

--- a/src/omnibase_infra/services/mcp/service_mcp_tool_registry.py
+++ b/src/omnibase_infra/services/mcp/service_mcp_tool_registry.py
@@ -19,14 +19,16 @@ Version Tracking:
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
-from typing import TYPE_CHECKING
-from uuid import uuid4
+from uuid import UUID, uuid4
 
-if TYPE_CHECKING:
-    from omnibase_infra.models.mcp.model_mcp_tool_definition import (
-        ModelMCPToolDefinition,
-    )
+from omnibase_infra.models.mcp.model_mcp_generated_tool_registration import (
+    ModelMCPGeneratedToolRegistration,
+)
+from omnibase_infra.models.mcp.model_mcp_tool_definition import (
+    ModelMCPToolDefinition,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -100,6 +102,120 @@ class ServiceMCPToolRegistry:
         Note: This is a snapshot and may change immediately after reading.
         """
         return len(self._tools)
+
+    # MCP exposure tags required by ServiceMCPToolSync._is_mcp_exposable for a
+    # generated COMPUTE node (the SEA self-extension loop output, OMN-12827 B2).
+    _TAG_MCP_ENABLED = "mcp-enabled"
+    _TAG_NODE_TYPE_COMPUTE = "node-type:compute"
+    _TAG_GENERATED = "generated"
+    _TAG_PREFIX_MCP_TOOL = "mcp-tool:"
+
+    @staticmethod
+    def _artifact_hash(text: str) -> str:
+        """Return a ``sha256:<hex>`` digest binding a generated artifact."""
+        return "sha256:" + hashlib.sha256(text.encode()).hexdigest()
+
+    async def register_generated_tool(
+        self,
+        *,
+        node_name: str,
+        description: str,
+        contract_yaml: str,
+        handler_source: str,
+        correlation_id: UUID,
+    ) -> ModelMCPGeneratedToolRegistration:
+        """Register a generated COMPUTE node as an MCP tool on the canonical registry.
+
+        This is the canonical replacement for the bespoke SEA
+        ``ToolRegistry.register`` (the in-process generated-tool store that the
+        SEA self-extension loop used). It routes the *registration semantics* of
+        a generated tool onto this canonical registry: the generated node surfaces
+        through the one MCP exposure path (``ServiceMCPToolRegistry`` /
+        ``ServiceMCPToolSync``) instead of a parallel bespoke store.
+
+        The MCP server in ``omnibase_infra`` is the protocol-infra owner of tool
+        registration (feedback_mcp_server_in_omnibase_infra.md). In-process
+        ``exec()``/``invoke()`` of the handler is deliberately NOT part of this
+        method: that hot-load sandbox concern belongs to the Phase 0 generation
+        executor (OMN-13605), not to MCP registration.
+
+        The built tool carries the tags the canonical exposure rule requires for a
+        generated compute node (``mcp-enabled`` + ``node-type:compute`` +
+        ``generated`` + ``mcp-tool:<name>``), so it is surfaced exactly as a
+        hot-reloaded generated node from the bus would be.
+
+        Args:
+            node_name: Generated node name; becomes the canonical MCP tool name.
+            description: AI-friendly description surfaced to MCP clients.
+            contract_yaml: The generating contract YAML (hashed for provenance).
+            handler_source: The generating handler source (hashed for provenance).
+            correlation_id: Correlation id of the generation request.
+
+        Returns:
+            A typed ``ModelMCPGeneratedToolRegistration`` binding the artifact
+            hashes and the registry version key used for the upsert.
+
+        Raises:
+            ValueError: If ``node_name`` is empty (fail fast; no silent default).
+        """
+        if not node_name:
+            raise ValueError("node_name must be a non-empty generated node name")
+
+        contract_hash = self._artifact_hash(contract_yaml)
+        handler_hash = self._artifact_hash(handler_source)
+
+        # Version key binds to the artifact content so re-registering the same
+        # generated artifact is idempotent (same hashes -> same version), while a
+        # revised contract/handler mints a newer version that updates the registry.
+        registry_event_id = self._artifact_hash(contract_hash + handler_hash)
+
+        tags = [
+            self._TAG_MCP_ENABLED,
+            self._TAG_NODE_TYPE_COMPUTE,
+            self._TAG_GENERATED,
+            f"{self._TAG_PREFIX_MCP_TOOL}{node_name}",
+        ]
+
+        tool = ModelMCPToolDefinition(
+            name=node_name,
+            description=description,
+            version="1.0.0",
+            parameters=[],
+            input_schema={"type": "object", "properties": {}},
+            orchestrator_node_id=None,
+            orchestrator_service_id=None,
+            endpoint=None,
+            timeout_seconds=30,
+            metadata={
+                "tags": tags,
+                "node_kind": "generated compute node",
+                "generated_contract_hash": contract_hash,
+                "generated_handler_hash": handler_hash,
+                "generation_correlation_id": str(correlation_id),
+                "source": "generated_tool_registration",
+            },
+        )
+
+        await self.upsert_tool(tool, registry_event_id)
+
+        logger.info(
+            "Generated tool registered on canonical MCP registry",
+            extra={
+                "tool_name": node_name,
+                "registry_event_id": registry_event_id,
+                "correlation_id": str(correlation_id),
+            },
+        )
+
+        return ModelMCPGeneratedToolRegistration(
+            registration_id=uuid4(),
+            name=node_name,
+            description=description,
+            generated_contract_hash=contract_hash,
+            generated_handler_hash=handler_hash,
+            generation_correlation_id=correlation_id,
+            registry_event_version=registry_event_id,
+        )
 
     async def upsert_tool(
         self,

--- a/tests/unit/services/mcp/test_service_mcp_tool_registry_generated.py
+++ b/tests/unit/services/mcp/test_service_mcp_tool_registry_generated.py
@@ -1,0 +1,204 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Unit tests for ServiceMCPToolRegistry.register_generated_tool (OMN-13612).
+
+This is the canonical replacement for the bespoke SEA ToolRegistry.register
+(onex-self-extending-agent/src/agent/tool_registry.py). The SEA registry stored
+generated-tool registration records in its own in-process dict; this routes that
+registration *semantics* onto the canonical MCP registry so generated tools surface
+through the one canonical ServiceMCPToolRegistry / ServiceMCPToolSync exposure path.
+
+The contract this test is written from (the source of truth):
+
+- register_generated_tool registers a generated COMPUTE node into the canonical
+  registry, derived from the same metadata the SEA ToolRegistration captured
+  (node name, description, contract/handler artifact hashes, correlation id).
+- After registration the tool is retrievable from the *canonical* registry
+  (get_tool / has_tool / list_tools / tool_count) -- not a bespoke store.
+- The stored tool carries the tags the canonical MCP exposure rule requires for a
+  generated compute node: mcp-enabled + node-type:compute + generated + mcp-tool:<name>
+  (ServiceMCPToolSync._is_mcp_exposable must accept them).
+- The returned ModelMCPGeneratedToolRegistration binds the artifact hashes and the
+  registry event id used for the upsert.
+- Re-registering the same generated artifact is idempotent (same content -> not a
+  new version); a newer correlation/registration yields a fresh registry version.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from uuid import uuid4
+
+import pytest
+
+from omnibase_infra.models.mcp.model_mcp_generated_tool_registration import (
+    ModelMCPGeneratedToolRegistration,
+)
+from omnibase_infra.services.mcp.service_mcp_tool_registry import ServiceMCPToolRegistry
+from omnibase_infra.services.mcp.service_mcp_tool_sync import ServiceMCPToolSync
+
+_CONTRACT_YAML = """\
+name: node_generated_sentiment
+contract_version: {major: 1, minor: 0, patch: 0}
+node_type: COMPUTE_GENERIC
+description: Generated sentiment classifier
+input_model: {name: ModelSentimentInput, module: generated.models}
+output_model: {name: ModelSentimentOutput, module: generated.models}
+"""
+
+_HANDLER_SOURCE = "def handle(input_data):\n    return {'label': 'positive'}\n"
+
+
+@pytest.fixture
+def registry() -> ServiceMCPToolRegistry:
+    return ServiceMCPToolRegistry()
+
+
+def _expected_hash(text: str) -> str:
+    return "sha256:" + hashlib.sha256(text.encode()).hexdigest()
+
+
+class TestRegisterGeneratedTool:
+    @pytest.mark.asyncio
+    async def test_register_returns_typed_record_with_artifact_hashes(
+        self, registry: ServiceMCPToolRegistry
+    ) -> None:
+        correlation_id = uuid4()
+        record = await registry.register_generated_tool(
+            node_name="node_generated_sentiment",
+            description="Generated sentiment classifier",
+            contract_yaml=_CONTRACT_YAML,
+            handler_source=_HANDLER_SOURCE,
+            correlation_id=correlation_id,
+        )
+
+        assert isinstance(record, ModelMCPGeneratedToolRegistration)
+        assert record.name == "node_generated_sentiment"
+        assert record.description == "Generated sentiment classifier"
+        assert record.generated_contract_hash == _expected_hash(_CONTRACT_YAML)
+        assert record.generated_handler_hash == _expected_hash(_HANDLER_SOURCE)
+        assert record.generation_correlation_id == correlation_id
+        assert record.registry_event_version  # non-empty version key
+
+    @pytest.mark.asyncio
+    async def test_generated_tool_appears_in_canonical_registry(
+        self, registry: ServiceMCPToolRegistry
+    ) -> None:
+        await registry.register_generated_tool(
+            node_name="node_generated_sentiment",
+            description="Generated sentiment classifier",
+            contract_yaml=_CONTRACT_YAML,
+            handler_source=_HANDLER_SOURCE,
+            correlation_id=uuid4(),
+        )
+
+        assert registry.tool_count == 1
+        assert await registry.has_tool("node_generated_sentiment") is True
+
+        tool = await registry.get_tool("node_generated_sentiment")
+        assert tool is not None
+        assert tool.name == "node_generated_sentiment"
+        assert tool.description == "Generated sentiment classifier"
+
+        tools = await registry.list_tools()
+        assert [t.name for t in tools] == ["node_generated_sentiment"]
+
+    @pytest.mark.asyncio
+    async def test_registered_tool_passes_canonical_mcp_exposure_rule(
+        self, registry: ServiceMCPToolRegistry
+    ) -> None:
+        """The stored tool's tags must satisfy ServiceMCPToolSync._is_mcp_exposable.
+
+        This is what proves the registration rides the *canonical* exposure path:
+        a generated compute tool is only surfaced if it carries
+        mcp-enabled + node-type:compute + generated.
+        """
+        await registry.register_generated_tool(
+            node_name="node_generated_sentiment",
+            description="Generated sentiment classifier",
+            contract_yaml=_CONTRACT_YAML,
+            handler_source=_HANDLER_SOURCE,
+            correlation_id=uuid4(),
+        )
+
+        tool = await registry.get_tool("node_generated_sentiment")
+        assert tool is not None
+
+        tags = tool.metadata["tags"]
+        assert isinstance(tags, list)
+
+        class _StubBus:
+            environment = "test"
+
+        sync = ServiceMCPToolSync(registry=registry, bus=_StubBus())  # type: ignore[arg-type]
+        assert sync._is_mcp_exposable([str(t) for t in tags]) is True
+        assert ServiceMCPToolSync.TAG_MCP_ENABLED in tags
+        assert ServiceMCPToolSync.TAG_NODE_TYPE_COMPUTE in tags
+        assert ServiceMCPToolSync.TAG_GENERATED in tags
+        assert (
+            f"{ServiceMCPToolSync.TAG_PREFIX_MCP_TOOL}node_generated_sentiment" in tags
+        )
+
+    @pytest.mark.asyncio
+    async def test_reregister_same_artifact_is_idempotent(
+        self, registry: ServiceMCPToolRegistry
+    ) -> None:
+        first = await registry.register_generated_tool(
+            node_name="node_generated_sentiment",
+            description="Generated sentiment classifier",
+            contract_yaml=_CONTRACT_YAML,
+            handler_source=_HANDLER_SOURCE,
+            correlation_id=uuid4(),
+        )
+        second = await registry.register_generated_tool(
+            node_name="node_generated_sentiment",
+            description="Generated sentiment classifier",
+            contract_yaml=_CONTRACT_YAML,
+            handler_source=_HANDLER_SOURCE,
+            correlation_id=uuid4(),
+        )
+
+        # Same artifact (same content hashes) -> same registry version key,
+        # one tool, no duplicate entries.
+        assert registry.tool_count == 1
+        assert first.registry_event_version == second.registry_event_version
+
+    @pytest.mark.asyncio
+    async def test_new_artifact_version_updates_registry(
+        self, registry: ServiceMCPToolRegistry
+    ) -> None:
+        await registry.register_generated_tool(
+            node_name="node_generated_sentiment",
+            description="v1",
+            contract_yaml=_CONTRACT_YAML,
+            handler_source=_HANDLER_SOURCE,
+            correlation_id=uuid4(),
+        )
+
+        new_handler = _HANDLER_SOURCE + "# revised\n"
+        record = await registry.register_generated_tool(
+            node_name="node_generated_sentiment",
+            description="v2",
+            contract_yaml=_CONTRACT_YAML,
+            handler_source=new_handler,
+            correlation_id=uuid4(),
+        )
+
+        assert registry.tool_count == 1
+        tool = await registry.get_tool("node_generated_sentiment")
+        assert tool is not None
+        assert tool.description == "v2"
+        assert record.generated_handler_hash == _expected_hash(new_handler)
+
+    @pytest.mark.asyncio
+    async def test_empty_node_name_is_rejected(
+        self, registry: ServiceMCPToolRegistry
+    ) -> None:
+        with pytest.raises(ValueError):
+            await registry.register_generated_tool(
+                node_name="",
+                description="Generated sentiment classifier",
+                contract_yaml=_CONTRACT_YAML,
+                handler_source=_HANDLER_SOURCE,
+                correlation_id=uuid4(),
+            )


### PR DESCRIPTION
## OMN-13612 — WS-C Phase 2.2: Route SEA tool_registry.py registration onto the canonical omnibase_infra MCP registration path

Epic: OMN-13604 (SEA → canonical migration, TRANSFORM→PROVE→DELETE). Plan: `docs/tracking/2026-06-24-sea-canonicalization-plan.md` §Phase 2.2.

### ROUTE-1 gate — PASSED (all 4 sub-gates)
1. **Target exists in source:** canonical MCP registration service `ServiceMCPToolRegistry` (`src/omnibase_infra/services/mcp/service_mcp_tool_registry.py`) + event-driven sync `ServiceMCPToolSync`.
2. **Owner confirmed:** omnibase_infra MCP server (`feedback_mcp_server_in_omnibase_infra.md` — MCP server = protocol infra → omnibase_infra; bespoke registries elsewhere = migration debt).
3. **Runtime path confirmed:** wired via `mcp_server_lifecycle.py` + `handler_mcp.py`; hot-reload via `ServiceMCPToolSync`. Already SEA-aware: OMN-12827 Plan B2 relaxed `_is_mcp_exposable` to surface generated COMPUTE nodes (`mcp-enabled` + `node-type:compute` + `generated`).
4. **Acceptance proof defined:** a generated tool registered through the canonical path is retrievable from `ServiceMCPToolRegistry.get_tool(name)` and satisfies `ServiceMCPToolSync._is_mcp_exposable`.

### What this PR does
Adds `ServiceMCPToolRegistry.register_generated_tool(node_name, description, contract_yaml, handler_source, correlation_id)` — the canonical replacement for the bespoke SEA `ToolRegistry.register` (`onex-self-extending-agent/src/agent/tool_registry.py`). It:
- builds a canonical `ModelMCPToolDefinition` carrying the generated-compute exposure tags the canonical sync path requires (`mcp-enabled` + `node-type:compute` + `generated` + `mcp-tool:<name>`),
- upserts it into the canonical `ServiceMCPToolRegistry` (reusing existing `upsert_tool` plumbing — no parallel/bespoke store),
- derives the registry version key from the artifact content hashes (idempotent re-registration; revised artifact → new version),
- returns a typed, frozen `ModelMCPGeneratedToolRegistration` binding the contract/handler artifact hashes + correlation id + registry version key.

New typed model: `src/omnibase_infra/models/mcp/model_mcp_generated_tool_registration.py` (frozen, `extra="forbid"`, UUID for ids).

### Scope boundary — invoke/exec NOT migrated here (by design)
The SEA `ToolRegistry` conflates two capabilities: (a) **registration** (this PR) and (b) **in-process `exec()`/`invoke()`** of the generated handler (the hot-load sandbox). (b) is the Phase 0 executor concern — **OMN-13605 (Done)** now homes it canonically in omnimarket `handler_generated_executor`. This PR is the registration half only.

### SEA `agent/tool_registry.py` deletion — deferred to Phase 8.1 (OMN-13626), documented honestly
The ticket DoD asks to delete `agent/tool_registry.py` from SEA "after parity, no shim." That deletion is **blocked by Phase 8 ordering** and is **not** done in this PR. Reasons (evidence-based):
- The SEA file is the **demo runtime backbone** consumed by `node_registration_effect`, `node_invocation_effect`, `node_demo_orchestrator`, `agent/tools.py`, `src/__main__.py`, `agent/agent_demo.py`, `dashboard_server.py` + 6 test files. Those `src/nodes/node_*` scaffolds are the explicit deletion scope of **Phase 8.1 (OMN-13626)** ("Prune hackathon-local `src/nodes/node_*` scaffolds after all logic ported"), gated on "ALL prior waves merged and parity-proven."
- Deleting it now (Wave 1; Phases 1, 2.1, 3, 4, 5, 6, 7 still **Backlog**) would break the SEA repo mid-migration — a direct violation of the epic's TRANSFORM→PROVE→DELETE north star ("Bespoke imperative code is deleted ONLY after its capability is wired canonically AND proven") and Phase 8 ordering.
- SEA depends only on `omnibase-core` (not `omnibase-infra`); routing SEA's own register call to import this infra service would add an upstream runtime dep to a public standalone repo, which the plan explicitly forbids. The canonical registration entry point is proven here; SEA's call-site rewire + file deletion belong to Phase 8 decommission.

This PR therefore delivers the canonical registration target + parity proof (the routable half), and the SEA file deletion is carried by OMN-13626. No shim is added in either repo.

### Local verification (no `-k` filter)
- `ruff format` + `ruff check --fix`: clean
- `mypy --strict` (changed source): `Success: no issues found in 2 source files`
- full unit suite (`tests/unit/ -m "not slow and not kafka and not postgres and not consul"`): **20807 passed, 20 skipped** (skips pre-existing: omnimarket-not-installed / external-dep / invalid-state guards)
- `pre-commit run --files <changed>`: all hooks **Passed** (incl. ONEX Pattern Validation)
- targeted TDD suite: 6 passed (written failing first)

### dod_evidence
- `dod-canonical-mcp-registration`: `register_generated_tool` upserts into the canonical `ServiceMCPToolRegistry`; test proves `get_tool`/`has_tool`/`list_tools` return the generated tool and `_is_mcp_exposable` accepts its tags.
- `dod-tdd-red-then-green`: failing test committed conceptually first, then implementation; 6/6 pass.
- `dod-full-suite-green`: 20807 unit tests pass, mypy strict clean, pre-commit clean.
- `dod-sea-delete-deferred`: SEA file deletion routed to Phase 8.1 (OMN-13626) with evidence above — not silently dropped.

Evidence-Source: OCC#3159
Evidence-Ticket: OMN-13612