### PR TITLE
feat(OMN-13043): typed Durable-findings / Runtime-state-as-of sections in deep-dive generator

### DIFF
--- a/scripts/generate_deep_dive.py
+++ b/scripts/generate_deep_dive.py
@@ -423,6 +423,14 @@ def find_git_repos_direct_children(root: Path) -> list[Path]:
 
 _FAMILY_RE = re.compile(r"^(omni\w+?)(\d+)$")
 
+# Regex that matches the typed Runtime State section header emitted by this
+# generator.  Group 1 captures the ISO-8601 UTC timestamp (minute precision).
+# Example: ## Runtime State — as of 2026-06-28T14:30Z
+_RUNTIME_STATE_RE = re.compile(
+    r"^## Runtime State — as of (\d{4}-\d{2}-\d{2}T\d{2}:\d{2}Z)",
+    re.MULTILINE,
+)
+
 
 def family_key(repo_name: str) -> str | None:
     """
@@ -877,6 +885,84 @@ def unique_commit_entries(repo_days: list[RepoDay]) -> list[CommitEntry]:
     return uniq
 
 
+def _now_utc_iso_minutes() -> str:
+    """Return current UTC time as YYYY-MM-DDTHH:MMZ (minute precision)."""
+    return dt.datetime.now(dt.UTC).strftime("%Y-%m-%dT%H:%MZ")
+
+
+def parse_runtime_state_timestamp(text: str) -> dt.datetime | None:
+    """Extract the UTC datetime from a '## Runtime State — as of' header.
+
+    Returns a UTC-aware :class:`datetime.datetime` or ``None`` when the
+    section is absent or the timestamp is malformed.
+
+    The expected header format is::
+
+        ## Runtime State — as of YYYY-MM-DDTHH:MMZ
+
+    Args:
+        text: Full Markdown content of a deep-dive document.
+
+    Returns:
+        A UTC-aware datetime on success, or ``None``.
+    """
+    m = _RUNTIME_STATE_RE.search(text)
+    if not m:
+        return None
+    try:
+        return dt.datetime.fromisoformat(m.group(1).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def validate_deep_dive_ingest(
+    deep_dive_path: Path,
+    handoff_cutoff: dt.datetime,
+) -> tuple[bool, str]:
+    """Check that a deep-dive's Runtime State section is not stale.
+
+    A deep-dive is safe to ingest when its ``## Runtime State — as of``
+    timestamp is **equal to or newer than** *handoff_cutoff*.  A missing
+    section is always refused because its freshness is unknown.
+
+    Args:
+        deep_dive_path: Path to the deep-dive Markdown file.
+        handoff_cutoff: UTC-aware datetime representing the probe time of the
+            corresponding final handoff.  Documents whose runtime-state
+            timestamp predates this cutoff are considered stale.
+
+    Returns:
+        A ``(ok, message)`` tuple.  *ok* is ``True`` when the document is
+        safe to ingest; *message* describes the outcome either way.
+    """
+    try:
+        text = deep_dive_path.read_text(encoding="utf-8")
+    except OSError as e:
+        return False, f"cannot read {deep_dive_path}: {e}"
+
+    ts = parse_runtime_state_timestamp(text)
+    if ts is None:
+        return False, (
+            f"{deep_dive_path.name}: missing '## Runtime State — as of <timestamp>' "
+            "section; add it or regenerate with generate_deep_dive.py"
+        )
+
+    # Normalise cutoff to UTC-aware for comparison.
+    if handoff_cutoff.tzinfo is None:
+        handoff_cutoff = handoff_cutoff.replace(tzinfo=dt.UTC)
+
+    if ts < handoff_cutoff:
+        return False, (
+            f"{deep_dive_path.name}: runtime state is stale: "
+            f"section timestamp {ts.isoformat()} < handoff cutoff {handoff_cutoff.isoformat()}"
+        )
+
+    return True, (
+        f"{deep_dive_path.name}: runtime state is fresh "
+        f"({ts.isoformat()} >= {handoff_cutoff.isoformat()})"
+    )
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     _default_root = os.environ.get("OMNI_HOME", ".")
@@ -907,7 +993,49 @@ def main() -> int:
         default=False,
         help="Include repos that only have dirty working trees (no commits today). Default: False.",
     )
+    ap.add_argument(
+        "--validate-ingest",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help=(
+            "Validate an existing deep-dive for corpus ingestion. "
+            "Exits 0 if the '## Runtime State — as of' section is not stale "
+            "relative to --handoff-time, non-zero otherwise."
+        ),
+    )
+    ap.add_argument(
+        "--handoff-time",
+        type=str,
+        default=None,
+        metavar="ISO-TIMESTAMP",
+        help=(
+            "UTC probe time of the corresponding final handoff, "
+            "e.g. '2026-06-28T14:30Z'. Required when --validate-ingest is used."
+        ),
+    )
     args = ap.parse_args()
+
+    # Validation mode: check an existing deep-dive for staleness and exit.
+    if args.validate_ingest is not None:
+        if not args.handoff_time:
+            print(
+                "error: --handoff-time is required with --validate-ingest", flush=True
+            )
+            return 2
+        try:
+            cutoff = dt.datetime.fromisoformat(args.handoff_time.replace("Z", "+00:00"))
+        except ValueError:
+            print(
+                f"error: --handoff-time '{args.handoff_time}' is not a valid ISO-8601 timestamp",
+                flush=True,
+            )
+            return 2
+        ok, msg = validate_deep_dive_ingest(
+            Path(args.validate_ingest).expanduser().resolve(), cutoff
+        )
+        print(msg, flush=True)
+        return 0 if ok else 1
 
     date = _today_local() if not args.date else dt.date.fromisoformat(args.date)
     start_s, end_s = _day_window(date)
@@ -1453,6 +1581,53 @@ def main() -> int:
         weight = _CATEGORY_WEIGHTS.get(cat, 0.5)
         points = count * weight
         lines.append(f"| {cat} | {count} | {weight} | {points:.1f} |")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    # -----------------------------------------------------------------------
+    # Typed sections: Durable Findings vs Runtime State (OMN-13043 / C-3)
+    #
+    # Durable Findings: structural observations from commit and PR history.
+    # These remain valid until the referenced code is changed.
+    #
+    # Runtime State: ephemeral observations captured at generation time.
+    # The '## Runtime State — as of' header carries a machine-readable
+    # UTC timestamp used by --validate-ingest to gate corpus ingestion.
+    # -----------------------------------------------------------------------
+    lines.append("## Durable Findings")
+    lines.append("")
+    lines.append(
+        "*Structural findings derived from commit and PR history in this report.*"
+    )
+    lines.append("*These remain valid until the referenced code is changed.*")
+    lines.append("")
+    lines.append(
+        "<!-- Operator: promote session retrospective findings here. "
+        "Each entry must cite a commit SHA or PR number as evidence. -->"
+    )
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    _state_ts = _now_utc_iso_minutes()
+    lines.append(f"## Runtime State — as of {_state_ts}")
+    lines.append("")
+    lines.append("*Ephemeral runtime observations captured at generation time.*")
+    lines.append("*This section has a bounded lifetime — it becomes stale once the*")
+    lines.append("*runtime state changes.  Use*")
+    lines.append(
+        "*`generate_deep_dive.py --validate-ingest <path> --handoff-time <ISO>`*"
+    )
+    lines.append("*to check freshness before corpus ingestion.*")
+    lines.append("")
+    drift_emoji2 = {"green": "green", "yellow": "yellow", "red": "red"}.get(
+        drift.level, drift.level
+    )
+    lines.append(f"- **Drift level at generation**: {drift_emoji2}")
+    lines.append(f"- **Main-dirty repos**: {drift.main_dirty}")
+    lines.append(f"- **Stale feature branches (>72h)**: {drift.stale_branches}")
+    lines.append(f"- **Active worktrees**: {drift.active_worktrees}")
     lines.append("")
     lines.append("---")
     lines.append("")

--- a/tests/unit/scripts/test_deep_dive_typed_sections.py
+++ b/tests/unit/scripts/test_deep_dive_typed_sections.py
@@ -1,0 +1,262 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for typed Durable-findings / Runtime-state-as-of sections in generate_deep_dive.py.
+
+Covers OMN-13043 (C-3 retro item): the generator must produce typed section
+headers so that stale runtime-state claims can't poison the corpus.
+
+Validates:
+  - parse_runtime_state_timestamp: extracts the UTC datetime from a
+    '## Runtime State — as of <YYYY-MM-DDTHH:MMZ>' header.
+  - validate_deep_dive_ingest: rejects deep-dives whose Runtime State
+    section is older than the provided handoff cutoff.
+  - Generated output: both '## Durable Findings' and
+    '## Runtime State — as of' sections are present in generated Markdown.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import importlib.util
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_REPO = Path(__file__).resolve().parents[3]
+_SCRIPT = _REPO / "scripts" / "generate_deep_dive.py"
+
+
+def _load_module() -> Any:
+    spec = importlib.util.spec_from_file_location("generate_deep_dive", _SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    # Use a distinct module key to avoid interfering with other test files
+    # that also load generate_deep_dive under the name "generate_deep_dive".
+    sys.modules.setdefault("generate_deep_dive", mod)
+    spec.loader.exec_module(mod)
+    return sys.modules["generate_deep_dive"]
+
+
+MOD = _load_module()
+
+_UTC = ZoneInfo("UTC")
+
+
+# ---------------------------------------------------------------------------
+# parse_runtime_state_timestamp
+# ---------------------------------------------------------------------------
+
+
+class TestParseRuntimeStateTimestamp:
+    """parse_runtime_state_timestamp must return a UTC-aware datetime or None."""
+
+    def test_valid_header_returns_datetime(self) -> None:
+        text = (
+            "## Some header\n\n"
+            "## Runtime State — as of 2026-06-28T14:30Z\n\n"
+            "Some content."
+        )
+        ts = MOD.parse_runtime_state_timestamp(text)
+        assert ts is not None
+        assert ts.year == 2026
+        assert ts.month == 6
+        assert ts.day == 28
+        assert ts.hour == 14
+        assert ts.minute == 30
+        assert ts.tzinfo is not None
+
+    def test_missing_section_returns_none(self) -> None:
+        text = "## Durable Findings\n\nSome findings.\n"
+        assert MOD.parse_runtime_state_timestamp(text) is None
+
+    def test_malformed_timestamp_returns_none(self) -> None:
+        text = "## Runtime State — as of NOT-A-DATE\n\nContent."
+        assert MOD.parse_runtime_state_timestamp(text) is None
+
+    def test_timestamp_is_utc_aware(self) -> None:
+        text = "## Runtime State — as of 2026-01-01T00:00Z\n"
+        ts = MOD.parse_runtime_state_timestamp(text)
+        assert ts is not None
+        # Must be UTC-aware (offset zero)
+        utc_offset = ts.utcoffset()
+        assert utc_offset is not None
+        assert utc_offset.total_seconds() == 0
+
+    def test_returns_none_for_empty_string(self) -> None:
+        assert MOD.parse_runtime_state_timestamp("") is None
+
+    def test_section_in_middle_of_document(self) -> None:
+        text = (
+            "# Daily Deep Dive\n\n"
+            "## Metrics\n\nSome data.\n\n"
+            "## Runtime State — as of 2026-03-15T09:45Z\n\n"
+            "Runtime observations.\n\n"
+            "## Appendix\n\nMore stuff."
+        )
+        ts = MOD.parse_runtime_state_timestamp(text)
+        assert ts is not None
+        assert ts.day == 15
+        assert ts.month == 3
+
+
+# ---------------------------------------------------------------------------
+# validate_deep_dive_ingest
+# ---------------------------------------------------------------------------
+
+
+def _write_deep_dive(content: str) -> Path:
+    with tempfile.NamedTemporaryFile(
+        suffix=".md", mode="w", encoding="utf-8", delete=False
+    ) as f:
+        f.write(content)
+        return Path(f.name)
+
+
+class TestValidateDeepDiveIngest:
+    """validate_deep_dive_ingest returns (ok, message) based on freshness."""
+
+    def _make_cutoff(self, iso: str) -> dt.datetime:
+        return dt.datetime.fromisoformat(iso.replace("Z", "+00:00"))
+
+    def test_fresh_runtime_state_accepted(self) -> None:
+        """Runtime state newer than handoff cutoff must be accepted."""
+        content = (
+            "## Durable Findings\n\nFinding A.\n\n"
+            "## Runtime State — as of 2026-06-28T16:00Z\n\nDrift: green."
+        )
+        path = _write_deep_dive(content)
+        cutoff = self._make_cutoff("2026-06-28T14:00Z")
+        ok, msg = MOD.validate_deep_dive_ingest(path, cutoff)
+        assert ok is True
+        assert "fresh" in msg.lower()
+
+    def test_equal_timestamp_accepted(self) -> None:
+        """Runtime state exactly at the handoff cutoff must be accepted."""
+        content = "## Runtime State — as of 2026-06-28T14:00Z\n\nDrift: yellow."
+        path = _write_deep_dive(content)
+        cutoff = self._make_cutoff("2026-06-28T14:00Z")
+        ok, _ = MOD.validate_deep_dive_ingest(path, cutoff)
+        assert ok is True
+
+    def test_stale_runtime_state_rejected(self) -> None:
+        """Runtime state older than handoff cutoff must be rejected."""
+        content = (
+            "## Durable Findings\n\nFinding B.\n\n"
+            "## Runtime State — as of 2026-06-10T20:00Z\n\nProd broker is down."
+        )
+        path = _write_deep_dive(content)
+        cutoff = self._make_cutoff("2026-06-10T22:00Z")
+        ok, msg = MOD.validate_deep_dive_ingest(path, cutoff)
+        assert ok is False
+        assert "stale" in msg.lower()
+
+    def test_missing_runtime_state_section_rejected(self) -> None:
+        """Deep-dives without a Runtime State section must be rejected."""
+        content = "## Durable Findings\n\nSome findings.\n\n## Metrics\n\nNumbers."
+        path = _write_deep_dive(content)
+        cutoff = self._make_cutoff("2026-06-01T00:00Z")
+        ok, msg = MOD.validate_deep_dive_ingest(path, cutoff)
+        assert ok is False
+        assert "missing" in msg.lower()
+
+    def test_nonexistent_file_rejected(self, tmp_path: Path) -> None:
+        """Non-existent file must be rejected without raising."""
+        cutoff = self._make_cutoff("2026-06-01T00:00Z")
+        # Use tmp_path for a path that is guaranteed not to exist.
+        missing = tmp_path / "does_not_exist_omn13043.md"
+        ok, msg = MOD.validate_deep_dive_ingest(missing, cutoff)
+        assert ok is False
+        assert "cannot read" in msg.lower() or "no such" in msg.lower()
+
+    def test_message_includes_timestamps_on_rejection(self) -> None:
+        """Rejection message must cite both timestamps for debuggability."""
+        content = "## Runtime State — as of 2026-06-10T20:00Z\n\nContent."
+        path = _write_deep_dive(content)
+        cutoff = self._make_cutoff("2026-06-11T00:00Z")
+        ok, msg = MOD.validate_deep_dive_ingest(path, cutoff)
+        assert ok is False
+        # Both the section timestamp and the handoff cutoff must appear
+        assert "2026-06-10T20:00" in msg
+        assert "2026-06-11T00:00" in msg
+
+
+# ---------------------------------------------------------------------------
+# Generated-output section presence
+# ---------------------------------------------------------------------------
+
+
+class TestGeneratedOutputSections:
+    """The generated deep-dive must contain both typed section headers."""
+
+    def _run_generator(self, tmp_path: Path, date_str: str) -> str:
+        """Run generate_deep_dive.main() with a no-op empty root and return output."""
+        # Use a temporary directory as the workspace root.  It contains no
+        # git repos, so repo_days will be empty — but the static sections
+        # (Durable Findings, Runtime State) must still be emitted.
+        out_file = tmp_path / "test_deep_dive.md"
+        orig_argv = sys.argv
+        try:
+            sys.argv = [
+                "generate_deep_dive.py",
+                "--root",
+                str(tmp_path),
+                "--date",
+                date_str,
+                "--out",
+                str(out_file),
+            ]
+            MOD.main()
+        finally:
+            sys.argv = orig_argv
+        return out_file.read_text(encoding="utf-8")
+
+    def test_durable_findings_section_present(self, tmp_path: Path) -> None:
+        content = self._run_generator(tmp_path, "2026-06-28")
+        assert "## Durable Findings" in content
+
+    def test_runtime_state_section_present(self, tmp_path: Path) -> None:
+        content = self._run_generator(tmp_path, "2026-06-28")
+        assert "## Runtime State — as of" in content
+
+    def test_runtime_state_timestamp_is_parseable(self, tmp_path: Path) -> None:
+        content = self._run_generator(tmp_path, "2026-06-28")
+        ts = MOD.parse_runtime_state_timestamp(content)
+        assert ts is not None, (
+            "Generated output must contain a parseable Runtime State timestamp"
+        )
+
+    def test_runtime_state_timestamp_is_utc(self, tmp_path: Path) -> None:
+        content = self._run_generator(tmp_path, "2026-06-28")
+        ts = MOD.parse_runtime_state_timestamp(content)
+        assert ts is not None
+        utc_offset = ts.utcoffset()
+        assert utc_offset is not None
+        assert utc_offset.total_seconds() == 0
+
+    def test_generated_deep_dive_passes_own_validate(self, tmp_path: Path) -> None:
+        """A freshly generated deep-dive must pass validate_deep_dive_ingest."""
+        out_file = tmp_path / "test_deep_dive.md"
+        orig_argv = sys.argv
+        try:
+            sys.argv = [
+                "generate_deep_dive.py",
+                "--root",
+                str(tmp_path),
+                "--date",
+                "2026-06-28",
+                "--out",
+                str(out_file),
+            ]
+            MOD.main()
+        finally:
+            sys.argv = orig_argv
+        # Use a cutoff well before generation — must pass.
+        old_cutoff = dt.datetime(2026, 1, 1, 0, 0, 0, tzinfo=dt.UTC)
+        ok, msg = MOD.validate_deep_dive_ingest(out_file, old_cutoff)
+        assert ok is True, f"Fresh deep-dive rejected: {msg}"


### PR DESCRIPTION
## Summary

Implements C-3 from the 2026-06-11 process failure retro (OMN-13043).

The daily deep-dive generator gains two typed section headers that separate persistent structural findings from ephemeral runtime observations:

- `## Durable Findings` — architectural/code findings that stay valid until the referenced code changes.
- `## Runtime State — as of <YYYY-MM-DDTHH:MMZ>` — ephemeral runtime observations captured at generation time with a machine-readable UTC timestamp.

The generator also adds `--validate-ingest PATH --handoff-time ISO`, which refuses stale or missing Runtime State sections before corpus ingestion.

## Changed Files

- `scripts/generate_deep_dive.py`
- `tests/unit/scripts/test_deep_dive_typed_sections.py`

## Evidence

Evidence-Source: OCC#3255
Evidence-Ticket: OMN-13043
OCC Receipt PR: https://github.com/OmniNode-ai/onex_change_control/pull/3255

Proof:
- `uv run pytest tests/unit/scripts/test_deep_dive_typed_sections.py -q` -> `17 passed`
- `uv run ruff check scripts/generate_deep_dive.py tests/unit/scripts/test_deep_dive_typed_sections.py` -> `All checks passed!`
- `uv run pre-commit run --files scripts/generate_deep_dive.py tests/unit/scripts/test_deep_dive_typed_sections.py` -> passed
- Focused mypy still reports 8 pre-existing `scripts/generate_deep_dive.py` errors already present before this PR.