### PR TITLE
feat(OMN-13321): vendor node_pr_lifecycle_state_reducer ledger migration into infra forward-migration tree

### DIFF
--- a/docker/migrations/forward/nodes/node_pr_lifecycle_state_reducer/0001_create_pr_lifecycle_ledger_entries.sql
+++ b/docker/migrations/forward/nodes/node_pr_lifecycle_state_reducer/0001_create_pr_lifecycle_ledger_entries.sql
@@ -1,0 +1,62 @@
+-- OMN-13321 / Enforcement Map F5 (hardens OMN-12569):
+-- node-owned projection migration for pr_lifecycle_ledger_entries.
+--
+-- WHY THIS EXISTS
+--   node_pr_lifecycle_state_reducer declares projection_api over
+--   pr_lifecycle_ledger_entries (topic
+--   onex.snapshot.projection.pr-lifecycle-ledger.v1). The state reducer UPSERTs
+--   one user-readable ledger row per PR EVERY sweep iteration (not only at sweep
+--   end), so an operator can answer "what does the ledger say right now?".
+--
+--   OMN-12569 landed a provenance-rich, run_id-keyed derived ledger but did not
+--   materialize a clean per-iteration row in practice; F5 hardens that.
+--
+--   Vendored by omnibase_infra/scripts/sync-node-migrations.sh into
+--   docker/migrations/forward/nodes/node_pr_lifecycle_state_reducer/ and applied
+--   to NODE_POSTGRES_DB (omnidash_analytics) by run-forward-migrations.sh under
+--   the namespaced migration id
+--   node:node_pr_lifecycle_state_reducer:<file>.
+--
+-- KEY SHAPE
+--   Conflict key (sweep_id, repo, pr_number, iteration): one row per PR per
+--   iteration. Re-applying the same iteration's event is idempotent (UPSERT);
+--   two consecutive iterations produce two distinct rows.
+--
+--   DoD probe:
+--     select count(*) from pr_lifecycle_ledger_entries where sweep_id='<id>';
+--   returns >= the open-PR count for that sweep.
+--
+-- Idempotency: CREATE TABLE / INDEX guarded by IF NOT EXISTS so the migration is
+-- safe on a DB where the table already exists and on a fresh omnidash_analytics.
+
+-- ============================================================================
+-- PR_LIFECYCLE_LEDGER_ENTRIES TABLE
+-- ============================================================================
+-- One user-readable ledger row per PR per sweep iteration.
+CREATE TABLE IF NOT EXISTS public.pr_lifecycle_ledger_entries (
+    id                BIGSERIAL    PRIMARY KEY,
+    sweep_id          TEXT         NOT NULL,
+    iteration         INTEGER      NOT NULL,
+    found_at          TIMESTAMPTZ  NOT NULL,
+    repo              TEXT         NOT NULL,
+    pr_number         INTEGER      NOT NULL,
+    initial_state     TEXT         NOT NULL,
+    action_taken      TEXT         NOT NULL,
+    evidence          TEXT         NOT NULL DEFAULT '',
+    final_state       TEXT         NOT NULL,
+    next_check_at     TIMESTAMPTZ  NOT NULL,
+    created_at        TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    UNIQUE (sweep_id, repo, pr_number, iteration)
+);
+
+-- Primary DoD query: count rows for a sweep.
+CREATE INDEX IF NOT EXISTS idx_pr_lifecycle_ledger_sweep
+    ON public.pr_lifecycle_ledger_entries (sweep_id);
+
+-- Per-iteration ordering within a sweep.
+CREATE INDEX IF NOT EXISTS idx_pr_lifecycle_ledger_sweep_iter
+    ON public.pr_lifecycle_ledger_entries (sweep_id, iteration);
+
+-- Projection-API read ordering (order_by found_at DESC).
+CREATE INDEX IF NOT EXISTS idx_pr_lifecycle_ledger_found_at
+    ON public.pr_lifecycle_ledger_entries (found_at DESC);

--- a/docker/migrations/forward/nodes/node_pr_lifecycle_state_reducer/0001_create_pr_lifecycle_ledger_entries.sql
+++ b/docker/migrations/forward/nodes/node_pr_lifecycle_state_reducer/0001_create_pr_lifecycle_ledger_entries.sql
@@ -60,3 +60,50 @@ CREATE INDEX IF NOT EXISTS idx_pr_lifecycle_ledger_sweep_iter
 -- Projection-API read ordering (order_by found_at DESC).
 CREATE INDEX IF NOT EXISTS idx_pr_lifecycle_ledger_found_at
     ON public.pr_lifecycle_ledger_entries (found_at DESC);
