### PR TITLE
fix(OMN-13670): floor cryptography>=48.0.1 in runtime builder — clear last Trivy HIGH (emergency prod recovery)

### DIFF
--- a/contracts/OMN-13011.yaml
+++ b/contracts/OMN-13011.yaml
@@ -4,22 +4,7 @@ schema_version: "1.0.0"
 ticket_id: "OMN-13011"
 title: "LANE CENSUS RECONCILIATION ratchet — declared desired-state per lane, scheduled + on-demand, drift = auto-ticket"
 summary: >-
-  The class fix for the recurring lane-drift regression. Nothing reconciled the
-  declared desired state of a runtime lane against what is actually running, so
-  the same failure kept recurring with zero signal: volume config drift
-  (OMN-12945), WORKER_REPLICAS silent zero (OMN-12988/12990), and on 2026-06-11
-  prod runtime containers plus the broker network were silently absent for hours
-  during demo prep. This ships a per-lane DESIRED-STATE census: (a) DECLARED in a
-  versioned lane manifest (deploy/lane-census/lane-manifest.yaml) — container set,
-  network, replicas, image-tag pattern per lane (stability-test/prod/judge/dev),
-  derived from the canonical compose lane files; (b) RECONCILED on a schedule on
-  .201 by sharing the OMN-13008 systemd timer (a drop-in 4th ExecStart on
-  onex-disk-gc.service, never a second timer) and on-demand via runtime_sweep;
-  (c) drift = a typed bus event + Linear auto-ticket naming exactly what is
-  missing/extra (container_absent, network_detached, replicas_zero,
-  unexpected_container, oneshot_failed/stuck, image_tag_mismatch). Fail-fast,
-  no warn-only mode (gates-block policy). Builds on the OMN-12988 deploy-agent
-  RUNTIME census (deploy-time) as the complementary steady-state reconciler.
+  The class fix for the recurring lane-drift regression. Nothing reconciled the declared desired state of a runtime lane against what is actually running, so the same failure kept recurring with zero signal: volume config drift (OMN-12945), WORKER_REPLICAS silent zero (OMN-12988/12990), and on 2026-06-11 prod runtime containers plus the broker network were silently absent for hours during demo prep. This ships a per-lane DESIRED-STATE census: (a) DECLARED in a versioned lane manifest (deploy/lane-census/lane-manifest.yaml) — container set, network, replicas, image-tag pattern per lane (stability-test/prod/judge/dev), derived from the canonical compose lane files; (b) RECONCILED on a schedule on .201 by sharing the OMN-13008 systemd timer (a drop-in 4th ExecStart on onex-disk-gc.service, never a second timer) and on-demand via runtime_sweep; (c) drift = a typed bus event + Linear auto-ticket naming exactly what is missing/extra (container_absent, network_detached, replicas_zero, unexpected_container, oneshot_failed/stuck, image_tag_mismatch). Fail-fast, no warn-only mode (gates-block policy). Builds on the OMN-12988 deploy-agent RUNTIME census (deploy-time) as the complementary steady-state reconciler.
 is_seam_ticket: false
 interface_change: false
 interfaces_touched: []
@@ -31,22 +16,14 @@ evidence_requirements:
   - kind: "tests"
     description: "Event-builder, manifest-parity, dry-run, and timer-dropin tests pass"
     command: >-
-      uv run pytest
-      tests/unit/scripts/test_lane_census_event.py
-      tests/unit/scripts/test_lane_census_manifest_parity.py
-      tests/unit/scripts/test_lane_census_dry_run.py
-      tests/unit/scripts/test_lane_census_timer_dropin.py -q
+      uv run pytest tests/unit/scripts/test_lane_census_event.py tests/unit/scripts/test_lane_census_manifest_parity.py tests/unit/scripts/test_lane_census_dry_run.py tests/unit/scripts/test_lane_census_timer_dropin.py -q
   - kind: "ci"
     description: "New source passes ruff and mypy --strict"
     command: >-
