### PR TITLE
feat(OMN-13281): wire check-receipt-honesty pre-commit hook to omnibase_infra

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,12 +21,19 @@
 #   pre-commit install --hook-type pre-push  # Install pre-push hooks
 #   pre-commit run --all-files            # Run all pre-commit hooks
 repos:
-  # Stub implementation detection + transport-mock lint — sourced from omnibase_core.
-  # Rev bumped to OMN-13026 (transport-mock-lint hook added).
+  # Stub implementation detection + receipt-honesty gate + transport-mock lint —
+  # sourced from omnibase_core. Rev bumped to OMN-13026 (transport-mock-lint
+  # hook added); OMN-13281 wires receipt-honesty to this block.
   - repo: https://github.com/OmniNode-ai/omnibase_core
     rev: 309d89fa7254701347f95bf99205cccfb3f6c1df # pragma: allowlist secret
     hooks:
       - id: check-stub-implementations
+      # OMN-13281: scan staged ModelDodReceipt YAML files under
+      # drift/dod_receipts/ for gaming patterns (echo-probe PASS, deferred
+      # evidence in PASS receipts, self-attestation, fake human verifiers,
+      # deploy-keyword echo receipts). Only fires when a receipt YAML is
+      # staged; no-op on commits that touch no receipts.
+      - id: check-receipt-honesty
       # OMN-13026: bare AsyncMock/MagicMock without spec=/spec_set= on
       # EventBus/transport/kafka surfaces. Ratchet: existing violations frozen
       # in config/validation/transport_mock_baseline.yaml (218 violations, 63 files).


### PR DESCRIPTION
## Summary

Wires the `check-receipt-honesty` hook (OMN-12791) to omnibase_infra's `.pre-commit-config.yaml`. The hook scans staged `ModelDodReceipt` YAML files under `drift/dod_receipts/` for gaming patterns and is a no-op on commits that do not touch any receipt files.

- omnibase_infra has an active `drift/dod_receipts/` corpus (OMN-12184, OMN-13532 on `origin/dev`) → hook wired
- omniclaude has no `drift/dod_receipts/` → N/A
- omniintelligence has no `drift/dod_receipts/` → N/A

## Change

Added `- id: check-receipt-honesty` under the existing `omnibase_core` repo block in `.pre-commit-config.yaml`, alongside `check-stub-implementations` and `transport-mock-lint`. The omnibase_core rev (`309d89fa7254701347f95bf99205cccfb3f6c1df`) already includes this hook (OMN-12791).

## Fail-Closed Proof

Gamed PASS receipt with `verifier == runner == claude-sonnet-4-6` (self-attestation):

```
RECEIPT HONESTY GATE FAILED: 2 violation(s) across 1 receipt(s):

  [SELF_ATTESTATION] drift/dod_receipts/OMN-13281-PROOF/dod-proof/command.yaml
    verifier='jonah/omn-13281-impl-agent' == runner='jonah/omn-13281-impl-agent'.
    Self-attestation is rejected.

  [FAKE_HUMAN_VERIFIER] ...
    runner='jonah/omn-13281-impl-agent' is an AI agent but verifier='...' is a
    human handle.
exit:1
```

After reverting, clean tree: `RECEIPT HONESTY GATE PASSED: 0 violations in 5 explicit receipt file(s)`.

## DoD

- [x] drift/dod_receipts/ exists in omnibase_infra dev (OMN-12184, OMN-13532)
- [x] omniclaude and omniintelligence have no drift/dod_receipts/ — N/A
- [x] check-receipt-honesty hook added to .pre-commit-config.yaml
- [x] Fail-closed proof: gamed receipt exits non-zero; clean tree exits 0
- [x] pre-commit run --files .pre-commit-config.yaml: all hooks pass
- [x] No CI mirror enforcement removed

## Evidence

Evidence-Source: OCC#3280
Evidence-Ticket: OMN-13281
Implementation-Head: 0d260fa3a1219e911a93196d2c64c9495690e620

OCC PR: https://github.com/OmniNode-ai/onex_change_control/pull/3267