+
+-- Warm-table reconciliation (OMN-13321 / CodeRabbit Major):
+-- CREATE TABLE IF NOT EXISTS skips the entire body — including the inline
+-- UNIQUE (sweep_id, repo, pr_number, iteration) — when the table already
+-- exists. The reducer UPSERT relies on that conflict target, so on a warm
+-- omnidash_analytics where the table was created without it (e.g. a prior
+-- partial/hand-create), the ON CONFLICT would fail. Add the unique constraint
+-- idempotently so the conflict target is guaranteed regardless of how the
+-- table came to exist. (On a fresh DB the inline UNIQUE already created an
+-- equivalent auto-named constraint; this DO block is a no-op there.)
+DO $$
+DECLARE
+    target_cols  smallint[];
+    has_unique   boolean;
+BEGIN
+    -- Resolve the attnums of the four conflict-key columns (set, sorted).
+    SELECT array_agg(a.attnum ORDER BY a.attnum)
+    INTO   target_cols
+    FROM   pg_attribute a
+    JOIN   pg_class t ON t.oid = a.attrelid
+    JOIN   pg_namespace n ON n.oid = t.relnamespace
+    WHERE  n.nspname = 'public'
+      AND  t.relname = 'pr_lifecycle_ledger_entries'
+      AND  a.attname IN ('sweep_id', 'repo', 'pr_number', 'iteration')
+      AND  NOT a.attisdropped;
+
+    -- Does any UNIQUE constraint already cover exactly those columns
+    -- (order-independent — the inline UNIQUE auto-named constraint counts)?
+    SELECT EXISTS (
+        SELECT 1
+        FROM   pg_constraint c
+        JOIN   pg_class t ON t.oid = c.conrelid
+        JOIN   pg_namespace n ON n.oid = t.relnamespace
+        WHERE  n.nspname = 'public'
+          AND  t.relname = 'pr_lifecycle_ledger_entries'
+          AND  c.contype = 'u'
+          AND  (SELECT array_agg(k ORDER BY k) FROM unnest(c.conkey) AS k) = target_cols
+    )
+    INTO   has_unique;
+
+    IF NOT has_unique THEN
+        ALTER TABLE public.pr_lifecycle_ledger_entries
+            ADD CONSTRAINT uq_pr_lifecycle_ledger_sweep_repo_pr_iter
+            UNIQUE (sweep_id, repo, pr_number, iteration);
+    END IF;
+END
+$$;

--- a/tests/unit/migrations/test_node_migration_discovery.py
+++ b/tests/unit/migrations/test_node_migration_discovery.py
@@ -67,6 +67,11 @@ EVIDENCE_DASHBOARD_CREATE = (
     / "node_evidence_dashboard_reducer"
     / "0001_create_evidence_dashboard_projection_tables.sql"
 )
+PR_LIFECYCLE_LEDGER_CREATE = (
+    NODES_DIR
+    / "node_pr_lifecycle_state_reducer"
+    / "0001_create_pr_lifecycle_ledger_entries.sql"
+)
 
 pytestmark = pytest.mark.unit
 
@@ -295,6 +300,51 @@ class TestVendoredViewMigrations:
         assert (
             "CREATE TABLE IF NOT EXISTS evidence_readiness_aggregate_projection" in sql
         )
+
+    def test_pr_lifecycle_ledger_migration_vendored(self) -> None:
+        """OMN-13321 / F5: the per-iteration PR-ledger projection migration is vendored.
+
+        ``node_pr_lifecycle_state_reducer`` (omnimarket #1440) declares
+        ``projection_api`` over ``pr_lifecycle_ledger_entries`` (topic
+        ``onex.snapshot.projection.pr-lifecycle-ledger.v1``) and UPSERTs one
+        user-readable ledger row per PR EVERY sweep iteration. The node-owned
+        migration that creates ``pr_lifecycle_ledger_entries`` in
+        ``omnidash_analytics`` was merged in the omnimarket source tree but was
+        NEVER vendored into omnibase_infra's tracked forward-migration tree, so
+        the forward-migration runner had no SQL to apply and the table was
+        missing on dev — the OMN-13415 migration-sync guard correctly aborted.
+
+        This guard pins the vendored migration so a clean clone materializes the
+        table under ``run-forward-migrations.sh`` (namespaced id
+        ``node:node_pr_lifecycle_state_reducer:0001_create_pr_lifecycle_ledger_entries.sql``).
+        This is the OMN-13636 migration-gap class made concrete.
+        """
+        assert PR_LIFECYCLE_LEDGER_CREATE.is_file(), (
+            "0001_create_pr_lifecycle_ledger_entries.sql must be vendored under "
+            "docker/migrations/forward/nodes/node_pr_lifecycle_state_reducer/ "
+            "(run scripts/sync-node-migrations.sh)"
+        )
+        sql = PR_LIFECYCLE_LEDGER_CREATE.read_text(encoding="utf-8")
+        # Idempotent create so warm volumes and fresh omnidash_analytics both
+        # reconcile without error.
+        assert "CREATE TABLE IF NOT EXISTS public.pr_lifecycle_ledger_entries" in sql
+        # The conflict key (sweep_id, repo, pr_number, iteration) guarantees one
+        # row per PR per iteration so two consecutive iterations both persist.
+        assert "UNIQUE (sweep_id, repo, pr_number, iteration)" in sql
+        # The ticket-required user-readable ledger fields must all be present.
+        for column in (
+            "sweep_id",
+            "iteration",
+            "found_at",
+            "repo",
+            "pr_number",
+            "initial_state",
+            "action_taken",
+            "evidence",
+            "final_state",
+            "next_check_at",
+        ):
+            assert column in sql, f"ledger column {column!r} missing from migration"
 
 
 class TestNamespacedDiscoveryWiring:

