### PR TITLE
fix(OMN-13670): surgical main hotfix — re-apply OMN-13654 dep floors + OMN-13666 entrypoint tolerance (emergency prod recovery)

### DIFF
--- a/contracts/OMN-13654.yaml
+++ b/contracts/OMN-13654.yaml
@@ -1,0 +1,43 @@
+schema_version: '1.0.0'
+ticket_id: OMN-13654
+title: 'Fix red build-and-push-runtime.yml — bump Trivy-flagged HIGH-CVE runtime deps'
+summary: >-
+  The runtime ECR build (build-and-push-runtime.yml) has been red since 2026-06-07: the Docker build succeeds but the Trivy gate (CRITICAL,HIGH --ignore-unfixed --exit-code 1) fails on 5 fixable HIGH CVEs in the resolved Python deps (pyjwt 2.12.1 / python-multipart 0.0.27 / starlette 1.0.1), so the ECR push + digest steps are skipped. Fix bumps the three deps to the CVE-fixed minimums via explicit security-floor constraints in pyproject.toml (matching the existing pyjwt CVE-2026-32597 pattern) and re-locks; Trivy never disabled or weakened. Resolved: pyjwt 2.13.0, python-multipart 0.0.32, starlette 1.3.1.
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: tests
+    description: >-
+      Trivy (same scanner/DB/severity gate as the CI step) reports 0 HIGH/CRITICAL on the re-locked uv.lock.
+    command: 'trivy fs --scanners vuln --severity CRITICAL,HIGH --ignore-unfixed --exit-code 1 uv.lock'
+  - kind: ci
+    description: CI pipeline green on PR
+    command: 'gh pr checks <PR> --repo OmniNode-ai/omnibase_infra'
+emergency_bypass:
+  enabled: false
+  justification: ''
+  follow_up_ticket_id: ''
+dod_evidence:
+  - id: dod-001
+    description: >-
+      pyproject.toml declares explicit security-floor constraints (pyjwt>=2.13.0, python-multipart>=0.0.30, starlette>=1.3.1) and uv.lock resolves all three at or above the CVE-fixed minimums.
+    source: generated
+    checks:
+      - check_type: command
+        check_value: >-
+          grep -q 'pyjwt>=2.13.0' pyproject.toml && grep -q 'python-multipart>=0.0.30' pyproject.toml && grep -q 'starlette>=1.3.1' pyproject.toml
+  - id: dod-002
+    description: >-
+      Trivy scan of the re-locked uv.lock returns 0 HIGH/CRITICAL (exit 0) with the identical CI severity gate.
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'trivy fs --scanners vuln --severity CRITICAL,HIGH --ignore-unfixed --exit-code 1 uv.lock'
+  - id: dod-003
+    description: >-
+      version_compatibility matrix + suite stay green after the dependency bump (pyproject remains the single source of truth).
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/unit/runtime/test_version_compatibility.py -q'

