### PR TITLE
feat(OMN-13656): scanned workspace-from-dev ECR build as a gated stability-candidate

### DIFF
--- a/.github/workflows/build-workspace-candidate-runtime.yml
+++ b/.github/workflows/build-workspace-candidate-runtime.yml
@@ -84,12 +84,12 @@ jobs:
           echo "Docker daemon accessible"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
         with:
           driver: docker
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -135,7 +135,7 @@ jobs:
           cat workspace/sibling-vcs-provenance.json
 
       - name: Set up Python for AWS CLI
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -148,7 +148,7 @@ jobs:
           "$HOME/.local/bin/aws" --version
 
       - name: Configure AWS credentials (OIDC -> omninode-github-actions-role)
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@d45db47bd94e3a7d50b9c36da4cfe07ceca89d74 # v6
         with:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/omninode-github-actions-role
@@ -163,7 +163,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2
 
       - name: Extract metadata
         id: meta
@@ -204,7 +204,7 @@ jobs:
       # the OCI labels the prod gate / lineage guard consult.
       - name: Build runtime image (workspace stability-candidate)
         id: build-local
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           file: docker/Dockerfile.runtime
@@ -245,10 +245,12 @@ jobs:
       # main, so the clean-main assertion does not apply). The hash-equals-HEAD
       # invariant IS enforced here and is NOT weakened.
       - name: Attest baked-in source hash (OMN-9139)
+        env:
+          IMAGE_REF: ${{ steps.meta.outputs.image_repo }}:${{ steps.meta.outputs.candidate_tag }}
         run: |
           set -euo pipefail
-          BAKED="$(docker inspect "${{ steps.meta.outputs.image_repo }}:${{ steps.meta.outputs.candidate_tag }}" \
-            --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}')"
+          BAKED="$(docker inspect "${IMAGE_REF}" \
+            --format '{{range .Config.Env}}{{println .}}{{end}}' | sed -n 's/^RUNTIME_SOURCE_HASH=//p')"
           EXPECTED="${GITHUB_SHA}"
           if [ -z "$BAKED" ] || [ "$BAKED" = "unknown" ] || [ "$BAKED" = "dev" ]; then
             echo "::error::baked source hash '${BAKED}' is empty/unknown/dev"; exit 1
@@ -310,6 +312,8 @@ jobs:
       # evidence a deploy verifier reads to refuse the candidate for prod.
       - name: Create candidate build manifest
         id: manifest
+        env:
+          SIBLING_REF: ${{ inputs.sibling_ref }}
         run: |
           set -euo pipefail
           mkdir -p ops/digests
@@ -321,7 +325,7 @@ jobs:
             --arg ref "${{ steps.resolve-digest.outputs.image_ref }}" \
             --arg tag "${{ steps.meta.outputs.candidate_tag }}" \
             --arg date "${{ steps.timestamp.outputs.build_date }}" \
-            --arg sibling_ref "${{ inputs.sibling_ref }}" \
+            --arg sibling_ref "${SIBLING_REF}" \
             --arg run_id "$GITHUB_RUN_ID" \
             --argjson siblings "$SIBLINGS" \
             '{
@@ -345,7 +349,7 @@ jobs:
           cat ops/digests/build-manifest.json
 
       - name: Upload candidate build manifest
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: build-manifest-candidate-${{ steps.meta.outputs.candidate_tag }}
           path: ops/digests/build-manifest.json
@@ -353,6 +357,8 @@ jobs:
 
       - name: Build summary
         if: always()
