### PR TITLE
build(OMN-13664): bump uv dependency group with runner identity refresh

### DIFF
--- a/docker/migrations/forward/nodes/node_projection_delegation/0021_delegation_tier_distribution_not_tier_routed.sql
+++ b/docker/migrations/forward/nodes/node_projection_delegation/0021_delegation_tier_distribution_not_tier_routed.sql
@@ -1,0 +1,204 @@
+-- OMN-13662 (T3): explicit not_tier_routed classification in the delegation
+-- model-routing rollup.
+--
+-- The delegate-skill terminal path (ModelDelegateSkillTerminalProjection) is
+-- skill->node delegation, NOT LLM-tier routing, so those delegation_events rows
+-- legitimately carry an empty cost_tier_name (TEXT NOT NULL DEFAULT '' from
+-- migration 0018). The tier rollup must define HOW empty-tier rows are treated
+-- rather than leaving it implementation-defined (which is what produced the old
+-- client-side regex).
+--
+-- Authoritative projection rule (doctrine: no silent default):
+--   * map empty cost_tier_name -> the explicit value 'not_tier_routed';
+--   * EXCLUDE not_tier_routed rows from tier-distribution percentage
+--     DENOMINATORS (pct is computed over LLM-tier-routed rows only, so the
+--     tier-routed percentages sum to 1.0);
+--   * INCLUDE not_tier_routed rows in total task counts (total_tasks);
+--   * surface the classification + the excluded count on the projection so the
+--     dashboard READS it and never re-derives it.
+--
+-- This is a CREATE OR REPLACE VIEW (psql-applicable, no node redeploy). The new
+-- by_tier column is appended at the END of the SELECT list so the replace is
+-- compatible with the existing projection_delegation_model_routing view defined
+-- in migration 0010.
+
+CREATE OR REPLACE VIEW projection_delegation_model_routing AS
+WITH grouped AS (
+    SELECT
+        delegated_to AS model_alias,
+        COALESCE(NULLIF(model_name, ''), delegated_to) AS model_name,
+        task_type,
+        COUNT(*)::int AS event_count,
+        COALESCE(SUM(CASE WHEN quality_gate_passed THEN 1 ELSE 0 END), 0)::int
+            AS quality_passed,
+        COALESCE(AVG(COALESCE(latency_ms, delegation_latency_ms)), 0)::float
+            AS avg_latency_ms
+    FROM delegation_events
+    GROUP BY delegated_to, COALESCE(NULLIF(model_name, ''), delegated_to), task_type
+),
+totals AS (
+    SELECT COUNT(*)::int AS total_delegations, MAX(created_at) AS latest_projection_updated_at
+    FROM delegation_events
+),
+by_model AS (
+    SELECT COALESCE(
+        jsonb_agg(
+            jsonb_build_object(
+                'model_name', model_alias,
+                'total_count', total_count,
+                'pct_of_total', CASE WHEN totals.total_delegations > 0
+                    THEN total_count::float / totals.total_delegations ELSE 0 END,
+                'top_task_type', top_task_type,
+                'avg_latency_ms', avg_latency_ms,
+                'qg_pass_rate', CASE WHEN total_count > 0
+                    THEN quality_passed::float / total_count ELSE 0 END,
+                'task_types', task_types
+            )
+            ORDER BY total_count DESC
+        ),
+        '[]'::jsonb
+    ) AS rows
+    FROM (
+        SELECT
+            model_alias,
+            SUM(event_count)::int AS total_count,
+            SUM(quality_passed)::int AS quality_passed,
+            CASE WHEN SUM(event_count) > 0
+                THEN SUM(avg_latency_ms * event_count)::float / SUM(event_count)
+                ELSE 0
+            END AS avg_latency_ms,
+            (array_agg(task_type ORDER BY event_count DESC))[1] AS top_task_type,
+            to_jsonb(array_agg(task_type ORDER BY task_type)) AS task_types
+        FROM grouped
+        GROUP BY model_alias
+    ) m
+    CROSS JOIN totals
+),
+routing_rows AS (
+    SELECT COALESCE(
+        jsonb_agg(
+            jsonb_build_object(
+                'model_name', g.model_alias,
+                'task_type', g.task_type,
+                'count', g.event_count,
+                'pct_of_model', CASE WHEN model_totals.total_count > 0
+                    THEN g.event_count::float / model_totals.total_count ELSE 0 END,
+                'pct_of_total', CASE WHEN totals.total_delegations > 0
+                    THEN g.event_count::float / totals.total_delegations ELSE 0 END
+            )
+            ORDER BY g.event_count DESC
+        ),
+        '[]'::jsonb
+    ) AS rows
+    FROM grouped g
+    JOIN (
+        SELECT model_alias, SUM(event_count)::int AS total_count
+        FROM grouped
+        GROUP BY model_alias
+    ) model_totals USING (model_alias)
+    CROSS JOIN totals
+),
+decision_traces AS (
+    SELECT COALESCE(
+        jsonb_agg(
+            jsonb_build_object(
+                'id', id,
+                'correlation_id', correlation_id,
+                'task_type', task_type,
+                'model_name', COALESCE(NULLIF(model_name, ''), delegated_to),
+                'delegated_to', delegated_to,
+                'routing_rule', NULL,
+                'routing_confidence', NULL,
+                'routing_candidates', NULL,
+                'latency_ms', COALESCE(latency_ms, delegation_latency_ms),
+                'quality_gate_passed', quality_gate_passed,
+                'created_at', EXTRACT(EPOCH FROM created_at)
+            )
+            ORDER BY created_at DESC
+        ),
+        '[]'::jsonb
+    ) AS rows
+    FROM (
+        SELECT
+            row_number() OVER (ORDER BY created_at DESC)::int AS id,
+            correlation_id,
+            task_type,
+            model_name,
+            delegated_to,
+            latency_ms,
+            delegation_latency_ms,
+            quality_gate_passed,
+            created_at
+        FROM delegation_events
+        ORDER BY created_at DESC
+        LIMIT 20
+    ) traces
+),
+-- OMN-13662: tier distribution with explicit not_tier_routed classification.
+-- A row is "tier-routed" iff cost_tier_name is non-empty. Empty-tier rows are
+-- the delegate-skill terminals (skill->node, not LLM-tier routing).
+tier_totals AS (
+    SELECT
+        COUNT(*)::int AS total_tasks,
+        COALESCE(SUM(CASE WHEN cost_tier_name <> '' THEN 1 ELSE 0 END), 0)::int
+            AS tier_routed_total,
+        COALESCE(SUM(CASE WHEN cost_tier_name = '' THEN 1 ELSE 0 END), 0)::int
+            AS not_tier_routed_count
+    FROM delegation_events
+),
+tier_rows AS (
+    SELECT
+        CASE WHEN cost_tier_name = '' THEN 'not_tier_routed' ELSE cost_tier_name END
+            AS cost_tier_name,
+        (cost_tier_name <> '') AS tier_routed,
+        COUNT(*)::int AS count
+    FROM delegation_events
+    GROUP BY 1, 2
+),
+by_tier AS (
+    SELECT jsonb_build_object(
+        -- inclusive of not_tier_routed rows
+        'total_tasks', tt.total_tasks,
+        -- denominator for tier percentages (LLM-tier-routed rows only)
+        'tier_routed_total', tt.tier_routed_total,
+        -- delegate-skill terminals excluded from the percentage denominator
+        'not_tier_routed_count', tt.not_tier_routed_count,
+        'tiers', COALESCE(
+            (
+                SELECT jsonb_agg(
+                    jsonb_build_object(
+                        'cost_tier_name', tr.cost_tier_name,
+                        'count', tr.count,
+                        'tier_routed', tr.tier_routed,
+                        -- pct over LLM-tier-routed rows only; 0 for the
+                        -- excluded not_tier_routed bucket so the tier-routed
+                        -- percentages sum to 1.0
+                        'pct_of_tier_routed', CASE
+                            WHEN tr.tier_routed AND tt.tier_routed_total > 0
+                                THEN tr.count::float / tt.tier_routed_total
+                            ELSE 0
+                        END
+                    )
+                    ORDER BY tr.tier_routed DESC, tr.count DESC, tr.cost_tier_name
+                )
+                FROM tier_rows tr
+            ),
+            '[]'::jsonb
+        )
+    ) AS summary
+    FROM tier_totals tt
+)
+SELECT
+    totals.total_delegations,
+    routing_rows.rows,
+    by_model.rows AS by_model,
+    decision_traces.rows AS decision_traces,
+    COALESCE(totals.latest_projection_updated_at, NOW()) AS captured_at,
+    TRUE AS provisioned,
+    totals.latest_projection_updated_at,
+    by_tier.summary AS by_tier
+FROM totals
+CROSS JOIN routing_rows
+CROSS JOIN by_model
+CROSS JOIN decision_traces
+CROSS JOIN by_tier;

