### PR TITLE
fix(OMN-13687): bounded retry on docker push to ECR — absorb transient runner→ECR EOF (emergency prod recovery)

### DIFF
--- a/.github/workflows/build-and-push-runtime.yml
+++ b/.github/workflows/build-and-push-runtime.yml
@@ -192,12 +192,46 @@ jobs:
       - name: Push image to Amazon ECR
         if: success()
         shell: bash
+        env:
+          # OMN-13687: bounded retry config for the docker push. Mirrors the
+          # exponential-backoff idiom in .github/actions/resolve-ecr-digest.
+          PUSH_MAX_ATTEMPTS: '5'
+          PUSH_INITIAL_DELAY: '10'
+          PUSH_MAX_DELAY: '120'
+          PUSH_BACKOFF_FACTOR: '2'
         run: |
           echo "Trivy scan passed — pushing image to ECR..."
+          # OMN-13687: wrap `docker push` in a bounded retry loop to absorb the
+          # transient network EOF on a blob HEAD seen on the .201 self-hosted
+          # runner -> ECR path. Additive only: image tags and digest
+          # computation are unchanged; this only retries the network push.
+          push_with_retry() {
+            local tag="$1"
+            local delay="$PUSH_INITIAL_DELAY"
+            local attempt
+            for attempt in $(seq 1 "$PUSH_MAX_ATTEMPTS"); do
+              echo "Attempt ${attempt}/${PUSH_MAX_ATTEMPTS}: docker push ${tag}"
+              if docker push "${tag}"; then
+                echo "Pushed ${tag} on attempt ${attempt}"
+                return 0
+              fi
+              if [[ "${attempt}" -lt "$PUSH_MAX_ATTEMPTS" ]]; then
+                echo "::warning::push attempt ${attempt} for ${tag} failed; retrying in ${delay}s..."
+                sleep "${delay}"
+                delay=$((delay * PUSH_BACKOFF_FACTOR))
+                if [[ "${delay}" -gt "$PUSH_MAX_DELAY" ]]; then
+                  delay="$PUSH_MAX_DELAY"
+                fi
+              fi
+            done
+            echo "::error::docker push ${tag} failed after ${PUSH_MAX_ATTEMPTS} attempts"
+            return 1
+          }
+
           IFS=',' read -ra TAGS <<< "${{ steps.meta.outputs.tags }}"
           for TAG in "${TAGS[@]}"; do
             echo "Pushing: ${TAG}"
-            docker push "${TAG}"
+            push_with_retry "${TAG}"
           done
           echo "All tags pushed successfully"
 


### PR DESCRIPTION
## Context

**EMERGENCY PROD RECOVERY — OMN-13687 (operator-authorized).**

The runtime image build (`build-and-push-runtime.yml`) builds and Trivy-scans cleanly on main HEAD `2cd720817` (the OMN-13670 crypto-floor hotfix #2131), but the final `docker push` to ECR repeatedly fails with a transient network EOF on a single blob HEAD request from the `.201` self-hosted runner fleet to `272493677981.dkr.ecr.us-east-1.amazonaws.com`. Two fresh `workflow_dispatch` runs on main today (runs 28315044412, 28315257828) both pushed several blobs successfully, then died on a blob HEAD with:

```
failed to do request: Head ".../v2/omninode-runtime/blobs/sha256:d08926bc...": EOF
```

Because the EOF recurs across different runs/runners, it is not one bad runner. No fresh `omninode-runtime` image has reached ECR since 2026-05-25 (`sha256:de9a7a4c`), which blocks the OMN-13418-gated prod re-pin.

## Change

Wrap the `docker push` in `build-and-push-runtime.yml` in a bounded retry loop (5 attempts, exponential backoff 10s, 20s, 40s, 80s, cap 120s), mirroring the existing exponential-backoff resilience idiom already used by `.github/actions/resolve-ecr-digest`. `docker push` is resumable -- already-pushed blobs are skipped on retry -- so retrying absorbs the transient blob-HEAD EOF.

**Additive only.** The build, the image tag/digest computation, the lineage-guard, and the Trivy step are all unchanged. Only the network push is retried.

This PR does NOT deploy, restart, retag, or touch any cluster or `.201` host config. The prod re-pin follows separately under OMN-13418 gating.

## dod_evidence

Evidence-Ticket: OMN-13687
Evidence-Source: OCC#3241
Evidence-Class: hotfix
Active-Hotfix-PR: this PR

hotfix-evidence: OCC-3241
backmerge: #2131

Local gate results (2026-06-28):
- `pre-commit run --files .github/workflows/build-and-push-runtime.yml` -- all applicable hooks Passed (yamlfmt, skip-token rejector, root-cleanliness, etc.)
- `yaml.safe_load(...)` on the workflow -- YAML valid
- Diff: +35 / -1, scoped entirely to the `Push image to Amazon ECR` step

## Backmerge note

The workflow retry loop should also land on `dev` to prevent re-divergence on the next dev to main promotion; tracked under OMN-13687. `backmerge: #2131` references the prior emergency-recovery hotfix in the same OMN-13670/OMN-13687 recovery chain (same pattern #2131 used referencing #2128).

check-refresh: 2026-06-28T08:16:54Z