### PR TITLE
feat(OMN-13648): vendor migration 078 for delegation savings-series projection

### DIFF
--- a/docker/migrations/forward/nodes/node_projection_savings/078_create_delegation_savings_series_projection_view.sql
+++ b/docker/migrations/forward/nodes/node_projection_savings/078_create_delegation_savings_series_projection_view.sql
@@ -1,0 +1,84 @@
+-- OMN-13648 (G1): time-bucketed savings-over-time series for the delegation
+-- dashboard "savings over time" depth view.
+--
+-- The new omnidash delegation dashboard (OMN-13602) renders a savings-over-time
+-- chart, but no projection exposes a per-bucket series. This view re-derives the
+-- same bus-fed delegation source as projection_delegation_savings (migration
+-- 076) -- the UNION of savings_estimates and delegation_events -- then
+-- aggregates it into ONE row per UTC day across ALL sessions (no LIMIT 500).
+--
+-- The source CTEs (savings_sessions / event_sessions / combined_sessions) are
+-- copied faithfully from migration 076 so this series view stands alone and does
+-- NOT depend on 076's internal CTEs.
+--
+-- Tier-mix columns (local_pct / cheap_pct / prem_pct) are intentionally deferred
+-- to OMN-13649; this view ships only the cost/savings/task_count aggregates.
+
+CREATE OR REPLACE VIEW projection_delegation_savings_series AS
+WITH savings_sessions AS (
+    SELECT
+        session_id,
+        model_local AS task_type,
+        model_local AS model_name,
+        local_cost_usd::float AS local_cost_usd,
+        cloud_cost_usd::float AS cloud_cost_usd,
+        savings_usd::float AS savings_usd,
+        model_cloud_baseline AS baseline_model,
+        'savings-estimated' AS pricing_manifest_version,
+        'measured' AS savings_method,
+        'savings_estimates' AS usage_source,
+        0::int AS prompt_tokens,
+        0::int AS completion_tokens,
+        NULL::int AS tokens_to_compliance,
+        NULL::int AS latency_ms,
+        created_at,
+        NULL::text AS prompt_text,
+        NULL::text AS response_text
+    FROM savings_estimates
+),
+event_sessions AS (
+    SELECT
+        COALESCE(NULLIF(session_id, ''), NULLIF(correlation_id, ''), id::text)
+            AS session_id,
+        COALESCE(task_type, '') AS task_type,
+        COALESCE(NULLIF(model_name, ''), NULLIF(delegated_to, ''), 'local')
+            AS model_name,
+        COALESCE(cost_usd, 0)::float AS local_cost_usd,
+        (COALESCE(cost_usd, 0) + COALESCE(cost_savings_usd, 0))::float
+            AS cloud_cost_usd,
+        COALESCE(cost_savings_usd, 0)::float AS savings_usd,
+        'claude-opus-4.1' AS baseline_model,
+        pricing_manifest_version::text AS pricing_manifest_version,
+        CASE WHEN COALESCE(cost_savings_usd, 0) > 0
+            THEN 'measured' ELSE 'estimated' END AS savings_method,
+        CASE WHEN COALESCE(tokens_input, 0) + COALESCE(tokens_output, 0) > 0
+            THEN 'measured' ELSE 'unknown' END AS usage_source,
+        COALESCE(tokens_input, 0)::int AS prompt_tokens,
+        COALESCE(tokens_output, 0)::int AS completion_tokens,
+        NULLIF(tokens_to_compliance, 0)::int AS tokens_to_compliance,
+        COALESCE(delegation_latency_ms, latency_ms)::int AS latency_ms,
+        COALESCE(created_at, timestamp) AS created_at,
+        prompt_text,
+        response_text
+    FROM delegation_events
+),
+combined_sessions AS (
+    SELECT * FROM savings_sessions
+    UNION ALL
+    SELECT event_sessions.*
+    FROM event_sessions
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM savings_sessions
+        WHERE savings_sessions.session_id = event_sessions.session_id
+    )
+)
+SELECT
+    date_trunc('day', created_at) AS bucket,
+    COALESCE(SUM(local_cost_usd), 0)::float AS actual_cost_usd,
+    COALESCE(SUM(cloud_cost_usd), 0)::float AS baseline_cost_usd,
+    COALESCE(SUM(savings_usd), 0)::float AS savings_usd,
+    COUNT(*)::int AS task_count
+FROM combined_sessions
+GROUP BY 1
+ORDER BY 1;


### PR DESCRIPTION
## OMN-13648 (G1) — Vendor migration 078 for delegation savings-series projection

### Problem
omnimarket node-owned projection migrations ship under
`src/omnimarket/nodes/<node>/migrations/*.sql`, but the omnibase_infra
forward-migration runner only reads `docker/migrations/forward/`. A node
migration that is not vendored here means its projection table/view is **missing
after a clean redeploy** (node-migration-sync golden-chain finding).

### Change
Vendor the new omnimarket migration **078**
(`078_create_delegation_savings_series_projection_view.sql`) into
`docker/migrations/forward/nodes/node_projection_savings/`, **byte-identical** to
the omnimarket source. The forward-migration runner applies it under the
namespaced id `node:node_projection_savings:078_...` so a clean redeploy
materializes the `projection_delegation_savings_series` view in the projection DB
(`omnidash_analytics`).

This is the standard `scripts/sync-node-migrations.sh` vendoring path — the
diff is exactly what that script produces against the omnimarket branch that
adds migration 078.

### Architecture
Feeds the new omnidash delegation dashboard "savings over time" depth view
(**OMN-13602**). The view re-derives the same bus-fed
`savings_estimates` UNION `delegation_events` source as
`projection_delegation_savings` and aggregates into one row per UTC day. No new
REST route, no client-side computation.

### dod_evidence
- `OMNIMARKET_SRC=<omnimarket@OMN-13648 worktree> bash scripts/sync-node-migrations.sh --check` → **`check: in sync.`** (exit 0). The vendored tree matches the omnimarket source that ships migration 078.
- `diff <vendored 078> <omnimarket source 078>` → **identical**.
- `uv run pytest tests/ -q -k "migration"` → **364 passed, 4 skipped**, 1 fail = `TestVendoredTreeMatchesSource::test_sync_check_reports_in_sync`, which resolves omnimarket from the canonical clone (`$OMNI_HOME/omnimarket`, still on dev WITHOUT 078). With `OMNIMARKET_SRC` pointed at the co-changing omnimarket branch the check is **in sync** (see above). This is the expected cross-repo ordering: the omnimarket source PR (#1457) merges to `dev` first, then the `node-migration-sync` gate here goes green against the dev tip. `node-migration-sync` is NOT a required status check on `dev`.
- `pre-commit run` on the changed file → all hooks **Passed** (the `onex-check-node-migration-sync` hook validated against the co-changing omnimarket source via `OMNIMARKET_SRC`).

### Deploy
No live deploy in this PR. The view is materialized on the next clean redeploy.
The LIVE dev-lane DoD proof (`psql` on `omnidash_analytics` +
`GET /projection/onex.snapshot.projection.delegation.savings-series.v1`) is the
post-deploy final DoD step, NOT done in this PR.

### Paired PR
omnimarket **#1457** adds the source migration 078 + the projection_api exposure.
That PR must merge to `dev` first so the `node-migration-sync` gate here compares
against an omnimarket dev tip that contains 078.

---

Evidence-Ticket: OMN-13648

Evidence-Source: OCC#3191