--- a/docker/migrations/forward/nodes/node_projection_savings/079_add_savings_series_tier_mix.sql
+++ b/docker/migrations/forward/nodes/node_projection_savings/079_add_savings_series_tier_mix.sql
@@ -16,12 +16,13 @@
 --     'claude'                        -> premium (ceiling tier slot)
 --     '' / NULL / unrecognized        -> not_tier_routed (no cost_tier_name)
 --
--- not_tier_routed rows (every savings_estimates-sourced row, plus any
--- delegation_events terminal that predates OMN-13649 and never carried a tier)
--- are EXCLUDED from the tier-% denominator but still counted in task_count, per
--- the T3/OMN-13662 rule. Each pct = count(bucket rows) / count(tier-routed rows)
--- within the day; the three pcts therefore sum to 1.0 for any bucket that has at
--- least one tier-routed row, and are 0 when a bucket has none.
+-- not_tier_routed rows (savings_estimates rows without a matching tier-routed
+-- delegation event, plus any delegation_events terminal that predates
+-- OMN-13649 and never carried a tier) are EXCLUDED from the tier-% denominator
+-- but still counted in task_count, per the T3/OMN-13662 rule. Each pct =
+-- count(bucket rows) / count(tier-routed rows) within the day; the three pcts
+-- therefore sum to 1.0 for any bucket that has at least one tier-routed row, and
+-- are 0 when a bucket has none.
 --
 -- CREATE OR REPLACE keeps the existing five columns (bucket, actual_cost_usd,
 -- baseline_cost_usd, savings_usd, task_count) in the same order and type and