-      uv run ruff check scripts/lane_census_plan.py scripts/lane_census_event.py
-      && uv run mypy scripts/lane_census_plan.py scripts/lane_census_event.py --strict
+      uv run ruff check scripts/lane_census_plan.py scripts/lane_census_event.py && uv run mypy scripts/lane_census_plan.py scripts/lane_census_event.py --strict
   - kind: "manual"
     description: >-
-      On .201, after OMN-13008's install-disk-gc.sh, run
-      deploy/lane-census/install-lane-census.sh and confirm via
-      `systemctl --user cat onex-disk-gc.service` that the lane-census ExecStart
-      is the 4th pass on the shared unit (no second timer)
+      On .201, after OMN-13008's install-disk-gc.sh, run deploy/lane-census/install-lane-census.sh and confirm via `systemctl --user cat onex-disk-gc.service` that the lane-census ExecStart is the 4th pass on the shared unit (no second timer)
 emergency_bypass:
   enabled: false
   justification: ""

--- a/contracts/OMN-13141.yaml
+++ b/contracts/OMN-13141.yaml
@@ -5,15 +5,7 @@ schema_version: "1.0.0"
 ticket_id: "OMN-13141"
 title: "fix(OMN-13141): runtime executor skips event_model import for operation_match entries"
 summary: >-
-  Executor companion to OMN-13137's validator half (#1973, merged). _run_event_driven
-  unconditionally imported entry.event_model_module for every resolved routing entry.
-  operation_match entries declare no event_model, so event_model_module is empty and
-  importlib.import_module("") raised ValueError: Empty module name — not caught by the
-  (ImportError, AttributeError) clause, swallowed by the outer except in run_async ->
-  result FAILED. The node never booted end-to-end (e.g. node_integration_sweep_orchestrator).
-  Fix gates the import on a non-empty event_model_module: operation_match forwards the raw
-  decoded payload (input_model_cls=None); only payload_type_match resolves a typed event
-  model. _validate_routing (the OMN-13137 half) is left untouched.
+  Executor companion to OMN-13137's validator half (#1973, merged). _run_event_driven unconditionally imported entry.event_model_module for every resolved routing entry. operation_match entries declare no event_model, so event_model_module is empty and importlib.import_module("") raised ValueError: Empty module name — not caught by the (ImportError, AttributeError) clause, swallowed by the outer except in run_async -> result FAILED. The node never booted end-to-end (e.g. node_integration_sweep_orchestrator). Fix gates the import on a non-empty event_model_module: operation_match forwards the raw decoded payload (input_model_cls=None); only payload_type_match resolves a typed event model. _validate_routing (the OMN-13137 half) is left untouched.
 is_seam_ticket: false
 interface_change: false
 interfaces_touched: []
@@ -37,9 +29,7 @@ dod_evidence:
         check_value: "test -f contracts/OMN-13141.yaml"
   - id: "dod-boot-e2e"
     description: >-
-      operation_match contract boots end-to-end through RuntimeLocal.run_async()
-      with no empty-module ValueError, and the payload_type_match import path is
-      unchanged (regression guard). This boot test is the CI gate for the fix.
+      operation_match contract boots end-to-end through RuntimeLocal.run_async() with no empty-module ValueError, and the payload_type_match import path is unchanged (regression guard). This boot test is the CI gate for the fix.
     source: "manual"
     checks:
       - check_type: "command"
@@ -52,10 +42,7 @@ dod_evidence:
         check_value: "uv run pytest tests/unit/runtime/ -q"
   - id: "dod-deploy"
     description: >-
-      Deploy validation: change is an internal correctness fix to the local-runtime
-      event-driven executor (_run_event_driven) and its bus adapter. No new Kafka topics,
-      no schema changes, no container image changes, no API surface changes. Runtime
-      restart picks up the change automatically on next deploy.
+      Deploy validation: change is an internal correctness fix to the local-runtime event-driven executor (_run_event_driven) and its bus adapter. No new Kafka topics, no schema changes, no container image changes, no API surface changes. Runtime restart picks up the change automatically on next deploy.
     source: "manual"
     checks:
       - check_type: "command"

