### PR TITLE
fix(OMN-13690): replace direct omnimarket import with entry-point discovery in service_kernel

### DIFF
--- a/docker/migrations/forward/nodes/node_projection_baselines_quality/001_create_baselines_quality_snapshots.sql
+++ b/docker/migrations/forward/nodes/node_projection_baselines_quality/001_create_baselines_quality_snapshots.sql
@@ -1,0 +1,62 @@
+-- SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+-- SPDX-License-Identifier: MIT
+-- OMN-13076: Baselines quality snapshot projection table.
+--
+-- Backs the projection topic
+--   onex.snapshot.projection.baselines.quality.v1
+-- consumed by the omnidash quality-baseline-panel widget.
+--
+-- Source: per-snapshot ModelBaselinesComputedEvent carried on the topic
+-- onex.evt.omnibase-infra.baselines-computed.v1.
+-- One projection row per snapshot_id (upserted; latest per snapshot wins).
+-- Fields:
+--   patterns_compared       — total patterns compared in the snapshot window.
+--   patterns_recommended    — patterns for which a recommendation was produced.
+--   high_confidence_count   — comparisons where confidence == "high".
+--   medium_confidence_count — comparisons where confidence == "medium".
+--   low_confidence_count    — comparisons where confidence == "low" (or unknown tier).
+--   quality_score           — weighted avg: (high*1.0 + medium*0.5 + low*0.25)
+--                             / max(1, total_comparisons).
+--   recommend_rate          — patterns_recommended / max(1, patterns_compared).
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS baselines_quality_snapshots (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    -- Identity — upsert conflict key
+    snapshot_id TEXT NOT NULL,
+    -- Source event timestamp
+    captured_at TEXT NOT NULL,
+    -- Pattern counts from the snapshot
+    patterns_compared INTEGER NOT NULL DEFAULT 0 CHECK (patterns_compared >= 0),
+    patterns_recommended INTEGER NOT NULL DEFAULT 0 CHECK (patterns_recommended >= 0),
+    -- Confidence tier counts
+    high_confidence_count INTEGER NOT NULL DEFAULT 0 CHECK (high_confidence_count >= 0),
+    medium_confidence_count INTEGER NOT NULL DEFAULT 0 CHECK (medium_confidence_count >= 0),
+    low_confidence_count INTEGER NOT NULL DEFAULT 0 CHECK (low_confidence_count >= 0),
+    -- Derived quality metrics
+    quality_score NUMERIC(8, 6) NOT NULL DEFAULT 0 CHECK (quality_score >= 0 AND quality_score <= 1),
+    recommend_rate NUMERIC(8, 6) NOT NULL DEFAULT 0 CHECK (recommend_rate >= 0 AND recommend_rate <= 1),
+    -- Projection metadata
+    projected_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_baselines_quality_snapshots_snapshot_id
+    ON baselines_quality_snapshots (snapshot_id);
+
+CREATE INDEX IF NOT EXISTS ix_baselines_quality_snapshots_projected_at
+    ON baselines_quality_snapshots (projected_at DESC);
+
+CREATE OR REPLACE FUNCTION refresh_baselines_quality_snapshots_projected_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.projected_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_baselines_quality_snapshots_projected_at ON baselines_quality_snapshots;
+CREATE TRIGGER trg_baselines_quality_snapshots_projected_at
+    BEFORE UPDATE ON baselines_quality_snapshots
+    FOR EACH ROW
+    EXECUTE FUNCTION refresh_baselines_quality_snapshots_projected_at();

--- a/docker/migrations/forward/nodes/node_projection_baselines_roi/001_create_baselines_roi_snapshots.sql
+++ b/docker/migrations/forward/nodes/node_projection_baselines_roi/001_create_baselines_roi_snapshots.sql
@@ -1,0 +1,59 @@
+-- SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+-- SPDX-License-Identifier: MIT
+-- OMN-13075: Baselines ROI snapshot projection table.
+--
+-- Backs the projection topic
+--   onex.snapshot.projection.baselines.roi.v1
+-- consumed by the omnidash BaselinesROICard widget (roi-trend, roi-by-model).
+--
+-- Source: per-snapshot ModelBaselinesComputedEvent carried on the topic
+-- onex.evt.omnibase-infra.baselines-computed.v1.
+-- One projection row per snapshot_id (upserted; latest per snapshot wins).
+-- Fields:
+--   token_delta   — sum of comparison.token_delta across all comparisons.
+--   time_delta_ms — sum of comparison.time_delta_s * 1000 across all comparisons.
+--   retry_delta   — sum of retry_count across all retry_counts.
+--   recommendations — JSONB counting actions: promote / shadow / suppress / fork.
+--   confidence    — average mapped confidence score across comparisons
+--                   (high=1.0, medium=0.5, low=0.25; 0.0 when no comparisons).
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS baselines_roi_snapshots (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    -- Identity — upsert conflict key
+    snapshot_id TEXT NOT NULL,
+    -- Source event timestamp
+    captured_at TEXT NOT NULL,
+    -- ROI aggregates
+    token_delta BIGINT NOT NULL DEFAULT 0,
+    time_delta_ms NUMERIC(18, 3) NOT NULL DEFAULT 0,
+    retry_delta INTEGER NOT NULL DEFAULT 0 CHECK (retry_delta >= 0),
+    -- Recommendation action counts stored as JSONB for structured access
+    -- Shape: {"promote": N, "shadow": N, "suppress": N, "fork": N}
+    recommendations JSONB NOT NULL DEFAULT '{"promote": 0, "shadow": 0, "suppress": 0, "fork": 0}',
+    -- Average confidence score [0.0, 1.0]
+    confidence NUMERIC(8, 6) NOT NULL DEFAULT 0 CHECK (confidence >= 0 AND confidence <= 1),
+    -- Projection metadata
+    projected_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_baselines_roi_snapshots_snapshot_id
+    ON baselines_roi_snapshots (snapshot_id);
+
+CREATE INDEX IF NOT EXISTS ix_baselines_roi_snapshots_projected_at
+    ON baselines_roi_snapshots (projected_at DESC);
+
+CREATE OR REPLACE FUNCTION refresh_baselines_roi_snapshots_projected_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.projected_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_baselines_roi_snapshots_projected_at ON baselines_roi_snapshots;
+CREATE TRIGGER trg_baselines_roi_snapshots_projected_at
+    BEFORE UPDATE ON baselines_roi_snapshots
+    FOR EACH ROW
+    EXECUTE FUNCTION refresh_baselines_roi_snapshots_projected_at();

--- a/src/omnibase_infra/runtime/service_kernel.py
+++ b/src/omnibase_infra/runtime/service_kernel.py
@@ -1896,26 +1896,45 @@ async def bootstrap() -> int:
         # takes ~12 minutes. If Intelligence goes first, later plugins never
         # get their consumers started before the runtime is restarted or killed.
 
-        # Try to register PluginDelegation (OMN-7040: delegation pipeline).
-        # Imported lazily here (not at module scope) so a missing/unavailable
-        # omnimarket dependency degrades gracefully instead of crashing kernel
-        # startup, and to avoid a module-load circular import.
-        try:
-            from omnimarket.nodes.node_delegation_orchestrator.plugin import (
-                PluginDelegation,
-            )
+        # Try to load and register PluginDelegation via entry-point discovery
+        # (graceful degradation - OMN-13690). omnimarket is optional and can be
+        # removed from the active runtime surface with ONEX_ACTIVE_RUNTIME_PACKAGES.
+        # Discovery via "onex.domain_plugins" avoids a direct infra-to-omnimarket
+        # import which violates the compat→core→spi→infra layering rule.
+        if is_runtime_package_active("omnimarket"):
+            try:
+                from importlib.metadata import entry_points
 
-            plugin_registry.register(PluginDelegation())
+                delegation_eps = [
+                    e
+                    for e in entry_points(group="onex.domain_plugins")
+                    if e.name == "delegation"
+                ]
+                if delegation_eps:
+                    PluginDelegation = delegation_eps[0].load()
+                    plugin_registry.register(PluginDelegation())
+                    logger.info(
+                        "PluginDelegation registered (correlation_id=%s)",
+                        correlation_id,
+                    )
+                else:
+                    logger.debug(
+                        "omnimarket not installed, delegation plugin not available "
+                        "(correlation_id=%s)",
+                        correlation_id,
+                    )
+            except Exception:  # noqa: BLE001 — boundary: logs warning and degrades
+                logger.warning(
+                    "PluginDelegation failed to initialize, continuing without it "
+                    "(correlation_id=%s)",
+                    correlation_id,
+                    exc_info=True,
+                )
+        else:
             logger.info(
-                "PluginDelegation registered (correlation_id=%s)",
-                correlation_id,
-            )
-        except Exception:  # noqa: BLE001 — boundary: logs warning and degrades
-            logger.warning(
-                "PluginDelegation failed to initialize, continuing without it "
+                "PluginDelegation skipped by active runtime package filter "
                 "(correlation_id=%s)",
                 correlation_id,
-                exc_info=True,
             )
 
         # Try to register PluginLlm (OMN-6600: LLM domain plugin).


### PR DESCRIPTION
## Summary

OMN-13690 removes the infra -> omnimarket layering violation in `service_kernel.py`.

- Before: `service_kernel.py` lazily imported `PluginDelegation` directly from `omnimarket.nodes.node_delegation_orchestrator.plugin`.
- After: it uses `entry_points(group="onex.domain_plugins")` discovery, guarded by `is_runtime_package_active("omnimarket")`.

This is the infra half of the two-PR fix. The companion omnimarket PR is OmniNode-ai/omnimarket#1491.

## Changes

- `src/omnibase_infra/runtime/service_kernel.py` replaces the direct omnimarket import with entry-point discovery.
- Node migration sync adds the two current projection baseline migrations required by the sync gate.

## Evidence

Evidence-Ticket: OMN-13690
Evidence-Source: OCC#3308

Paired OCC receipts:
- onex_change_control#3308: central OMN-13690 contract and DoD receipts for omnimarket entry point, infra service-kernel discovery, migration sync, and deploy assessment.

Verification already run on the product branch:
- `pre-commit run --files src/omnibase_infra/runtime/service_kernel.py docker/migrations/forward/nodes/node_projection_baselines_quality/001_create_baselines_quality_snapshots.sql docker/migrations/forward/nodes/node_projection_baselines_roi/001_create_baselines_roi_snapshots.sql`

Scope: entry-point discovery and required migration sync only.