--- a/tests/unit/migrations/test_node_migration_discovery.py
+++ b/tests/unit/migrations/test_node_migration_discovery.py
@@ -330,6 +330,10 @@ class TestVendoredViewMigrations:
         assert "CREATE TABLE IF NOT EXISTS public.pr_lifecycle_ledger_entries" in sql
         # The conflict key (sweep_id, repo, pr_number, iteration) guarantees one
         # row per PR per iteration so two consecutive iterations both persist.
+        # The named constraint is added after CREATE TABLE so warm pre-existing
+        # tables also receive the ON CONFLICT target.
+        assert "uq_pr_lifecycle_ledger_sweep_repo_pr_iter" in sql
+        assert "ADD CONSTRAINT uq_pr_lifecycle_ledger_sweep_repo_pr_iter" in sql
         assert "UNIQUE (sweep_id, repo, pr_number, iteration)" in sql
         # The ticket-required user-readable ledger fields must all be present.
         for column in (


### PR DESCRIPTION
## OMN-13321 (REOPEN) — vendor the missing node migration that the batched redeploy surfaced

This **reopens / completes OMN-13321**. The omnimarket node code merged in omnimarket #1440, but its projection table could not persist on dev: `node_pr_lifecycle_state_reducer` declares `projection_api` over `pr_lifecycle_ledger_entries`, but the node-owned migration that creates the table in `omnidash_analytics` was **never committed into omnibase_infra's tracked forward-migration tree** (`docker/migrations/forward/nodes/node_pr_lifecycle_state_reducer/`). The forward-migration runner therefore had no SQL to apply, the table was missing on dev, and the OMN-13415 migration-sync guard correctly aborted the deploy. This is the **OMN-13636 migration-gap class made concrete**.

## Fix

- Vendored the node migration via `scripts/sync-node-migrations.sh` (the canonical OMN-12559 vendoring path). The vendored file is **byte-identical** to the omnimarket source @ `dev`/#1440 (`cmp` IDENTICAL).
- `run-forward-migrations.sh` applies it under the namespaced id `node:node_pr_lifecycle_state_reducer:0001_create_pr_lifecycle_ledger_entries.sql`, so a clean clone / redeploy materializes `pr_lifecycle_ledger_entries`.
- TDD-first: added `test_pr_lifecycle_ledger_migration_vendored` (failed before the vendor, passes after) pinning the vendored file, the ticket-required ledger fields, and the `UNIQUE(sweep_id,repo,pr_number,iteration)` conflict key.

## dod_evidence

- **TDD red→green:** `test_pr_lifecycle_ledger_migration_vendored` failed (file absent) before vendoring, passes after.
- **Sync guard PASS:** `scripts/sync-node-migrations.sh --check` → `check: in sync` (exit 0). Pre-commit `ONEX Node Migration Vendor Sync Check` → Passed.
- **Real-SQL apply proof (Postgres 14, ephemeral):** migration applies clean; re-apply is idempotent (`IF NOT EXISTS`); table created with all 12 columns, the UNIQUE constraint, and 3 indexes (`idx_pr_lifecycle_ledger_sweep`, `..._sweep_iter`, `..._found_at`).
- **Exact DoD probe (real SQL):** 4 open PRs × 2 consecutive iterations → `select count(*) from pr_lifecycle_ledger_entries where sweep_id='20260626-dodproof'` returns **8**; distinct iterations `{0,1}`, 4 rows each; re-applying iteration 1's UPSERT keeps count at 8 (no overwrite, idempotent).
- **Local verify (no -k):** `tests/unit/migrations/ + tests/ci/test_validate_migration_sequence.py + tests/scripts/test_check_deployed_migration_tree_sync.py` → 79 passed; `mypy --strict` clean on changed test; `ruff format`/`check` clean; `pre-commit run --files <changed>` all green (migration freeze / sequence-duplicate / vendor-sync / writer-migration-coupling all Passed).

**Redeploy is a separate orchestration step** — a forward-migration run (batched redeploy) will apply the now-vendored SQL and create the table on dev. This PR does **not** mutate any runtime lane. No live deploy is performed here.

Evidence-Source: OCC#3165
Evidence-Ticket: OMN-13321

The paired OCC receipt PR #3165 carries the OMN-13321 contract update + the `dod-omnibase-infra-pr-2112` receipt binding this PR; `dod-occ-pr-self` self-binds to OCC #3165. Relates OMN-13636, OMN-13415.

Closes OMN-13321 (vendoring gap).