--- a/contracts/OMN-13149.yaml
+++ b/contracts/OMN-13149.yaml
@@ -5,18 +5,7 @@ schema_version: "1.0.0"
 ticket_id: "OMN-13149"
 title: "fix(OMN-13149): savings_estimation consumer decodes typed ModelEventMessage instead of calling .get()"
 summary: >-
-  The savings-estimation consumer is wired in service_kernel via event_bus.subscribe;
-  both the Kafka and in-memory buses deliver a typed ModelEventMessage to the
-  on_message callback. The pre-fix _savings_on_message did json.loads only when msg
-  was str/bytes and otherwise passed the value through unchanged, so a ModelEventMessage
-  reached ServiceSavingsEstimator.ingest_event -> _session_id_for_topic, which calls
-  payload.get("session_id"). ModelEventMessage has no .get(), raising
-  AttributeError: 'ModelEventMessage' object has no attribute 'get' at runtime — the
-  consumer wrote zero rows. Fix adds module-level decode_event_message(message) that
-  reads the JSON payload off the typed .value field directly (strongly typed, fail-fast:
-  raises TypeError on a non-object payload — no getattr-default, no dict-style fallback).
-  The kernel callback now decodes then calls ingest_event(topic, payload). Same
-  dict/typed-model family as OMN-13141 / golden-chain BUG A.
+  The savings-estimation consumer is wired in service_kernel via event_bus.subscribe; both the Kafka and in-memory buses deliver a typed ModelEventMessage to the on_message callback. The pre-fix _savings_on_message did json.loads only when msg was str/bytes and otherwise passed the value through unchanged, so a ModelEventMessage reached ServiceSavingsEstimator.ingest_event -> _session_id_for_topic, which calls payload.get("session_id"). ModelEventMessage has no .get(), raising AttributeError: 'ModelEventMessage' object has no attribute 'get' at runtime — the consumer wrote zero rows. Fix adds module-level decode_event_message(message) that reads the JSON payload off the typed .value field directly (strongly typed, fail-fast: raises TypeError on a non-object payload — no getattr-default, no dict-style fallback). The kernel callback now decodes then calls ingest_event(topic, payload). Same dict/typed-model family as OMN-13141 / golden-chain BUG A.
 is_seam_ticket: false
 interface_change: false
 interfaces_touched: []
@@ -40,10 +29,7 @@ dod_evidence:
         check_value: "test -f contracts/OMN-13149.yaml"
   - id: "dod-typed-message-regression"
     description: >-
-      Through the REAL consumer path (EventBusInmemory.subscribe/publish ->
-      on_message(ModelEventMessage) -> decode_event_message -> ingest_event) a typed
-      ModelEventMessage correlates a session; the pre-fix path (typed message straight
-      to ingest_event) reproduces AttributeError. This is the CI gate for the fix.
+      Through the REAL consumer path (EventBusInmemory.subscribe/publish -> on_message(ModelEventMessage) -> decode_event_message -> ingest_event) a typed ModelEventMessage correlates a session; the pre-fix path (typed message straight to ingest_event) reproduces AttributeError. This is the CI gate for the fix.
     source: "manual"
     checks:
       - check_type: "command"
@@ -56,10 +42,7 @@ dod_evidence:
         check_value: "uv run pytest tests/unit/runtime/ tests/unit/services/observability/savings_estimation/ -q"
   - id: "dod-deploy"
     description: >-
-      Deploy validation: change is an internal correctness fix to the savings-estimation
-      consumer wiring in service_kernel (_savings_on_message) plus a module-level decode
-      helper in the consumer. No new Kafka topics, no schema changes, no container image
-      changes, no API surface changes. Runtime restart picks up the change on next deploy.
+      Deploy validation: change is an internal correctness fix to the savings-estimation consumer wiring in service_kernel (_savings_on_message) plus a module-level decode helper in the consumer. No new Kafka topics, no schema changes, no container image changes, no API surface changes. Runtime restart picks up the change on next deploy.
     source: "manual"
     checks:
       - check_type: "command"