@@ -79,8 +80,37 @@ event_sessions AS (
         NULLIF(cost_tier_name, '') AS cost_tier_name
     FROM delegation_events
 ),
+event_tiers AS (
+    SELECT
+        session_id,
+        (array_agg(cost_tier_name ORDER BY created_at DESC)
+            FILTER (WHERE cost_tier_name IS NOT NULL))[1] AS cost_tier_name
+    FROM event_sessions
+    GROUP BY session_id
+),
 combined_sessions AS (
-    SELECT * FROM savings_sessions
+    SELECT
+        savings_sessions.session_id,
+        savings_sessions.task_type,
+        savings_sessions.model_name,
+        savings_sessions.local_cost_usd,
+        savings_sessions.cloud_cost_usd,
+        savings_sessions.savings_usd,
+        savings_sessions.baseline_model,
+        savings_sessions.pricing_manifest_version,
+        savings_sessions.savings_method,
+        savings_sessions.usage_source,
+        savings_sessions.prompt_tokens,
+        savings_sessions.completion_tokens,
+        savings_sessions.tokens_to_compliance,
+        savings_sessions.latency_ms,
+        savings_sessions.created_at,
+        savings_sessions.prompt_text,
+        savings_sessions.response_text,
+        COALESCE(event_tiers.cost_tier_name, savings_sessions.cost_tier_name)
+            AS cost_tier_name
+    FROM savings_sessions
+    LEFT JOIN event_tiers USING (session_id)
     UNION ALL
     SELECT event_sessions.*
     FROM event_sessions

--- a/docker/migrations/forward/nodes/node_projection_savings/079_add_savings_series_tier_mix.sql
+++ b/docker/migrations/forward/nodes/node_projection_savings/079_add_savings_series_tier_mix.sql
@@ -1,0 +1,127 @@
+-- OMN-13661 (T2): tier-mix percentages for the delegation savings-over-time
+-- series. Extends projection_delegation_savings_series (migration 078) with the
+-- per-bucket routing-tier distribution the dashboard renders alongside the
+-- cost/savings curve, WITHOUT re-deriving tier from a model-name regex.
+--
+-- cost_tier_name is authoritative on delegation_events as of OMN-13649
+-- (migration 0018 column + the #1458 write path: the orchestrator now carries
+-- workflow.current_tier_name onto the canonical terminal, so a COMPLETED
+-- local/free delegation records its real serving tier instead of '').
+--
+-- Authoritative tier -> bucket mapping (routing_tiers.yaml escalation ladder
+-- local -> cheap_cloud -> cheap_frontier -> claude, collapsed to three display
+-- buckets). The projection owns this rule so the UI consumes it, never re-derives:
+--     'local'                         -> local   (owned-GPU, free_local cost)
+--     'cheap_cloud' | 'cheap_frontier'-> cheap   (cheap/free cloud, mid-ladder)
+--     'claude'                        -> premium (ceiling tier slot)
+--     '' / NULL / unrecognized        -> not_tier_routed (no cost_tier_name)
+--
+-- not_tier_routed rows (every savings_estimates-sourced row, plus any
+-- delegation_events terminal that predates OMN-13649 and never carried a tier)
+-- are EXCLUDED from the tier-% denominator but still counted in task_count, per
+-- the T3/OMN-13662 rule. Each pct = count(bucket rows) / count(tier-routed rows)
+-- within the day; the three pcts therefore sum to 1.0 for any bucket that has at
+-- least one tier-routed row, and are 0 when a bucket has none.
+--
+-- CREATE OR REPLACE keeps the existing five columns (bucket, actual_cost_usd,
+-- baseline_cost_usd, savings_usd, task_count) in the same order and type and
+-- appends local_pct/cheap_pct/prem_pct, satisfying Postgres' replace-view rule.
+
+CREATE OR REPLACE VIEW projection_delegation_savings_series AS
+WITH savings_sessions AS (
+    SELECT
+        session_id,
+        model_local AS task_type,
+        model_local AS model_name,
+        local_cost_usd::float AS local_cost_usd,
+        cloud_cost_usd::float AS cloud_cost_usd,
+        savings_usd::float AS savings_usd,
+        model_cloud_baseline AS baseline_model,
+        'savings-estimated' AS pricing_manifest_version,
+        'measured' AS savings_method,
+        'savings_estimates' AS usage_source,
+        0::int AS prompt_tokens,
+        0::int AS completion_tokens,
+        NULL::int AS tokens_to_compliance,
+        NULL::int AS latency_ms,
+        created_at,
+        NULL::text AS prompt_text,
+        NULL::text AS response_text,
+        -- savings_estimates rows are not LLM-tier-routed: no serving tier.
+        NULL::text AS cost_tier_name
+    FROM savings_estimates
+),
+event_sessions AS (
+    SELECT
+        COALESCE(NULLIF(session_id, ''), NULLIF(correlation_id, ''), id::text)
+            AS session_id,
+        COALESCE(task_type, '') AS task_type,
+        COALESCE(NULLIF(model_name, ''), NULLIF(delegated_to, ''), 'local')
+            AS model_name,
+        COALESCE(cost_usd, 0)::float AS local_cost_usd,
+        (COALESCE(cost_usd, 0) + COALESCE(cost_savings_usd, 0))::float
+            AS cloud_cost_usd,
+        COALESCE(cost_savings_usd, 0)::float AS savings_usd,
+        'claude-opus-4.1' AS baseline_model,
+        pricing_manifest_version::text AS pricing_manifest_version,
+        CASE WHEN COALESCE(cost_savings_usd, 0) > 0
+            THEN 'measured' ELSE 'estimated' END AS savings_method,
+        CASE WHEN COALESCE(tokens_input, 0) + COALESCE(tokens_output, 0) > 0
+            THEN 'measured' ELSE 'unknown' END AS usage_source,
+        COALESCE(tokens_input, 0)::int AS prompt_tokens,
+        COALESCE(tokens_output, 0)::int AS completion_tokens,
+        NULLIF(tokens_to_compliance, 0)::int AS tokens_to_compliance,
+        COALESCE(delegation_latency_ms, latency_ms)::int AS latency_ms,
+        COALESCE(created_at, timestamp) AS created_at,
+        prompt_text,
+        response_text,
+        -- OMN-13649: authoritative serving tier. Empty string -> not tier-routed.
+        NULLIF(cost_tier_name, '') AS cost_tier_name
+    FROM delegation_events
+),
+combined_sessions AS (
+    SELECT * FROM savings_sessions
+    UNION ALL
+    SELECT event_sessions.*
+    FROM event_sessions
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM savings_sessions
+        WHERE savings_sessions.session_id = event_sessions.session_id
+    )
+),
+classified_sessions AS (
+    SELECT
+        *,
+        CASE
+            WHEN cost_tier_name = 'local' THEN 'local'
+            WHEN cost_tier_name IN ('cheap_cloud', 'cheap_frontier') THEN 'cheap'
+            WHEN cost_tier_name = 'claude' THEN 'premium'
+            ELSE NULL  -- not_tier_routed: excluded from the tier-% denominator
+        END AS tier_bucket
+    FROM combined_sessions
+)
+SELECT
+    date_trunc('day', created_at) AS bucket,
+    COALESCE(SUM(local_cost_usd), 0)::float AS actual_cost_usd,
+    COALESCE(SUM(cloud_cost_usd), 0)::float AS baseline_cost_usd,
+    COALESCE(SUM(savings_usd), 0)::float AS savings_usd,
+    COUNT(*)::int AS task_count,
+    COALESCE(
+        COUNT(*) FILTER (WHERE tier_bucket = 'local')::float
+        / NULLIF(COUNT(*) FILTER (WHERE tier_bucket IS NOT NULL), 0),
+        0
+    )::float AS local_pct,
+    COALESCE(
+        COUNT(*) FILTER (WHERE tier_bucket = 'cheap')::float
+        / NULLIF(COUNT(*) FILTER (WHERE tier_bucket IS NOT NULL), 0),
+        0
+    )::float AS cheap_pct,
+    COALESCE(
+        COUNT(*) FILTER (WHERE tier_bucket = 'premium')::float
+        / NULLIF(COUNT(*) FILTER (WHERE tier_bucket IS NOT NULL), 0),
+        0
+    )::float AS prem_pct
+FROM classified_sessions
+GROUP BY 1
+ORDER BY 1;