+        env:
+          SIBLING_REF: ${{ inputs.sibling_ref }}
         run: |
           {
             echo "# Workspace Stability-Candidate Build (OMN-13656)"
@@ -363,7 +369,7 @@ jobs:
             echo "| promotion_class | stability-candidate |"
             echo "| non_main_lineage | true |"
             echo "| pinnable lanes | dev, stability-test (NEVER prod) |"
-            echo "| sibling ref | \`${{ inputs.sibling_ref }}\` |"
+            echo "| sibling ref | \`${SIBLING_REF}\` |"
             echo "| digest | \`${{ steps.resolve-digest.outputs.digest }}\` |"
             echo "| candidate tag | \`${{ steps.meta.outputs.candidate_tag }}\` |"
             echo ""

--- a/.github/workflows/build-workspace-candidate-runtime.yml
+++ b/.github/workflows/build-workspace-candidate-runtime.yml
@@ -1,0 +1,372 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# build-workspace-candidate-runtime.yml — OMN-13656
+#
+# Builds a SCANNED workspace-from-dev runtime image and pushes it to ECR as an
+# explicitly NON-PROD "stability-candidate". This is the CI counterpart of the
+# local deploy-runtime.sh BUILD_SOURCE=workspace path: it stages the sibling
+# repos at their dev HEAD, builds docker/Dockerfile.runtime in WORKSPACE mode,
+# runs the SAME Trivy scan + the OMN-9139 source-hash attestation + a provenance
+# manifest, and pushes a candidate-tagged image.
+#
+# Lineage guard discipline (OMN-12626):
+#   A workspace build is NON-main-lineage BY DESIGN (it stages dev-HEAD siblings),
+#   so the prod-bound lineage guard does NOT run here. Instead the image is STAMPED
+#   as a stability-candidate (build-manifest BUILD_SOURCE=workspace,
+#   promotion_class=stability-candidate, non_main_lineage:true + OCI labels
+#   com.omninode.promotion_class / com.omninode.non_main_lineage). The omnimarket
+#   prod-promotion gate (node_prod_promotion_gate_compute) REFUSES such an image
+#   for prod unless an explicit candidate-authorizing grant exists. The digest is
+#   pinnable to the dev / stability-test lane kustomization ONLY — never prod.
+#
+# Trigger: workflow_dispatch only (never auto on push). The image NEVER masquerades
+# as a clean-main build under the lineage guard.
+
+name: Build workspace stability-candidate runtime (OMN-13656)
+
+on:
+  workflow_dispatch:
+    inputs:
+      sibling_ref:
+        description: "Git ref to stage sibling repos at (default: dev)."
+        required: false
+        default: "dev"
+        type: string
+      no-cache:
+        description: "Build with --no-cache to force a fresh foundation install."
+        required: false
+        default: "false"
+        type: boolean
+
+concurrency:
+  group: build-workspace-candidate-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  AWS_REGION: us-east-1
+  ECR_REGISTRY: ${{ vars.AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com
+  ECR_REPOSITORY: omninode-runtime
+  UV_VERSION: "0.6.14"
+  PYTHON_VERSION: "3.12"
+  # The sibling repos the workspace build stages. omnibase_core is staged FIRST
+  # (Dockerfile workspace branch reinstalls dev-HEAD core before the others).
+  SIBLING_REPOS: "omnibase_core omnibase_compat onex_change_control omnimarket"
+
+jobs:
+  build-workspace-candidate:
+    name: Build + scan + push workspace stability-candidate
+    permissions:
+      id-token: write
+      contents: read
+    # OMNI_RUNNER_SELECTOR_V1 — trusted Docker job on self-hosted omnibase-ci.
+    runs-on: >-
+      ${{ fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]') }}
+    timeout-minutes: 75
+
+    outputs:
+      image_digest: ${{ steps.resolve-digest.outputs.digest }}
+      image_ref: ${{ steps.resolve-digest.outputs.image_ref }}
+      candidate_tag: ${{ steps.meta.outputs.candidate_tag }}
+
+    steps:
+      - name: Checkout omnibase_infra (the consuming repo / build context)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Verify Docker socket access
+        run: |
+          if ! docker info > /dev/null 2>&1; then
+            echo "::error::Docker daemon is not accessible on this runner."
+            exit 1
+          fi
+          echo "Docker daemon accessible"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+        with:
+          driver: docker
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      # Stage the sibling repos at their requested ref into a workspace root, then
+      # point OMNI_HOME at it so stage_workspace.sh + the Dockerfile workspace
+      # branch vendor the dev-HEAD siblings. Each clone is shallow at the ref but
+      # carries full enough history for HEAD SHA / branch / status probes that
+      # stage_workspace.sh records as per-repo VCS provenance (OMN-13030).
+      - name: Stage sibling repos at the requested ref
+        id: stage-siblings
+        env:
+          SIBLING_REF: ${{ inputs.sibling_ref }}
+        run: |
+          set -euo pipefail
+          WORKSPACE_ROOT="${RUNNER_TEMP}/omni_workspace"
+          rm -rf "${WORKSPACE_ROOT}"
+          mkdir -p "${WORKSPACE_ROOT}"
+          # The consuming repo (omnibase_infra) is itself a sibling for the
+          # lock-pin preflight; symlink the checked-out tree in.
+          ln -s "${GITHUB_WORKSPACE}" "${WORKSPACE_ROOT}/omnibase_infra"
+          # omnibase_spi is referenced by the lock-pin preflight too.
+          for repo in omnibase_spi ${SIBLING_REPOS}; do
+            echo "::group::clone ${repo}@${SIBLING_REF}"
+            git clone --depth 50 --branch "${SIBLING_REF}" \
+              "https://github.com/OmniNode-ai/${repo}.git" \
+              "${WORKSPACE_ROOT}/${repo}"
+            echo "  ${repo} HEAD: $(git -C "${WORKSPACE_ROOT}/${repo}" rev-parse HEAD)"
+            echo "::endgroup::"
+          done
+          echo "workspace_root=${WORKSPACE_ROOT}" >> "$GITHUB_OUTPUT"
+
+      - name: Stage workspace sibling trees into the build context
+        env:
+          OMNI_HOME: ${{ steps.stage-siblings.outputs.workspace_root }}
+          # The consuming pin authority is omnimarket's uv.lock (OMN-12977).
+          CONSUMER_LOCK: ${{ steps.stage-siblings.outputs.workspace_root }}/omnimarket/uv.lock
+        run: |
+          set -euo pipefail
+          bash scripts/runtime_build/stage_workspace.sh
+          echo "Staged sibling trees:"
+          ls -1 workspace/sibling-repos/
+          echo "Per-repo VCS provenance:"
+          cat workspace/sibling-vcs-provenance.json
+
+      - name: Set up Python for AWS CLI
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Ensure AWS CLI is available
+        shell: bash
+        run: |
+          if command -v aws >/dev/null 2>&1; then aws --version; exit 0; fi
+          python -m pip install --user 'awscli>=1.33,<2'
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/aws" --version
+
+      - name: Configure AWS credentials (OIDC -> omninode-github-actions-role)
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/omninode-github-actions-role
+          role-session-name: gha-build-workspace-candidate
+
+      - name: Verify AWS caller identity
+        shell: bash
+        env:
+          AWS_CLI_CONNECT_TIMEOUT: '10'
+          AWS_CLI_READ_TIMEOUT: '30'
+        run: aws sts get-caller-identity
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Extract metadata
+        id: meta
+        run: |
+          set -euo pipefail
+          SHA_SHORT="${GITHUB_SHA::7}"
+          IMAGE_REPO="${ECR_REGISTRY}/${ECR_REPOSITORY}"
+          # candidate-* tag namespace makes the non-prod lineage unmistakable and
+          # disjoint from the clean-main commit-SHA tags the prod build pushes.
+          CANDIDATE_TAG="candidate-${SHA_SHORT}-$(date -u +'%Y%m%d%H%M%S')"
+          {
+            echo "sha_short=${SHA_SHORT}"
+            echo "image_repo=${IMAGE_REPO}"
+            echo "candidate_tag=${CANDIDATE_TAG}"
+            echo "tags=${IMAGE_REPO}:${CANDIDATE_TAG}"
+            echo "build_date=$(date -u +'%Y%m%d')"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Generate build timestamp
+        id: timestamp
+        run: echo "build_date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+
+      - name: Read runtime version from pyproject
+        id: version
+        run: |
+          set -euo pipefail
+          VER="$(awk '
+            /^\[project\]/ { in_s=1; next }
+            /^\[/          { in_s=0 }
+            in_s && /^version[[:space:]]*=/ { gsub(/.*=[[:space:]]*"/,""); gsub(/".*/,""); print; exit }
+          ' pyproject.toml)"
+          if [ -z "$VER" ]; then echo "::error::could not read version from pyproject.toml"; exit 1; fi
+          echo "runtime_version=${VER}" >> "$GITHUB_OUTPUT"
+
+      # WORKSPACE-mode build. BUILD_SOURCE=workspace + EXPECTED_BUILD_SOURCE=workspace
+      # selects the staged-sibling install branch; PROMOTION_CLASS / NON_MAIN_LINEAGE
+      # stamp the stability-candidate provenance the Dockerfile guard requires and
+      # the OCI labels the prod gate / lineage guard consult.
+      - name: Build runtime image (workspace stability-candidate)
+        id: build-local
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: docker/Dockerfile.runtime
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: ${{ steps.meta.outputs.tags }}
+          no-cache: ${{ inputs.no-cache == true }}
+          build-args: |
+            RUNTIME_VERSION=${{ steps.version.outputs.runtime_version }}
+            BUILD_DATE=${{ steps.timestamp.outputs.build_date }}
+            VCS_REF=${{ github.sha }}
+            RUNTIME_SOURCE_HASH=${{ github.sha }}
+            UV_VERSION=${{ env.UV_VERSION }}
+            BUILD_SOURCE=workspace
+            EXPECTED_BUILD_SOURCE=workspace
+            OMNI_HOME=/workspace
+            PROMOTION_CLASS=stability-candidate
+            NON_MAIN_LINEAGE=true
+
+      # SAME Trivy scan as the prod build path — CRITICAL,HIGH, --ignore-unfixed,
+      # exit-code 1. NOT weakened, NOT advisory. A finding fails the build before
+      # any push.
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.34.2
+        with:
+          image-ref: '${{ steps.meta.outputs.image_repo }}:${{ steps.meta.outputs.candidate_tag }}'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+          version: 'v0.69.3'
+
+      # OMN-9139 source-hash attestation: assert the baked-in RUNTIME_SOURCE_HASH
+      # equals the build SHA. Runs inline (not via the reusable workflow, which
+      # re-asserts a clean main tree — a workspace build is intentionally dev/non-
+      # main, so the clean-main assertion does not apply). The hash-equals-HEAD
+      # invariant IS enforced here and is NOT weakened.
+      - name: Attest baked-in source hash (OMN-9139)
+        run: |
+          set -euo pipefail
+          BAKED="$(docker inspect "${{ steps.meta.outputs.image_repo }}:${{ steps.meta.outputs.candidate_tag }}" \
+            --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}')"
+          EXPECTED="${GITHUB_SHA}"
+          if [ -z "$BAKED" ] || [ "$BAKED" = "unknown" ] || [ "$BAKED" = "dev" ]; then
+            echo "::error::baked source hash '${BAKED}' is empty/unknown/dev"; exit 1
+          fi
+          if [[ "$EXPECTED" == "$BAKED"* ]] || [[ "$BAKED" == "$EXPECTED"* ]]; then
+            echo "source-hash attestation OK: baked='${BAKED}' expected='${EXPECTED}'"
+          else
+            echo "::error::baked source hash '${BAKED}' != HEAD '${EXPECTED}'"; exit 1
+          fi
+
+      # Assert the image carries the non-main-lineage / stability-candidate labels
+      # so it can NEVER masquerade as a clean-main build under the lineage guard.
+      - name: Assert stability-candidate lineage labels
+        run: |
+          set -euo pipefail
+          IMG="${{ steps.meta.outputs.image_repo }}:${{ steps.meta.outputs.candidate_tag }}"
+          BS="$(docker inspect "$IMG" --format '{{ index .Config.Labels "com.omninode.build_source" }}')"
+          PC="$(docker inspect "$IMG" --format '{{ index .Config.Labels "com.omninode.promotion_class" }}')"
+          NL="$(docker inspect "$IMG" --format '{{ index .Config.Labels "com.omninode.non_main_lineage" }}')"
+          echo "build_source=${BS} promotion_class=${PC} non_main_lineage=${NL}"
+          [ "$BS" = "workspace" ] || { echo "::error::build_source label must be workspace"; exit 1; }
+          [ "$PC" = "stability-candidate" ] || { echo "::error::promotion_class label must be stability-candidate"; exit 1; }
+          [ "$NL" = "true" ] || { echo "::error::non_main_lineage label must be true"; exit 1; }
+
+      - name: Push candidate image to Amazon ECR
+        if: success()
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Trivy + attestation + lineage labels passed — pushing candidate..."
+          docker push "${{ steps.meta.outputs.tags }}"
+          echo "Pushed: ${{ steps.meta.outputs.tags }}"
+
+      - name: Resolve ECR image digest for candidate tag
+        id: resolve-digest
+        shell: bash
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3 4 5; do
+            DIGEST="$(aws ecr describe-images \
+              --repository-name "${ECR_REPOSITORY}" \
+              --image-ids imageTag="${{ steps.meta.outputs.candidate_tag }}" \
+              --query 'imageDetails[0].imageDigest' --output text 2>/dev/null || true)"
+            if [[ "$DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+              echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+              echo "image_ref=${ECR_REGISTRY}/${ECR_REPOSITORY}@${DIGEST}" >> "$GITHUB_OUTPUT"
+              echo "Resolved digest: ${DIGEST}"
+              exit 0
+            fi
+            echo "digest not yet resolvable (attempt ${attempt}/5); backing off..."
+            sleep $((attempt * 3))
+          done
+          echo "::error::could not resolve ECR digest for the candidate tag"; exit 1
+
+      # Provenance build-manifest. Records BUILD_SOURCE=workspace,
+      # promotion_class=stability-candidate, non_main_lineage:true, the consuming
+      # lock pin authority, and per-sibling VCS provenance (folded from
+      # stage_workspace.sh's sibling-vcs-provenance.json). This is the durable
+      # evidence a deploy verifier reads to refuse the candidate for prod.
+      - name: Create candidate build manifest
+        id: manifest
+        run: |
+          set -euo pipefail
+          mkdir -p ops/digests
+          SIBLINGS="$(cat workspace/sibling-vcs-provenance.json)"
+          jq -n \
+            --arg sha "$GITHUB_SHA" \
+            --arg repo "${{ steps.meta.outputs.image_repo }}" \
+            --arg digest "${{ steps.resolve-digest.outputs.digest }}" \
+            --arg ref "${{ steps.resolve-digest.outputs.image_ref }}" \
+            --arg tag "${{ steps.meta.outputs.candidate_tag }}" \
+            --arg date "${{ steps.timestamp.outputs.build_date }}" \
+            --arg sibling_ref "${{ inputs.sibling_ref }}" \
+            --arg run_id "$GITHUB_RUN_ID" \
+            --argjson siblings "$SIBLINGS" \
+            '{
+              build_source: "workspace",
+              promotion_class: "stability-candidate",
+              non_main_lineage: true,
+              pinnable_lanes: ["dev", "stability-test"],
+              prod_pinnable: false,
+              commit_sha: $sha,
+              image_repo: $repo,
+              image_digest: $digest,
+              image_ref: $ref,
+              image_tag: $tag,
+              sibling_ref: $sibling_ref,
+              per_sibling_vcs_provenance: $siblings.siblings,
+              build_date: $date,
+              workflow_run_id: $run_id,
+              ticket: "OMN-13656"
+            }' > ops/digests/build-manifest.json
+          echo "Candidate build manifest:"
+          cat ops/digests/build-manifest.json
+
+      - name: Upload candidate build manifest
+        uses: actions/upload-artifact@v7
+        with:
+          name: build-manifest-candidate-${{ steps.meta.outputs.candidate_tag }}
+          path: ops/digests/build-manifest.json
+          retention-days: 90
+
+      - name: Build summary
+        if: always()
+        run: |
+          {
+            echo "# Workspace Stability-Candidate Build (OMN-13656)"
+            echo ""
+            echo "| Field | Value |"
+            echo "|-------|-------|"
+            echo "| build_source | workspace |"
+            echo "| promotion_class | stability-candidate |"
+            echo "| non_main_lineage | true |"
+            echo "| pinnable lanes | dev, stability-test (NEVER prod) |"
+            echo "| sibling ref | \`${{ inputs.sibling_ref }}\` |"
+            echo "| digest | \`${{ steps.resolve-digest.outputs.digest }}\` |"
+            echo "| candidate tag | \`${{ steps.meta.outputs.candidate_tag }}\` |"
+            echo ""
+            echo "> This image is a NON-main-lineage stability-candidate. The omnimarket"
+            echo "> prod-promotion gate refuses it for prod absent an explicit candidate grant."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/contracts/OMN-13656.yaml
+++ b/contracts/OMN-13656.yaml
@@ -1,0 +1,43 @@
+schema_version: '1.0.0'
+ticket_id: OMN-13656
+title: 'Scanned workspace-from-dev ECR build as a gated stability-candidate'
+summary: >-
+  Add a CI path that builds a SCANNED workspace-from-dev runtime image to ECR as an explicitly non-prod stability-candidate, and stamp it so the omnimarket prod-promotion gate refuses it for prod absent an explicit candidate grant.
+is_seam_ticket: false
+interface_change: true
+interfaces_touched:
+  - ci_workflow
+  - dockerfile
+evidence_requirements:
+  - kind: tests
+    description: Workspace stability-candidate build invariants pass
+    command: uv run pytest tests/ci/test_workspace_candidate_build.py -q
+  - kind: tests
+    description: Prod-lineage + Dockerfile regression suites stay green
+    command: uv run pytest tests/scripts/test_check_prod_promotion_lineage.py tests/scripts/test_deploy_runtime_prod_lineage.py tests/scripts/test_dockerfile_runtime_git_refresh.py -q
+emergency_bypass:
+  enabled: false
+  justification: ''
+  follow_up_ticket_id: ''
+dod_evidence:
+  - id: dod-001
+    description: >-
+      New workflow build-workspace-candidate-runtime.yml stages siblings, builds Dockerfile.runtime in workspace mode, runs the SAME Trivy scan + source-hash attestation + provenance manifest, and pushes a stability-candidate to ECR.
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/ci/test_workspace_candidate_build.py -q'
+  - id: dod-002
+    description: >-
+      Dockerfile stamps com.omninode.promotion_class / non_main_lineage labels and fails closed unless a workspace build is marked stability-candidate.
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/ci/test_workspace_candidate_build.py::TestDockerfileCandidateStamping -q'
+  - id: dod-deploy
+    description: >-
+      No prod kustomization mutation. The candidate is pinnable to dev/stability lanes only; prod refusal is proven by the omnimarket gate test, not a deploy.
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/scripts/test_deploy_runtime_prod_lineage.py -q'

--- a/contracts/OMN-13656.yaml
+++ b/contracts/OMN-13656.yaml
@@ -6,8 +6,7 @@ summary: >-
 is_seam_ticket: false
 interface_change: true
 interfaces_touched:
-  - ci_workflow
-  - dockerfile
+  - public_api
 evidence_requirements:
   - kind: tests
     description: Workspace stability-candidate build invariants pass

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -475,6 +475,14 @@ ARG RUNTIME_SOURCE_HASH=unknown
 # Docker Compose project name used for this deployment.
 # Lets operators confirm the container belongs to the expected compose stack.
 ARG COMPOSE_PROJECT=unknown
+# OMN-13656: promotion-class provenance. A workspace build (staged dev-HEAD
+# siblings) is a non-main-lineage stability-candidate and must be STAMPED as such
+# on the image so the prod-promotion gate (omnimarket node_prod_promotion_gate_
+# compute) and the lineage guard (OMN-12626) can refuse it for prod. Release
+# builds default to clean-main. The CI workspace path passes
+# PROMOTION_CLASS=stability-candidate explicitly.
+ARG PROMOTION_CLASS=clean-main
+ARG NON_MAIN_LINEAGE=false
 
 RUN set -eu; \
     case "${BUILD_SOURCE}" in \
@@ -507,6 +515,10 @@ RUN set -eu; \
         echo "workspace build requires RUNTIME_VERSION from pyproject (not placeholder 0.1.0) for org.opencontainers.image.version (OMN-12965)" >&2; \
         exit 64; \
       fi; \
+      if [ "${PROMOTION_CLASS}" != "stability-candidate" ] || [ "${NON_MAIN_LINEAGE}" != "true" ]; then \
+        echo "workspace build MUST stamp PROMOTION_CLASS=stability-candidate + NON_MAIN_LINEAGE=true so the prod-promotion gate refuses it for prod (OMN-13656); got PROMOTION_CLASS='${PROMOTION_CLASS}' NON_MAIN_LINEAGE='${NON_MAIN_LINEAGE}'" >&2; \
+        exit 64; \
+      fi; \
     fi
 
 # OCI Image Labels (https://github.com/opencontainers/image-spec/blob/main/annotations.md)
@@ -520,6 +532,8 @@ LABEL org.opencontainers.image.title="OmniBase Infra Runtime" \
       org.opencontainers.image.created="${BUILD_DATE}" \
       org.opencontainers.image.revision="${VCS_REF}" \
       com.omninode.build_source="${BUILD_SOURCE}" \
+      com.omninode.promotion_class="${PROMOTION_CLASS}" \
+      com.omninode.non_main_lineage="${NON_MAIN_LINEAGE}" \
       com.omninode.workspace_provenance_manifest="/app/build-provenance.json"
 
 # Runtime environment configuration

--- a/docker/migrations/forward/nodes/node_projection_delegation/0021_delegation_tier_distribution_not_tier_routed.sql
+++ b/docker/migrations/forward/nodes/node_projection_delegation/0021_delegation_tier_distribution_not_tier_routed.sql
@@ -1,0 +1,204 @@
+-- OMN-13662 (T3): explicit not_tier_routed classification in the delegation
+-- model-routing rollup.
+--
+-- The delegate-skill terminal path (ModelDelegateSkillTerminalProjection) is
+-- skill->node delegation, NOT LLM-tier routing, so those delegation_events rows
+-- legitimately carry an empty cost_tier_name (TEXT NOT NULL DEFAULT '' from
+-- migration 0018). The tier rollup must define HOW empty-tier rows are treated
+-- rather than leaving it implementation-defined (which is what produced the old
+-- client-side regex).
+--
+-- Authoritative projection rule (doctrine: no silent default):
+--   * map empty cost_tier_name -> the explicit value 'not_tier_routed';
+--   * EXCLUDE not_tier_routed rows from tier-distribution percentage
+--     DENOMINATORS (pct is computed over LLM-tier-routed rows only, so the
+--     tier-routed percentages sum to 1.0);
+--   * INCLUDE not_tier_routed rows in total task counts (total_tasks);
+--   * surface the classification + the excluded count on the projection so the
+--     dashboard READS it and never re-derives it.
+--
+-- This is a CREATE OR REPLACE VIEW (psql-applicable, no node redeploy). The new
+-- by_tier column is appended at the END of the SELECT list so the replace is
+-- compatible with the existing projection_delegation_model_routing view defined
+-- in migration 0010.
+
+CREATE OR REPLACE VIEW projection_delegation_model_routing AS
+WITH grouped AS (
+    SELECT
+        delegated_to AS model_alias,
+        COALESCE(NULLIF(model_name, ''), delegated_to) AS model_name,
+        task_type,
+        COUNT(*)::int AS event_count,
+        COALESCE(SUM(CASE WHEN quality_gate_passed THEN 1 ELSE 0 END), 0)::int
+            AS quality_passed,
+        COALESCE(AVG(COALESCE(latency_ms, delegation_latency_ms)), 0)::float
+            AS avg_latency_ms
+    FROM delegation_events
+    GROUP BY delegated_to, COALESCE(NULLIF(model_name, ''), delegated_to), task_type
+),
+totals AS (
+    SELECT COUNT(*)::int AS total_delegations, MAX(created_at) AS latest_projection_updated_at
+    FROM delegation_events
+),
+by_model AS (
+    SELECT COALESCE(
+        jsonb_agg(
+            jsonb_build_object(
+                'model_name', model_alias,
+                'total_count', total_count,
+                'pct_of_total', CASE WHEN totals.total_delegations > 0
+                    THEN total_count::float / totals.total_delegations ELSE 0 END,
+                'top_task_type', top_task_type,
+                'avg_latency_ms', avg_latency_ms,
+                'qg_pass_rate', CASE WHEN total_count > 0
+                    THEN quality_passed::float / total_count ELSE 0 END,
+                'task_types', task_types
+            )
+            ORDER BY total_count DESC
+        ),
+        '[]'::jsonb
+    ) AS rows
+    FROM (
+        SELECT
+            model_alias,
+            SUM(event_count)::int AS total_count,
+            SUM(quality_passed)::int AS quality_passed,
+            CASE WHEN SUM(event_count) > 0
+                THEN SUM(avg_latency_ms * event_count)::float / SUM(event_count)
+                ELSE 0
+            END AS avg_latency_ms,
+            (array_agg(task_type ORDER BY event_count DESC))[1] AS top_task_type,
+            to_jsonb(array_agg(task_type ORDER BY task_type)) AS task_types
+        FROM grouped
+        GROUP BY model_alias
+    ) m
+    CROSS JOIN totals
+),
+routing_rows AS (
+    SELECT COALESCE(
+        jsonb_agg(
+            jsonb_build_object(
+                'model_name', g.model_alias,
+                'task_type', g.task_type,
+                'count', g.event_count,
+                'pct_of_model', CASE WHEN model_totals.total_count > 0
+                    THEN g.event_count::float / model_totals.total_count ELSE 0 END,
+                'pct_of_total', CASE WHEN totals.total_delegations > 0
+                    THEN g.event_count::float / totals.total_delegations ELSE 0 END
+            )
+            ORDER BY g.event_count DESC
+        ),
+        '[]'::jsonb
+    ) AS rows
+    FROM grouped g
+    JOIN (
+        SELECT model_alias, SUM(event_count)::int AS total_count
+        FROM grouped
+        GROUP BY model_alias
+    ) model_totals USING (model_alias)
+    CROSS JOIN totals
+),
+decision_traces AS (
+    SELECT COALESCE(
+        jsonb_agg(
+            jsonb_build_object(
+                'id', id,
+                'correlation_id', correlation_id,
+                'task_type', task_type,
+                'model_name', COALESCE(NULLIF(model_name, ''), delegated_to),
+                'delegated_to', delegated_to,
+                'routing_rule', NULL,
+                'routing_confidence', NULL,
+                'routing_candidates', NULL,
+                'latency_ms', COALESCE(latency_ms, delegation_latency_ms),
+                'quality_gate_passed', quality_gate_passed,
+                'created_at', EXTRACT(EPOCH FROM created_at)
+            )
+            ORDER BY created_at DESC
+        ),
+        '[]'::jsonb
+    ) AS rows
+    FROM (
+        SELECT
+            row_number() OVER (ORDER BY created_at DESC)::int AS id,
+            correlation_id,
+            task_type,
+            model_name,
+            delegated_to,
+            latency_ms,
+            delegation_latency_ms,
+            quality_gate_passed,
+            created_at
+        FROM delegation_events
+        ORDER BY created_at DESC
+        LIMIT 20
+    ) traces
+),
+-- OMN-13662: tier distribution with explicit not_tier_routed classification.
+-- A row is "tier-routed" iff cost_tier_name is non-empty. Empty-tier rows are
+-- the delegate-skill terminals (skill->node, not LLM-tier routing).
+tier_totals AS (
+    SELECT
+        COUNT(*)::int AS total_tasks,
+        COALESCE(SUM(CASE WHEN cost_tier_name <> '' THEN 1 ELSE 0 END), 0)::int
+            AS tier_routed_total,
+        COALESCE(SUM(CASE WHEN cost_tier_name = '' THEN 1 ELSE 0 END), 0)::int
+            AS not_tier_routed_count
+    FROM delegation_events
+),
+tier_rows AS (
+    SELECT
+        CASE WHEN cost_tier_name = '' THEN 'not_tier_routed' ELSE cost_tier_name END
+            AS cost_tier_name,
+        (cost_tier_name <> '') AS tier_routed,
+        COUNT(*)::int AS count
+    FROM delegation_events
+    GROUP BY 1, 2
+),
+by_tier AS (
+    SELECT jsonb_build_object(
+        -- inclusive of not_tier_routed rows
+        'total_tasks', tt.total_tasks,
+        -- denominator for tier percentages (LLM-tier-routed rows only)
+        'tier_routed_total', tt.tier_routed_total,
+        -- delegate-skill terminals excluded from the percentage denominator
+        'not_tier_routed_count', tt.not_tier_routed_count,
+        'tiers', COALESCE(
+            (
+                SELECT jsonb_agg(
+                    jsonb_build_object(
+                        'cost_tier_name', tr.cost_tier_name,
+                        'count', tr.count,
+                        'tier_routed', tr.tier_routed,
+                        -- pct over LLM-tier-routed rows only; 0 for the
+                        -- excluded not_tier_routed bucket so the tier-routed
+                        -- percentages sum to 1.0
+                        'pct_of_tier_routed', CASE
+                            WHEN tr.tier_routed AND tt.tier_routed_total > 0
+                                THEN tr.count::float / tt.tier_routed_total
+                            ELSE 0
+                        END
+                    )
+                    ORDER BY tr.tier_routed DESC, tr.count DESC, tr.cost_tier_name
+                )
+                FROM tier_rows tr
+            ),
+            '[]'::jsonb
+        )
+    ) AS summary
+    FROM tier_totals tt
+)
+SELECT
+    totals.total_delegations,
+    routing_rows.rows,
+    by_model.rows AS by_model,
+    decision_traces.rows AS decision_traces,
+    COALESCE(totals.latest_projection_updated_at, NOW()) AS captured_at,
+    TRUE AS provisioned,
+    totals.latest_projection_updated_at,
+    by_tier.summary AS by_tier
+FROM totals
+CROSS JOIN routing_rows
+CROSS JOIN by_model
+CROSS JOIN decision_traces
+CROSS JOIN by_tier;

--- a/docker/migrations/forward/nodes/node_projection_savings/079_add_savings_series_tier_mix.sql
+++ b/docker/migrations/forward/nodes/node_projection_savings/079_add_savings_series_tier_mix.sql
@@ -16,12 +16,13 @@
 --     'claude'                        -> premium (ceiling tier slot)
 --     '' / NULL / unrecognized        -> not_tier_routed (no cost_tier_name)
 --
--- not_tier_routed rows (every savings_estimates-sourced row, plus any
--- delegation_events terminal that predates OMN-13649 and never carried a tier)
--- are EXCLUDED from the tier-% denominator but still counted in task_count, per
--- the T3/OMN-13662 rule. Each pct = count(bucket rows) / count(tier-routed rows)
--- within the day; the three pcts therefore sum to 1.0 for any bucket that has at
--- least one tier-routed row, and are 0 when a bucket has none.
+-- not_tier_routed rows (savings_estimates rows without a matching tier-routed
+-- delegation event, plus any delegation_events terminal that predates
+-- OMN-13649 and never carried a tier) are EXCLUDED from the tier-% denominator
+-- but still counted in task_count, per the T3/OMN-13662 rule. Each pct =
+-- count(bucket rows) / count(tier-routed rows) within the day; the three pcts
+-- therefore sum to 1.0 for any bucket that has at least one tier-routed row, and
+-- are 0 when a bucket has none.
 --
 -- CREATE OR REPLACE keeps the existing five columns (bucket, actual_cost_usd,
 -- baseline_cost_usd, savings_usd, task_count) in the same order and type and
@@ -79,8 +80,37 @@ event_sessions AS (
         NULLIF(cost_tier_name, '') AS cost_tier_name
     FROM delegation_events
 ),
+event_tiers AS (
+    SELECT
+        session_id,
+        (array_agg(cost_tier_name ORDER BY created_at DESC)
+            FILTER (WHERE cost_tier_name IS NOT NULL))[1] AS cost_tier_name
+    FROM event_sessions
+    GROUP BY session_id
+),
 combined_sessions AS (
-    SELECT * FROM savings_sessions
+    SELECT
+        savings_sessions.session_id,
+        savings_sessions.task_type,
+        savings_sessions.model_name,
+        savings_sessions.local_cost_usd,
+        savings_sessions.cloud_cost_usd,
+        savings_sessions.savings_usd,
+        savings_sessions.baseline_model,
+        savings_sessions.pricing_manifest_version,
+        savings_sessions.savings_method,
+        savings_sessions.usage_source,
+        savings_sessions.prompt_tokens,
+        savings_sessions.completion_tokens,
+        savings_sessions.tokens_to_compliance,
+        savings_sessions.latency_ms,
+        savings_sessions.created_at,
+        savings_sessions.prompt_text,
+        savings_sessions.response_text,
+        COALESCE(event_tiers.cost_tier_name, savings_sessions.cost_tier_name)
+            AS cost_tier_name
+    FROM savings_sessions
+    LEFT JOIN event_tiers USING (session_id)
     UNION ALL
     SELECT event_sessions.*
     FROM event_sessions

--- a/tests/ci/test_workspace_candidate_build.py
+++ b/tests/ci/test_workspace_candidate_build.py
@@ -111,12 +111,14 @@ class TestWorkspaceCandidateWorkflow:
         assert 'org.opencontainers.image.revision" }}' not in workflow_text
 
     def test_workflow_pins_third_party_actions(self, workflow_text: str) -> None:
-        assert "docker/setup-buildx-action@v4" not in workflow_text
-        assert "actions/setup-python@v6" not in workflow_text
-        assert "aws-actions/configure-aws-credentials@v6" not in workflow_text
-        assert "aws-actions/amazon-ecr-login@v2" not in workflow_text
-        assert "docker/build-push-action@v7" not in workflow_text
-        assert "actions/upload-artifact@v7" not in workflow_text
+        action_refs = re.findall(r"^\s*uses:\s*([^\s#]+)", workflow_text, re.MULTILINE)
+        assert action_refs
+        for action_ref in action_refs:
+            assert "@" in action_ref, f"{action_ref} is missing an immutable ref"
+            _, ref = action_ref.rsplit("@", 1)
+            assert re.fullmatch(r"[0-9a-f]{40}", ref), (
+                f"{action_ref} is not pinned to a 40-character commit SHA"
+            )
 
     def test_workflow_does_not_interpolate_sibling_ref_in_shell(
         self, workflow_text: str

--- a/tests/ci/test_workspace_candidate_build.py
+++ b/tests/ci/test_workspace_candidate_build.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Invariants for the workspace stability-candidate ECR build path (OMN-13656).
+
+The workspace-from-dev build (``.github/workflows/build-workspace-candidate-
+runtime.yml`` + ``docker/Dockerfile.runtime`` workspace mode) must produce an
+image that is UNMISTAKABLY a non-prod stability-candidate so the omnimarket
+prod-promotion gate (``node_prod_promotion_gate_compute``) and the lineage guard
+(OMN-12626) refuse it for prod. These deterministic tests pin the stamping
+invariants so they cannot silently regress into a clean-main-looking image.
+
+They assert static file contents only — no Docker build, no network.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DOCKERFILE = _REPO_ROOT / "docker" / "Dockerfile.runtime"
+_WORKFLOW = (
+    _REPO_ROOT / ".github" / "workflows" / "build-workspace-candidate-runtime.yml"
+)
+
+
+@pytest.fixture(scope="module")
+def dockerfile_text() -> str:
+    assert _DOCKERFILE.is_file(), f"missing {_DOCKERFILE}"
+    raw = _DOCKERFILE.read_text(encoding="utf-8")
+    # Collapse shell line continuations so a single statement is one line.
+    return re.sub(r"\\\n\s*", " ", raw)
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict[object, object]:
+    assert _WORKFLOW.is_file(), f"missing {_WORKFLOW}"
+    loaded = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+    assert isinstance(loaded, dict)
+    return loaded
+
+
+@pytest.fixture(scope="module")
+def workflow_text() -> str:
+    return _WORKFLOW.read_text(encoding="utf-8")
+
+
+@pytest.mark.unit
+class TestDockerfileCandidateStamping:
+    def test_promotion_class_and_lineage_args_default_clean_main(
+        self, dockerfile_text: str
+    ) -> None:
+        # Release builds must default to clean-main / non-main-lineage=false.
+        assert "ARG PROMOTION_CLASS=clean-main" in dockerfile_text
+        assert "ARG NON_MAIN_LINEAGE=false" in dockerfile_text
+
+    def test_oci_labels_carry_promotion_class_and_lineage(
+        self, dockerfile_text: str
+    ) -> None:
+        assert 'com.omninode.promotion_class="${PROMOTION_CLASS}"' in dockerfile_text
+        assert 'com.omninode.non_main_lineage="${NON_MAIN_LINEAGE}"' in dockerfile_text
+
+    def test_workspace_build_must_stamp_candidate(self, dockerfile_text: str) -> None:
+        # The Dockerfile fails closed if a workspace build does not stamp the
+        # candidate provenance — it can never be built as a clean-main image.
+        guard = 'if [ "${BUILD_SOURCE}" = "workspace" ]'
+        assert guard in dockerfile_text
+        assert '[ "${PROMOTION_CLASS}" != "stability-candidate" ]' in dockerfile_text
+        assert '[ "${NON_MAIN_LINEAGE}" != "true" ]' in dockerfile_text
+
+
+@pytest.mark.unit
+class TestWorkspaceCandidateWorkflow:
+    def test_workflow_is_dispatch_only(self, workflow: dict[object, object]) -> None:
+        # Never auto on push — a candidate must be deliberately requested so it
+        # cannot masquerade as a clean-main build. PyYAML parses the bare `on:`
+        # key as the boolean True.
+        on = workflow.get(True)
+        if on is None:
+            on = workflow.get("on")
+        assert isinstance(on, dict)
+        assert set(on.keys()) == {"workflow_dispatch"}
+
+    def test_workflow_builds_workspace_mode_with_candidate_stamp(
+        self, workflow_text: str
+    ) -> None:
+        assert "BUILD_SOURCE=workspace" in workflow_text
+        assert "EXPECTED_BUILD_SOURCE=workspace" in workflow_text
+        assert "PROMOTION_CLASS=stability-candidate" in workflow_text
+        assert "NON_MAIN_LINEAGE=true" in workflow_text
+
+    def test_workflow_stages_siblings(self, workflow_text: str) -> None:
+        assert "scripts/runtime_build/stage_workspace.sh" in workflow_text
+
+    def test_workflow_runs_unweakened_trivy_scan(self, workflow_text: str) -> None:
+        # SAME scan as the prod path: CRITICAL,HIGH, --ignore-unfixed, exit 1.
+        assert "aquasecurity/trivy-action" in workflow_text
+        assert "severity: 'CRITICAL,HIGH'" in workflow_text
+        assert "ignore-unfixed: true" in workflow_text
+        assert "exit-code: '1'" in workflow_text
+        # No advisory / continue-on-error softener on the scan.
+        assert "continue-on-error" not in workflow_text
+
+    def test_workflow_attests_source_hash(self, workflow_text: str) -> None:
+        assert "OMN-9139" in workflow_text
+        assert "RUNTIME_SOURCE_HASH=${{ github.sha }}" in workflow_text
+
+    def test_workflow_emits_provenance_manifest(self, workflow_text: str) -> None:
+        assert 'build_source: "workspace"' in workflow_text
+        assert 'promotion_class: "stability-candidate"' in workflow_text
+        assert "non_main_lineage: true" in workflow_text
+        assert "per_sibling_vcs_provenance" in workflow_text
+        # Candidate is pinnable to dev/stability only — never prod.
+        assert "prod_pinnable: false" in workflow_text
+
+    def test_workflow_asserts_lineage_labels_before_push(
+        self, workflow_text: str
+    ) -> None:
+        # The lineage-label assertion must precede the push step in the file so a
+        # mis-stamped image is never pushed.
+        assert "Assert stability-candidate lineage labels" in workflow_text
+        assert_idx = workflow_text.index("Assert stability-candidate lineage labels")
+        push_idx = workflow_text.index("Push candidate image to Amazon ECR")
+        assert assert_idx < push_idx
+
+    def test_workflow_has_no_skip_or_bypass_tokens(self, workflow_text: str) -> None:
+        assert "[skip-" not in workflow_text
+        assert "--no-verify" not in workflow_text

--- a/tests/ci/test_workspace_candidate_build.py
+++ b/tests/ci/test_workspace_candidate_build.py
@@ -107,6 +107,24 @@ class TestWorkspaceCandidateWorkflow:
     def test_workflow_attests_source_hash(self, workflow_text: str) -> None:
         assert "OMN-9139" in workflow_text
         assert "RUNTIME_SOURCE_HASH=${{ github.sha }}" in workflow_text
+        assert "sed -n 's/^RUNTIME_SOURCE_HASH=//p'" in workflow_text
+        assert 'org.opencontainers.image.revision" }}' not in workflow_text
+
+    def test_workflow_pins_third_party_actions(self, workflow_text: str) -> None:
+        assert "docker/setup-buildx-action@v4" not in workflow_text
+        assert "actions/setup-python@v6" not in workflow_text
+        assert "aws-actions/configure-aws-credentials@v6" not in workflow_text
+        assert "aws-actions/amazon-ecr-login@v2" not in workflow_text
+        assert "docker/build-push-action@v7" not in workflow_text
+        assert "actions/upload-artifact@v7" not in workflow_text
+
+    def test_workflow_does_not_interpolate_sibling_ref_in_shell(
+        self, workflow_text: str
+    ) -> None:
+        assert '--arg sibling_ref "${SIBLING_REF}"' in workflow_text
+        assert 'echo "| sibling ref | \\`${SIBLING_REF}\\` |"' in workflow_text
+        assert '--arg sibling_ref "${{ inputs.sibling_ref }}"' not in workflow_text
+        assert "`${{ inputs.sibling_ref }}`" not in workflow_text
 
     def test_workflow_emits_provenance_manifest(self, workflow_text: str) -> None:
         assert 'build_source: "workspace"' in workflow_text

--- a/tests/integration/docker/test_runtime_image_identity_build.py
+++ b/tests/integration/docker/test_runtime_image_identity_build.py
@@ -131,8 +131,7 @@ def test_workspace_build_with_identity_args_populates_labels(
         )
         # OMN-13656: candidate lineage labels populated.
         assert (
-            _inspect_label(tag, "com.omninode.promotion_class")
-            == "stability-candidate"
+            _inspect_label(tag, "com.omninode.promotion_class") == "stability-candidate"
         )
         assert _inspect_label(tag, "com.omninode.non_main_lineage") == "true"
     finally:

--- a/tests/integration/docker/test_runtime_image_identity_build.py
+++ b/tests/integration/docker/test_runtime_image_identity_build.py
@@ -96,7 +96,12 @@ def _inspect_label(tag: str, label: str) -> str:
 def test_workspace_build_with_identity_args_populates_labels(
     skip_if_no_docker: None, tmp_path: Path
 ) -> None:
-    """Workspace build + identity quad → populated version + revision labels."""
+    """Workspace build + identity quad + candidate stamp → populated labels.
+
+    OMN-13656: a workspace build MUST also stamp PROMOTION_CLASS=stability-candidate
+    + NON_MAIN_LINEAGE=true (the prod-promotion gate refuses it for prod). Assert
+    those OCI labels are populated alongside the identity quad.
+    """
     dockerfile = _write_proof_dockerfile(tmp_path)
     tag = f"omn12965-good-{uuid.uuid4().hex[:8]}"
     try:
@@ -111,6 +116,8 @@ def test_workspace_build_with_identity_args_populates_labels(
                 "RUNTIME_VERSION": "0.38.3",
                 "VCS_REF": "abc123def456",
                 "BUILD_DATE": "2026-06-11T00:00:00Z",
+                "PROMOTION_CLASS": "stability-candidate",
+                "NON_MAIN_LINEAGE": "true",
             },
         )
         assert result.returncode == 0, f"build failed: {result.stderr}"
@@ -122,6 +129,46 @@ def test_workspace_build_with_identity_args_populates_labels(
             r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z",
             _inspect_label(tag, "org.opencontainers.image.created"),
         )
+        # OMN-13656: candidate lineage labels populated.
+        assert (
+            _inspect_label(tag, "com.omninode.promotion_class")
+            == "stability-candidate"
+        )
+        assert _inspect_label(tag, "com.omninode.non_main_lineage") == "true"
+    finally:
+        subprocess.run(["docker", "rmi", "-f", tag], capture_output=True, check=False)
+
+
+@pytest.mark.integration
+def test_workspace_build_without_candidate_stamp_fails_guard(
+    skip_if_no_docker: None, tmp_path: Path
+) -> None:
+    """OMN-13656: a workspace build with the identity quad but WITHOUT the
+    stability-candidate stamp fails the guard — it can never be built as a
+    clean-main image."""
+    dockerfile = _write_proof_dockerfile(tmp_path)
+    tag = f"omn13656-nostamp-{uuid.uuid4().hex[:8]}"
+    try:
+        result = _build(
+            dockerfile,
+            tmp_path,
+            tag,
+            {
+                "BUILD_SOURCE": "workspace",
+                "EXPECTED_BUILD_SOURCE": "workspace",
+                "OMNI_HOME": "/x",
+                "RUNTIME_VERSION": "0.38.3",
+                "VCS_REF": "abc123def456",
+                "BUILD_DATE": "2026-06-11T00:00:00Z",
+                # PROMOTION_CLASS / NON_MAIN_LINEAGE deliberately omitted (defaults
+                # clean-main / false).
+            },
+        )
+        assert result.returncode != 0, (
+            "workspace build without the candidate stamp must fail the guard "
+            "(OMN-13656)"
+        )
+        assert "OMN-13656" in (result.stderr + result.stdout)
     finally:
         subprocess.run(["docker", "rmi", "-f", tag], capture_output=True, check=False)
 


### PR DESCRIPTION
## OMN-13656 — scanned workspace-from-dev ECR build as a gated stability-candidate

Adds a CI path that builds a SCANNED workspace-from-dev runtime image to ECR as an **explicitly non-prod stability-candidate**. The runtime build (`build-and-push-runtime.yml`) is main+release-only; `Dockerfile.runtime` already supports workspace mode, but it was wired only into the LOCAL `deploy-runtime.sh` path. This wires the same workspace build into CI.

### New workflow `build-workspace-candidate-runtime.yml` (workflow_dispatch only)
Stages the sibling repos at dev HEAD → builds `Dockerfile.runtime` in **WORKSPACE mode** → runs the **SAME Trivy scan** (`CRITICAL,HIGH --ignore-unfixed --exit-code 1`, NOT weakened, no `continue-on-error`) → attests the baked-in `RUNTIME_SOURCE_HASH` equals HEAD (OMN-9139) → asserts non-main-lineage labels **before** push → pushes a `candidate-*` tagged image to ECR.

### Stamped UNMISTAKABLY non-prod
- `build-manifest.json`: `build_source=workspace`, `promotion_class=stability-candidate`, `non_main_lineage:true`, `prod_pinnable:false`, `pinnable_lanes:[dev,stability-test]`, and **per-sibling VCS provenance** (folded from `stage_workspace.sh`'s `sibling-vcs-provenance.json`).
- `Dockerfile.runtime`: new `PROMOTION_CLASS` / `NON_MAIN_LINEAGE` args → OCI labels `com.omninode.promotion_class` + `com.omninode.non_main_lineage`; the Dockerfile **fails closed** unless a workspace build is marked stability-candidate, so it can never masquerade as a clean-main build under the lineage guard (OMN-12626).

### Gate discipline
The prod-bound lineage guard is intentionally **NOT** run on this path (a workspace build is non-main by design). The omnimarket prod-promotion gate (companion PR, OMN-13656) refuses the candidate for prod instead. The digest is pinnable to dev/stability **ONLY** — no prod kustomization is touched, no prod deploy.

### dod_evidence
- `uv run pytest tests/ci/test_workspace_candidate_build.py` → **11 passed** (Dockerfile + workflow invariants)
- `uv run pytest tests/scripts/test_check_prod_promotion_lineage.py tests/scripts/test_deploy_runtime_prod_lineage.py tests/scripts/test_dockerfile_runtime_git_refresh.py tests/scripts/test_deploy_runtime_build_context.py tests/scripts/test_check_dockerfile_pins.py` → **46 passed**
- `pre-commit run --files ...` → all hooks pass; actionlint clean
- `contracts/OMN-13656.yaml` carries the DoD evidence.


Evidence-Source: OCC#3208
Evidence-Ticket: OMN-13656


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a workflow to build and publish a workspace-mode runtime image as a stability candidate.
  * Runtime images now support promotion-lineage stamping to improve build traceability.
* **Bug Fixes**
  * Workspace builds are now fail-closed unless they carry the required stability-candidate lineage metadata.
  * Added stronger security scanning and provenance/identity verification before publishing.
* **Tests**
  * Added checks to enforce candidate build invariants and labeling, including identity-stamping behavior.
* **Data Updates**
  * Updated reporting views to reflect tier-routed vs not-tier-routed routing and day-level savings tier mixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