--- a/contracts/OMN-13666.yaml
+++ b/contracts/OMN-13666.yaml
@@ -1,0 +1,49 @@
+schema_version: '1.0.0'
+ticket_id: OMN-13666
+title: 'Runtime entrypoint: secondary-DB schema-fingerprint stamp failure is non-fatal (primary stays fatal)'
+summary: >-
+  The runtime image entrypoint (docker/entrypoint-runtime.sh) stamps schema fingerprints into db_metadata per-DB before starting the kernel. In prod, the runtime DB user lacks write permission on the omniintelligence (secondary, non-owned) database's db_metadata table, so its stamp failed with "permission denied for table db_metadata"; after 5 attempts the entrypoint exited 1 and the container crash-looped, holding all 7 onex-prod runtime deployments at 0/1. The runtime's OWN database (omnibase_infra) stamps fine. This fix introduces a principled required-vs-best-effort stamp policy in the entrypoint: the PRIMARY/owned DB (omnibase_infra) stamp stays REQUIRED — a failure after retries aborts boot loudly (exit 1) so a NULL/stale-fingerprint kernel never starts — while a SECONDARY/non-owned DB (omniintelligence) stamp is BEST-EFFORT — a failure logs a clear WARNING and boot proceeds (exit 0). No DB GRANT is added (operator chose the entrypoint-policy route). No gate is weakened.
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: tests
+    description: >-
+      Behavioral tests execute the real entrypoint with a stubbed python: a primary-DB stamp failure aborts boot (exit 1), a secondary-DB stamp failure warns and boot proceeds (exit 0); plus static source guards and shellcheck-clean.
+    command: 'uv run pytest tests/unit/docker/test_runtime_entrypoint_stamp_tolerance.py -q'
+  - kind: ci
+    description: CI pipeline green on PR
+    command: 'gh pr checks <PR> --repo OmniNode-ai/omnibase_infra'
+emergency_bypass:
+  enabled: false
+  justification: ''
+  follow_up_ticket_id: ''
+dod_evidence:
+  - id: dod-001
+    description: >-
+      Entrypoint marks the primary DB (omnibase_infra) stamp REQUIRED and the secondary DB (omniintelligence) stamp BEST-EFFORT.
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'grep -q ''stamp_fingerprint "omnibase_infra" "${OMNIBASE_INFRA_DB_URL}" "required"'' docker/entrypoint-runtime.sh && grep -q ''stamp_fingerprint "omniintelligence" "${OMNIINTELLIGENCE_DB_URL}" "optional"'' docker/entrypoint-runtime.sh'
+  - id: dod-002
+    description: >-
+      A required-stamp failure exits non-zero (fatal); the optional branch only warns (non-fatal continue).
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'grep -q ''if \[ "${REQUIRED}" = "required" \]; then'' docker/entrypoint-runtime.sh && grep -q "aborting boot" docker/entrypoint-runtime.sh && grep -q "continuing best-effort" docker/entrypoint-runtime.sh'
+  - id: dod-003
+    description: >-
+      Behavioral + static tests for the required/optional stamp policy pass.
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/unit/docker/test_runtime_entrypoint_stamp_tolerance.py -q'
+  - id: dod-004
+    description: >-
+      Entrypoint script is shellcheck-clean.
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'shellcheck docker/entrypoint-runtime.sh'

--- a/docker/entrypoint-runtime.sh
+++ b/docker/entrypoint-runtime.sh
@@ -66,6 +66,17 @@ echo "========================"
 # omniintelligence (e.g. code_entities, code_relationships), the stored
 # fingerprint was stale and the service failed health checks.
 #
+# OMN-13666: Required vs best-effort stamp policy.
+#   - The runtime's OWN database (omnibase_infra) is REQUIRED. Its db_metadata
+#     row drives the kernel's startup fingerprint assertion; if the stamp cannot
+#     succeed the kernel would start with a NULL/stale fingerprint and crash-loop
+#     anyway, so we fail FAST and loud here with a clear cause.
+#   - Secondary / non-owned databases (e.g. omniintelligence) are BEST-EFFORT.
+#     The runtime DB user legitimately lacks write permission on another
+#     service's db_metadata table ("permission denied for table db_metadata").
+#     A failure there must NOT take the whole runtime down -- it is logged as a
+#     WARNING and boot proceeds. The owning service stamps its own fingerprint.
+#
 # Retry logic: up to 5 attempts with 1s sleep between failures handles
 # transient DB-not-ready conditions at container startup.
 #
@@ -73,19 +84,19 @@ echo "========================"
 #   0 = success (fingerprint stamped)
 #   2 = schema mismatch (no point retrying -- bail immediately)
 #   1 = connection or general error (retry)