--- a/docker/runners/runner-image.lock.json
+++ b/docker/runners/runner-image.lock.json
@@ -1,12 +1,12 @@
 {
   "base_image_digest": "sha256:3ba65aa20f86a0fad9df2b2c259c613df006b2e6d0bfcc8a146afb8c525a9751",
   "gh_version": "2.67.0",
-  "identity_digest": "08ca594236ffd27f87325329103c8f98",
+  "identity_digest": "917d844856cec327a8e5c4220348526a",
   "image_version": 5,
   "kubectl_version": "1.32.1",
   "python_version": "3.12",
   "runner_version": "2.334.0",
-  "shared_env_digest": "9981cffc7324b45ab15b0922",
+  "shared_env_digest": "366971b13c707215ad917d59",
   "shared_env_install_args": "--frozen --all-extras --all-groups --no-install-project",
   "uv_version": "0.6.14"
 }

--- a/tests/integration/infra/test_omn_12765_release_backmerge_identity.py
+++ b/tests/integration/infra/test_omn_12765_release_backmerge_identity.py
@@ -33,7 +33,7 @@ def test_release_backmerge_preserves_runner_identity_lock() -> None:
         (ROOT / "docker/runners/runner-image.lock.json").read_text(encoding="utf-8")
     )
 
-    # OMN-13654: identity regenerated after the Trivy HIGH-CVE dependency bump
-    # updated the runtime shared-env inputs.
-    assert lock["identity_digest"] == "08ca594236ffd27f87325329103c8f98"
-    assert lock["shared_env_digest"] == "9981cffc7324b45ab15b0922"
+    # OMN-13664: identity regenerated after the uv dependency refresh updated
+    # the runtime shared-env inputs.
+    assert lock["identity_digest"] == "917d844856cec327a8e5c4220348526a"
+    assert lock["shared_env_digest"] == "366971b13c707215ad917d59"