--- a/deploy/lane-census/lane-manifest.yaml
+++ b/deploy/lane-census/lane-manifest.yaml
@@ -42,12 +42,9 @@
 # resolved runtime version; absence of a resolved tag relaxes the check to the
 # default pattern (never a hard failure on an unresolvable tag — that is a
 # separate signal, not a census drift).
-
 schema_version: "1.0.0"
-
 # Default image-tag pattern applied to a lane that does not override it.
 default_image_tag_pattern: '.+'
-
 lanes:
   stability-test:
     compose_file: docker/docker-compose.stability-test.yml
@@ -89,7 +86,6 @@ lanes:
       - name: omninode-stability-test-runtime-worker
         kind: service
         replicas: 1
-
   prod:
     compose_file: docker/docker-compose.prod.yml
     compose_project: omnibase-infra-prod
@@ -126,7 +122,6 @@ lanes:
       - name: omninode-prod-runtime-worker
         kind: service
         replicas: 1
-
   judge:
     compose_file: docker/docker-compose.judge.yml
     compose_project: omnibase-infra-judge
@@ -159,7 +154,6 @@ lanes:
       - name: omnimarket-judge-projection-api
         kind: service
         replicas: 1
-
   # The dev lane (compose project `omnibase-infra`, the default infra stack) uses
   # generated compose with non-prefixed container names; its census is the
   # deploy-agent RUNTIME-scope verifier (OMN-12988). The lane manifest treats dev

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -384,6 +384,12 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv-with-retry pip install "setuptools>=78.1.1"
 
+# Security: upgrade cryptography to clear GHSA-537c-gmf6-5ccf (HIGH, fixed in >=48.0.1).
+# cryptography 46.0.7 (from transitive deps) is flagged by Trivy scan (ignore-unfixed: true).
+# Force upgrade here after all plugin installs to ensure the patched version is present.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv-with-retry pip install "cryptography>=48.0.1"
+
 # Verify torch is CPU-only (torch.version.cuda must be None, no nvidia packages)
 RUN /app/.venv/bin/python -c "\
 import torch, pkgutil; \

--- a/docker/migrations/skip-manifest.yaml
+++ b/docker/migrations/skip-manifest.yaml
@@ -30,5 +30,4 @@
 # EXIT CODES for run-forward-migrations.sh
 #   0 — all migrations applied (or skipped by this manifest)
 #   1 — migration failure (nonzero psql exit)
-
 skipped_migrations: []