-#
-# Fail-open: kernel starts regardless of stamp outcome. The kernel's own
-# fingerprint assertion will catch any real problems.
 
 stamp_fingerprint() {
   # Stamp schema fingerprint for a single database.
-  # Usage: stamp_fingerprint <manifest_name> <db_url>
+  # Usage: stamp_fingerprint <manifest_name> <db_url> <required>
+  #   required="required" -> a failed stamp aborts boot (exit 1)
+  #   required="optional" -> a failed stamp warns and boot continues
   MANIFEST_NAME="$1"
   DB_URL="$2"
+  REQUIRED="$3"
 
   # Safe log: strip scheme and userinfo, show only host:port/db
   SAFE_DSN=$(echo "${DB_URL}" | sed 's|^[^/]*//[^@]*@||')
-  echo "[entrypoint] Stamping schema fingerprint for ${MANIFEST_NAME} (db: ${SAFE_DSN})..."
+  echo "[entrypoint] Stamping schema fingerprint for ${MANIFEST_NAME} (db: ${SAFE_DSN}, ${REQUIRED})..."
 
   STAMP_OK=0
   ATTEMPT=1
@@ -112,20 +123,24 @@ stamp_fingerprint() {
   done
 
   if [ "${STAMP_OK}" -eq 0 ]; then
-    echo "[entrypoint] WARNING: ${MANIFEST_NAME} fingerprint stamp did not succeed -- continuing"
+    if [ "${REQUIRED}" = "required" ]; then
+      echo "[entrypoint] ERROR: ${MANIFEST_NAME} (PRIMARY/owned DB) fingerprint stamp failed -- aborting boot" >&2
+      exit 1
+    fi
+    echo "[entrypoint] WARNING: ${MANIFEST_NAME} (secondary/non-owned DB) fingerprint stamp did not succeed -- continuing best-effort"
   fi
 }
 
-# Stamp omnibase_infra (primary, always required)
+# Stamp omnibase_infra (PRIMARY/owned DB -- REQUIRED: failure aborts boot)
 if [ -n "${OMNIBASE_INFRA_DB_URL:-}" ]; then
-  stamp_fingerprint "omnibase_infra" "${OMNIBASE_INFRA_DB_URL}"
+  stamp_fingerprint "omnibase_infra" "${OMNIBASE_INFRA_DB_URL}" "required"
 else
   echo "[entrypoint] OMNIBASE_INFRA_DB_URL not set -- skipping fingerprint stamp"
 fi
 
-# Stamp omniintelligence (optional, activates only when plugin DB is configured)
+# Stamp omniintelligence (SECONDARY/non-owned DB -- BEST-EFFORT: failure warns)
 if [ -n "${OMNIINTELLIGENCE_DB_URL:-}" ]; then
-  stamp_fingerprint "omniintelligence" "${OMNIINTELLIGENCE_DB_URL}"
+  stamp_fingerprint "omniintelligence" "${OMNIINTELLIGENCE_DB_URL}" "optional"
 else
   echo "[entrypoint] OMNIINTELLIGENCE_DB_URL not set -- skipping omniintelligence fingerprint stamp"
 fi

--- a/docker/runners/runner-image.lock.json
+++ b/docker/runners/runner-image.lock.json
@@ -1,12 +1,12 @@
 {
   "base_image_digest": "sha256:3ba65aa20f86a0fad9df2b2c259c613df006b2e6d0bfcc8a146afb8c525a9751",
   "gh_version": "2.67.0",
-  "identity_digest": "efc067283a47eb66bfae03322e966b0c",
+  "identity_digest": "36d88a277a3c3a10979bf7e4a142292b",
   "image_version": 5,
   "kubectl_version": "1.32.1",
   "python_version": "3.12",
   "runner_version": "2.334.0",
-  "shared_env_digest": "215aa5ffa92e228bf703615d",
+  "shared_env_digest": "bfc8a9fec199e4604ad96e1c",
   "shared_env_install_args": "--frozen --all-extras --all-groups --no-install-project",
   "uv_version": "0.6.14"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,8 +105,15 @@ dependencies = [
     "watchdog>=4.0.0", # Filesystem event monitoring (HandlerContractFileWatcher, OMN-3940)
     "a2a-sdk>=0.3.4,<1.0.0", # Real A2A client/server protocol support for remote-agent invocation
     # Security: CVE-2026-32597 (HIGH) - PyJWT <2.12.0 accepts unknown `crit` header extensions.
+    # Security: CVE-2026-48526 (HIGH) - PyJWT <2.13.0 authentication bypass via forged tokens.
     # Transitive dependency (via mcp/httpx/authlib). Explicitly declared to enforce minimum version.
-    "pyjwt>=2.12.0",
+    "pyjwt>=2.13.0",
+    # Security: CVE-2026-53539 (HIGH) - python-multipart <0.0.30 streaming-parser vulnerability.
+    # Transitive dependency (via fastapi/mcp). Explicitly declared to enforce the CVE-fixed minimum.
+    "python-multipart>=0.0.30",
+    # Security: CVE-2026-48818 + CVE-2026-54283 (HIGH) - starlette <1.3.1 SSRF/UNC and ASGI flaws.
+    # Transitive dependency (via fastapi/sse-starlette). Explicitly declared to enforce the CVE-fixed minimum.
+    "starlette>=1.3.1",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/tests/unit/docker/test_runtime_entrypoint_stamp_tolerance.py
+++ b/tests/unit/docker/test_runtime_entrypoint_stamp_tolerance.py
@@ -1,0 +1,186 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Regression tests for entrypoint schema-fingerprint stamp tolerance (OMN-13666).
+
+Policy under test:
+    * The runtime's OWN database (omnibase_infra) stamp is REQUIRED -- a failure
+      after all retries aborts boot (exit 1) so the crash cause is loud and the
+      kernel never starts with a NULL/stale fingerprint.
+    * A SECONDARY / non-owned database (omniintelligence) stamp is BEST-EFFORT --
+      a failure (e.g. "permission denied for table db_metadata") warns and boot
+      proceeds (exit 0).
+
+The behavioral tests execute the real ``docker/entrypoint-runtime.sh`` with a
+stubbed ``python`` on PATH whose exit code is driven per-manifest by env vars,
+so no Docker, Postgres, or privilege drop is involved. The CMD that the
+entrypoint exec's at the end is ``true`` (exit 0), so a clean run exits 0.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests.unit.docker.conftest import DOCKER_DIR
+
+pytestmark = [pytest.mark.unit]
+
+ENTRYPOINT = DOCKER_DIR / "entrypoint-runtime.sh"
+
+# Stub "python" that emulates util_schema_fingerprint stamp exit codes.
+# It parses the --manifest value out of its args and looks up an exit code from
+# an env var (STUB_RC_<MANIFEST>), defaulting to 0 (success). Any non-stamp
+# invocation (e.g. render modules, which the entrypoint guards behind unset env
+# vars and therefore never calls here) also exits 0.
+_PYTHON_STUB = """#!/bin/sh
+manifest=""
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "--manifest" ]; then
+    manifest="$arg"
+  fi
+  prev="$arg"
+done
+case "$manifest" in
+  omnibase_infra) exit "${STUB_RC_OMNIBASE_INFRA:-0}" ;;
+  omniintelligence) exit "${STUB_RC_OMNIINTELLIGENCE:-0}" ;;
+  *) exit 0 ;;
+esac
+"""
+
+
+def _run_entrypoint(
+    tmp_path: Path,
+    *,
+    infra_rc: int = 0,
+    intel_rc: int = 0,
+    with_intel_db: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    """Run the real entrypoint with a stubbed python and controlled stamp RCs."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    stub = bindir / "python"
+    stub.write_text(_PYTHON_STUB)
+    stub.chmod(stub.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+    env = {
+        # Minimal PATH: stub python first, then real sh/sed/echo/sleep tools.
+        "PATH": f"{bindir}:/usr/bin:/bin",
+        "OMNIBASE_INFRA_DB_URL": "postgresql://u:p@db:5432/omnibase_infra",
+        "STUB_RC_OMNIBASE_INFRA": str(infra_rc),
+        "STUB_RC_OMNIINTELLIGENCE": str(intel_rc),
+    }
+    if with_intel_db:
+        env["OMNIINTELLIGENCE_DB_URL"] = "postgresql://u:p@db:5432/omniintelligence"
+
+    # CMD the entrypoint exec's at the end; "true" exits 0 on a clean boot path.
+    return subprocess.run(
+        ["sh", str(ENTRYPOINT), "true"],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+
+
+def test_clean_stamp_both_dbs_boots() -> None:
+    """Both stamps succeed -> entrypoint reaches exec and exits 0."""
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as td:
+        result = _run_entrypoint(Path(td), infra_rc=0, intel_rc=0)
+    assert result.returncode == 0, result.stderr
+    assert "Schema fingerprint stamped for omnibase_infra." in result.stdout
+    assert "Schema fingerprint stamped for omniintelligence." in result.stdout
+    assert "Starting runtime kernel..." in result.stdout
+
+
+def test_secondary_db_stamp_failure_is_nonfatal() -> None:
+    """omniintelligence stamp fails (perm denied) -> WARNING, boot continues (exit 0)."""
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as td:
+        # rc=1 emulates "permission denied for table db_metadata" general error.
+        result = _run_entrypoint(Path(td), infra_rc=0, intel_rc=1)
+    assert result.returncode == 0, result.stderr
+    assert "Schema fingerprint stamped for omnibase_infra." in result.stdout
+    assert (
+        "WARNING: omniintelligence (secondary/non-owned DB) fingerprint stamp "
+        "did not succeed -- continuing best-effort" in result.stdout
+    )
+    # Boot proceeds past the stamp section.
+    assert "Starting runtime kernel..." in result.stdout
+
+
+def test_primary_db_stamp_failure_is_fatal() -> None:
+    """omnibase_infra stamp fails -> entrypoint aborts boot (exit 1), no kernel start."""
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as td:
+        result = _run_entrypoint(Path(td), infra_rc=1, intel_rc=0)
+    assert result.returncode == 1
+    assert (
+        "ERROR: omnibase_infra (PRIMARY/owned DB) fingerprint stamp failed "
+        "-- aborting boot" in result.stderr
+    )
+    # Must NOT reach kernel start when the primary DB stamp fails.
+    assert "Starting runtime kernel..." not in result.stdout
+
+
+def test_secondary_db_optional_when_db_url_unset() -> None:
+    """No OMNIINTELLIGENCE_DB_URL -> stamp skipped, boot proceeds (exit 0)."""
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as td:
+        result = _run_entrypoint(Path(td), infra_rc=0, with_intel_db=False)
+    assert result.returncode == 0, result.stderr
+    assert (
+        "OMNIINTELLIGENCE_DB_URL not set -- skipping omniintelligence "
+        "fingerprint stamp" in result.stdout
+    )
+    assert "Starting runtime kernel..." in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Static guards on the script source -- keep the required/optional contract.
+# ---------------------------------------------------------------------------
+
+
+def test_entrypoint_marks_primary_required_and_secondary_optional() -> None:
+    source = ENTRYPOINT.read_text()
+    assert (
+        'stamp_fingerprint "omnibase_infra" "${OMNIBASE_INFRA_DB_URL}" "required"'
+        in source
+    )
+    assert (
+        'stamp_fingerprint "omniintelligence" "${OMNIINTELLIGENCE_DB_URL}" "optional"'
+        in source
+    )
+
+
+def test_required_stamp_failure_exits_nonzero_in_source() -> None:
+    source = ENTRYPOINT.read_text()
+    # The required branch must exit non-zero; the optional branch must only warn.
+    assert 'if [ "${REQUIRED}" = "required" ]; then' in source
+    assert "exit 1" in source.split('if [ "${REQUIRED}" = "required" ]; then', 1)[1]
+
+
+def test_shellcheck_clean_if_available() -> None:
+    shellcheck = shutil.which("shellcheck")
+    if shellcheck is None:
+        pytest.skip("shellcheck not installed")
+    result = subprocess.run(
+        [shellcheck, str(ENTRYPOINT)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env={**os.environ},
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/uv.lock
+++ b/uv.lock
@@ -2131,6 +2131,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyjwt" },
+    { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "qdrant-client" },
     { name = "redis" },
@@ -2138,6 +2139,7 @@ dependencies = [
     { name = "sigstore" },
     { name = "slowapi" },
     { name = "sqlparse" },
+    { name = "starlette" },
     { name = "structlog" },
     { name = "tenacity" },
     { name = "textual" },
@@ -2204,7 +2206,8 @@ requires-dist = [
     { name = "psycopg2-binary", specifier = ">=2.9.10,<3.0.0" },
     { name = "pydantic", specifier = ">=2.11.7,<3.0.0" },
     { name = "pydantic-settings", specifier = ">=2.2.1,<3.0.0" },
-    { name = "pyjwt", specifier = ">=2.12.0" },
+    { name = "pyjwt", specifier = ">=2.13.0" },
+    { name = "python-multipart", specifier = ">=0.0.30" },
     { name = "pyyaml", specifier = ">=6.0.2,<7.0.0" },
     { name = "qdrant-client", specifier = ">=1.16.0,<2.0.0" },
     { name = "redis", specifier = ">=6.0.0,<9.0.0" },
@@ -2212,6 +2215,7 @@ requires-dist = [
     { name = "sigstore", specifier = ">=4.0.0,<5.0.0" },
     { name = "slowapi", specifier = ">=0.1.9,<0.2.0" },
     { name = "sqlparse", specifier = ">=0.4.4,<0.6.0" },
+    { name = "starlette", specifier = ">=1.3.1" },
     { name = "structlog", specifier = ">=23.2.0,<27.0.0" },
     { name = "tenacity", specifier = ">=9.0.0,<10.0.0" },
     { name = "textual", specifier = ">=0.89.0,<9.0.0" },
@@ -2873,11 +2877,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [package.optional-dependencies]
@@ -3037,11 +3041,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.27"
+version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043, upload-time = "2026-04-27T10:51:26.649Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254, upload-time = "2026-04-27T10:51:24.997Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
 ]
 
 [[package]]
@@ -3531,15 +3535,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.1"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/08/a3/84e821cc54b4ab50ae6dbc6ac3800a651b65ec35f045cc73785380654057/starlette-1.0.1.tar.gz", hash = "sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f", size = 2659596, upload-time = "2026-05-21T21:58:58.433Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/e1/b2df4bc09a1e51ff664c1e17018a4274b42e5e9352e4a478ea540512dc88/starlette-1.0.1-py3-none-any.whl", hash = "sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd", size = 72802, upload-time = "2026-05-21T21:58:56.551Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Context

**EMERGENCY PROD RECOVERY — OMN-13670 (operator-authorized).**

This is NOT a normal feature->dev->main promotion. This is a surgical hotfix applying only two already-reviewed-and-merged changes (dev PRs #2115 + #2124) directly to main, because:

1. The runtime ECR build (`build-and-push-runtime.yml`) has been red since 2026-06-07 (5 HIGH CVEs block Trivy gate → ECR push never completes → no fresh prod image can be built).
2. The prod runtime containers were crash-looping (all 7 deployments at 0/1) because the entrypoint exits 1 on omniintelligence DB permission errors.

The prod re-pin (re-tagging ECR digest + restarting containers) follows separately and is OMN-13418-gated (requires fresh CODEOWNERS-approved prod promotion grant). This PR does NOT deploy, restart, or touch any cluster.

## Changes

### OMN-13654 — CVE dep floors + relock

`pyproject.toml` adds explicit security-floor constraints matching the existing pyjwt CVE-2026-32597 pattern:

```
pyjwt>=2.13.0       (was >=2.12.0) — CVE-2026-48526: auth bypass via forged tokens
python-multipart>=0.0.30           — CVE-2026-53539: streaming-parser vulnerability
starlette>=1.3.1                   — CVE-2026-48818 + CVE-2026-54283: SSRF/UNC + ASGI flaws
```

`uv lock` resolves: pyjwt 2.13.0, python-multipart 0.0.32, starlette 1.3.1. Trivy gate passes 0 HIGH/CRITICAL at these versions.

**DoD evidence (dod-001):** `grep -q 'pyjwt>=2.13.0' pyproject.toml && grep -q 'python-multipart>=0.0.30' pyproject.toml && grep -q 'starlette>=1.3.1' pyproject.toml` — passes.

### OMN-13666 — entrypoint stamp tolerance

`docker/entrypoint-runtime.sh` introduces a principled required-vs-best-effort stamp policy:
- **PRIMARY/owned DB** (`omnibase_infra`): stamp is **REQUIRED** — failure aborts boot (exit 1) so a NULL/stale-fingerprint kernel never starts silently.
- **SECONDARY/non-owned DB** (`omniintelligence`): stamp is **BEST-EFFORT** — failure logs `WARNING` and boot continues. The runtime DB user legitimately lacks write permission on another service's `db_metadata` table.

New test file `tests/unit/docker/test_runtime_entrypoint_stamp_tolerance.py` provides 7 behavioral + static tests covering all policy branches.

**DoD evidence (dod-001):** static source guard: `stamp_fingerprint "omnibase_infra" "${OMNIBASE_INFRA_DB_URL}" "required"` and `stamp_fingerprint "omniintelligence" "${OMNIINTELLIGENCE_DB_URL}" "optional"` both present.

## dod_evidence

Evidence-Ticket: OMN-13670
Evidence-Source: OCC#3223
hotfix-evidence: OCC-3223
backmerge: #2124 (dev-equivalent entrypoint tolerance already merged; OMN-13654 dep floors merged via #2115)

Local gate results (2026-06-27):
- `uv run ruff format src/ tests/ && uv run ruff check --fix src/ tests/` — 0 issues
- `uv run mypy src/ --strict` — "Success: no issues found in 2442 source files"
- `uv run pytest tests/unit/docker/test_runtime_entrypoint_stamp_tolerance.py -q` — 7 passed
- `uv run pytest tests/unit/docker/ tests/unit/runtime/ tests/unit/migrations/ -q` — 5013 passed, 9 skipped, 0 failed (CI-mode: without OMNI_HOME)
- `pre-commit run --files <changed-files>` — all hooks pass (using OMNIMARKET_SRC=omnimarket@main, which is the correct comparison base for a main-targeting hotfix)

## Reconciliation Note

These hotfix commits are **equivalent** to dev PRs #2115 (OMN-13654) and #2124 (OMN-13666), which have already merged to dev. The changes were re-applied against the current main HEAD (commit `7200315b7`) rather than cherry-picked, to avoid dragging any dev-state alongside.

When the eventual full dev->main promotion lands (post-OMN-13418-approved prod re-pin), the dep floors and entrypoint changes will already be present on main. The promotion's merge will be clean: the dep version floor expressions are identical on both branches, and the entrypoint function signature and call sites are byte-for-byte equivalent.

**Migration vendor tree:** The `node-migration-sync` CI check compares against omnimarket dev. The vendored tree in main is in sync with omnimarket _main_ (verified locally: `OMNIMARKET_SRC=<omnimarket@main> bash scripts/sync-node-migrations.sh --check` → "in sync"). The node-migration-sync workflow will show a non-fatal diff (omnimarket dev has progressed since the last main promotion) — this is expected for any main-targeting PR during a period where dev leads. `node-migration-sync` is NOT a required status check for main merge.

## Post-merge

Prod re-pin (ECR retag + container restart) follows as a separate step, OMN-13418-gated with fresh CODEOWNERS-approved grant.