--- a/uv.lock
+++ b/uv.lock
@@ -3037,14 +3037,14 @@ wheels = [
 
 [[package]]
 name = "python-engineio"
-version = "4.13.1"
+version = "4.13.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "simple-websocket" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/34/12/bdef9dbeedbe2cdeba2a2056ad27b1fb081557d34b69a97f574843462cae/python_engineio-4.13.1.tar.gz", hash = "sha256:0a853fcef52f5b345425d8c2b921ac85023a04dfcf75d7b74696c61e940fd066", size = 92348, upload-time = "2026-02-06T23:38:06.12Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/6d/4384c2723adad93a3d6de4297e6d9c8b93be7f778a407f34f6ee0b2bea3e/python_engineio-4.13.2.tar.gz", hash = "sha256:a7732e99cfb7db6ed1aee31f18d7f73bbae086a92f31dee019bc646155d9684e", size = 79639, upload-time = "2026-05-21T21:45:07.578Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/54/0cce26da03a981f949bb8449c9778537f75f5917c172e1d2992ff25cb57d/python_engineio-4.13.1-py3-none-any.whl", hash = "sha256:f32ad10589859c11053ad7d9bb3c9695cdf862113bfb0d20bc4d890198287399", size = 59847, upload-time = "2026-02-06T23:38:04.861Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/28/180bfc5c95e83d40cb2abce512684ccad44e4819ec899fc36cb404a19061/python_engineio-4.13.2-py3-none-any.whl", hash = "sha256:8c101cd170e400dc4e970cd523325cde22df8fc25140953f379327055d701a6b", size = 59993, upload-time = "2026-05-21T21:45:06.162Z" },
 ]
 
 [[package]]