--- a/scripts/lane_census_event.py
+++ b/scripts/lane_census_event.py
@@ -128,7 +128,6 @@ def build_event(
 
 
 def main() -> int:
-
     host = os.environ.get("LANE_CENSUS_HOST", "")
     if not host:
         # Fail-fast: never silently fabricate a host into the alert_key.

--- a/src/omnibase_infra/nodes/node_bus_forwarder_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_bus_forwarder_effect/contract.yaml
@@ -13,13 +13,10 @@ node_version:
   minor: 1
   patch: 0
 description: >
-  Trust-boundary effect node that mirrors contract-declared tenant gateway
-  topics between a local runtime bus and the hosted cloud Kafka edge. The node
-  owns all publishes; handlers only validate and return transformed envelopes.
+  Trust-boundary effect node that mirrors contract-declared tenant gateway topics between a local runtime bus and the hosted cloud Kafka edge. The node owns all publishes; handlers only validate and return transformed envelopes.
 
 runtime_profiles:
   - effects
-
 input_model:
   name: "ModelGatewayEnvelope"
   module: "omnibase_infra.nodes.node_bus_forwarder_effect.models.model_gateway_envelope"
@@ -28,7 +25,6 @@ output_model:
   name: "ModelGatewayEnvelope"
   module: "omnibase_infra.nodes.node_bus_forwarder_effect.models.model_gateway_envelope"
   description: "Validated gateway envelope after prefix add/strip transformation."
-
 config:
   name: "ModelGatewayForwarderConfig"
   module: "omnibase_infra.nodes.node_bus_forwarder_effect.models.model_gateway_forwarder_config"
@@ -61,7 +57,6 @@ config:
       drain_deadline_seconds: 30
     dedupe:
       retention_hours: 24
-
 event_bus:
   subscribe_topics:
     - "onex.cmd.omnibase-infra.delegation-inference-request.v1"
@@ -71,7 +66,6 @@ event_bus:
     - "onex.cmd.omnibase-infra.delegation-inference-request.v1"
     - "onex.evt.omnibase-infra.inference-response.v1"
     - "onex.evt.omnibase-infra.gateway-heartbeat.v1"
-
 handler_routing:
   routing_strategy: "operation_match"
   handlers:
@@ -87,7 +81,6 @@ handler_routing:
         module: "omnibase_infra.nodes.node_bus_forwarder_effect.handlers.handler_consume_inbound"
         handler_type: "COMPUTE"
       description: "Validate tenant-prefixed cloud topic and strip to a bare local topic."
-
 capabilities:
   - name: "tenant_prefix_transform"
     description: "Adds and strips tenant wire prefixes with envelope validation."
@@ -95,7 +88,6 @@ capabilities:
     description: "Rejects any canonical topic not declared in mirror topic sets."
   - name: "node_owned_publish"
     description: "Handlers never publish; the effect node owns both bus legs."
-
 metadata:
   description: "Hybrid gateway local runtime bus forwarder"
   author: "OmniNode Team"


### PR DESCRIPTION
## Context

**EMERGENCY PROD RECOVERY — OMN-13670 follow-up (operator-authorized).**

This is a surgical one-line hotfix completing the Trivy remediation started in PR #2128. PR #2128 cleared 4 of 5 HIGH CVEs (pyjwt, python-multipart, starlette via pyproject.toml floors; plus setuptools and protobuf via Dockerfile floors). One HIGH remains:

- **GHSA-537c-gmf6-5ccf** — `cryptography` 46.0.7 flagged by Trivy (ignore-unfixed: true); fixed in >=48.0.1.

This PR adds `cryptography>=48.0.1` as a build-time pip floor in the BUILDER stage of `docker/Dockerfile.runtime`, matching the existing protobuf/setuptools floor pattern exactly.

This PR does NOT deploy, restart, or touch any cluster. The prod re-pin follows separately under OMN-13418 gating.

## Changes

`docker/Dockerfile.runtime` — adds after the setuptools floor block:

```dockerfile
# Security: upgrade cryptography to clear GHSA-537c-gmf6-5ccf (HIGH, fixed in >=48.0.1).
# cryptography 46.0.7 (from transitive deps) is flagged by Trivy scan (ignore-unfixed: true).
# Force upgrade here after all plugin installs to ensure the patched version is present.
RUN --mount=type=cache,target=/root/.cache/uv \
    uv-with-retry pip install "cryptography>=48.0.1"
```

Also includes yamlfmt and ruff format auto-fixes on pre-existing files (collateral cleanup).

## dod_evidence

Evidence-Ticket: OMN-13670
Evidence-Source: PENDING_OCC_SHA
Evidence-Class: hotfix
Active-Hotfix-PR: #THIS
hotfix-evidence: OCC-PENDING
backmerge: cryptography floor only — no pyproject.toml change; no uv.lock relock needed (cryptography is already pinned above 48.0.1 in uv.lock via transitive resolution)

Local gate results (2026-06-28):
- `uv run ruff format src/ tests/ && uv run ruff check src/ tests/` — 0 issues
- `pre-commit run --all-files` — yamlfmt+ruff auto-fixes staged; pre-existing hook failures on main are unrelated to this Dockerfile change (transport-mock-lint, node-migration-sync, runtime-profiles, spdx-headers, topic-parity all pre-date this PR)
- Dockerfile diff: adds exactly 6 lines matching the protobuf/setuptools floor pattern

## Reconciliation Note

The `node-migration-sync` CI check is NOT a required status check for main merge (confirmed in PR #2128 reconciliation note — omnimarket dev leads main during active development). This hotfix targets main only for the Dockerfile change.