@@ -3058,15 +3058,15 @@ wheels = [
 
 [[package]]
 name = "python-socketio"
-version = "5.16.1"
+version = "5.16.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bidict" },
     { name = "python-engineio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/59/81/cf8284f45e32efa18d3848ed82cdd4dcc1b657b082458fbe01ad3e1f2f8d/python_socketio-5.16.1.tar.gz", hash = "sha256:f863f98eacce81ceea2e742f6388e10ca3cdd0764be21d30d5196470edf5ea89", size = 128508, upload-time = "2026-02-06T23:42:07Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/dd/6fd4112b941f7d39b8171b6ba17902609bd8fa2059c3812a3c29dade13e7/python_socketio-5.16.2.tar.gz", hash = "sha256:ad88c228d921646efa436c0a0df217e364ef30ec072df4041484e54d49c15989", size = 128011, upload-time = "2026-05-21T22:03:44.418Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/c7/deb8c5e604404dbf10a3808a858946ca3547692ff6316b698945bb72177e/python_socketio-5.16.1-py3-none-any.whl", hash = "sha256:a3eb1702e92aa2f2b5d3ba00261b61f062cce51f1cfb6900bf3ab4d1934d2d35", size = 82054, upload-time = "2026-02-06T23:42:05.772Z" },
+    { url = "https://files.pythonhosted.org/packages/72/dc/0decaf5da92a7a969374474025787102d811d42aed1d32191fa338620e15/python_socketio-5.16.2-py3-none-any.whl", hash = "sha256:bef2da3374fd533aed4297f57b4f6512b52aa51604cb0da2165f401291c5ca20", size = 82137, upload-time = "2026-05-21T22:03:42.616Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- replace Dependabot branch #2117 with an OMN-13664-named branch so Receipt Gate identity binding can pass
- keep the uv dependency bump from #2117
- keep the runner-image identity refresh and node migration sync evidence from the #2117 remediation

## Evidence
Evidence-Source: OCC#3213
Evidence-Ticket: OMN-13664

Closes OMN-13664.

Supersedes #2117.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a tier distribution breakdown to delegation reporting, including an explicit “not tier-routed” category.
  * Updated savings series tier-mix reporting to include local/cheap/premium percentage shares alongside existing cost and savings totals.

* **Bug Fixes**
  * Fixed tier percentage denominator behavior so non-tier-routed tasks no longer skew tier mix results.
  * Improved tier classification and ensured session tier labeling can reflect the latest delegation event data when available.

* **Chores**
  * Refreshed runner image digests and updated the related identity lock integration test expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

