### PR TITLE
fix(OMN-13698): remove module-level and constructor LLM_EMBEDDING_URL env reads

### DIFF
--- a/src/omnibase_infra/services/session_registry/decision_embedder.py
+++ b/src/omnibase_infra/services/session_registry/decision_embedder.py
@@ -5,7 +5,7 @@
 Embeds decision records and stores them in Qdrant for semantic retrieval.
 
 Collection: "session_decisions"
-Vector: 1024-dim from Qwen3-Embedding-8B (LLM_EMBEDDING_URL)
+Vector: 1024-dim from Qwen3-Embedding-8B
 Payload: task_id, session_id, decision_text, context, timestamp
 
 Embedding text format:
@@ -24,7 +24,6 @@ from __future__ import annotations
 
 import hashlib
 import logging
-import os
 from uuid import UUID, uuid5
 
 import httpx
@@ -116,11 +115,16 @@ class EmbeddingClient:
     """Async HTTP client for generating embeddings via OpenAI-compatible API.
 
     Calls POST {base_url}/v1/embeddings with the standard request format.
-    Default base_url is read from LLM_EMBEDDING_URL env var.
+    The base_url must be injected by the caller from the node contract or
+    routing authority — no env-var fallback.
+
+    Args:
+        base_url: Full base URL of the embedding service (e.g.
+            ``"http://192.168.86.201:8100"``). Required; must not be empty.
     """
 
-    def __init__(self, base_url: str | None = None) -> None:
-        self._base_url = base_url or os.environ.get("LLM_EMBEDDING_URL", "")
+    def __init__(self, base_url: str) -> None:
+        self._base_url = base_url
 
     async def embed(self, text: str) -> list[float]:
         """Generate a 1024-dim embedding vector for the given text.

--- a/src/omnibase_infra/services/session_registry/decision_embedder.py
+++ b/src/omnibase_infra/services/session_registry/decision_embedder.py
@@ -124,7 +124,13 @@ class EmbeddingClient:
     """
 
     def __init__(self, base_url: str) -> None:
-        self._base_url = base_url
+        if not base_url.strip():
+            raise ValueError(
+                "EmbeddingClient.base_url is empty; inject the URL from the node "
+                "contract or routing authority rather than relying on an env-var "
+                "fallback."
+            )
+        self._base_url = base_url.strip()
 
     async def embed(self, text: str) -> list[float]:
         """Generate a 1024-dim embedding vector for the given text.

--- a/src/omnibase_infra/services/session_registry/decision_search.py
+++ b/src/omnibase_infra/services/session_registry/decision_search.py
@@ -27,7 +27,6 @@ Part of the Multi-Session Coordination Layer (OMN-6850, Task 14).
 from __future__ import annotations
 
 import logging
-import os
 
 import httpx
 from pydantic import BaseModel, ConfigDict, Field
@@ -37,7 +36,6 @@ from qdrant_client.http import models as qdrant_models
 logger = logging.getLogger(__name__)
 
 _COLLECTION_NAME = "session_decisions"
-_DEFAULT_EMBEDDING_URL = os.getenv("LLM_EMBEDDING_URL", "")
 _DEFAULT_EMBEDDING_MODEL = "Qwen3-Embedding-8B"
 
 
@@ -69,22 +67,34 @@ class DecisionSearchClient:
     Args:
         qdrant: QdrantClient instance (None for format-only usage).
         embedder: Callable that takes text and returns embedding vector.
-            If None, uses the default HTTP embedding client.
+            When provided, ``embedding_base_url`` is not used.
+        embedding_base_url: Full base URL of the embedding service (e.g.
+            ``"http://192.168.86.201:8100"``). Required when no custom
+            ``embedder`` is provided; must be injected from the node contract
+            or routing authority — no env-var fallback.
+        embedding_model: Model name to request from the embedding API.
+            Defaults to ``"Qwen3-Embedding-8B"``.
     """
 
     def __init__(
         self,
         qdrant: QdrantClient | None = None,
         embedder: object | None = None,
+        embedding_base_url: str = "",
+        embedding_model: str = _DEFAULT_EMBEDDING_MODEL,
     ) -> None:
         self._qdrant = qdrant
         self._embedder = embedder
+        self._embedding_base_url = embedding_base_url
+        self._embedding_model = embedding_model
 
     async def _embed(self, text: str) -> list[float]:
         """Embed text using the configured embedding endpoint.
 
-        Falls back to the default Qwen3-Embedding-8B endpoint if no
-        custom embedder is provided.
+        Uses ``self._embedder`` when provided; otherwise issues an HTTP
+        request to ``self._embedding_base_url``. The URL must have been
+        injected at construction time from the node contract or routing
+        authority — no env-var fallback occurs here.
         """
         if self._embedder is not None and callable(self._embedder):
             result = self._embedder(text)
@@ -94,12 +104,16 @@ class DecisionSearchClient:
             # Why: Runtime validation guarantees the returned value matches the contract.
             return await result  # type: ignore[return-value]
 
-        base_url = os.getenv("LLM_EMBEDDING_URL", _DEFAULT_EMBEDDING_URL)
-        model = os.getenv("LLM_EMBEDDING_MODEL", _DEFAULT_EMBEDDING_MODEL)
+        if not self._embedding_base_url:
+            raise ValueError(
+                "DecisionSearchClient.embedding_base_url is empty; "
+                "inject the URL from the node contract or routing authority "
+                "rather than relying on an env-var fallback."
+            )
         async with httpx.AsyncClient(timeout=30.0) as client:
             response = await client.post(
-                f"{base_url}/v1/embeddings",
-                json={"input": text, "model": model},
+                f"{self._embedding_base_url}/v1/embeddings",
+                json={"input": text, "model": self._embedding_model},
             )
             response.raise_for_status()
             data = response.json()

--- a/tests/unit/services/session_registry/test_decision_embedder.py
+++ b/tests/unit/services/session_registry/test_decision_embedder.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import pytest
 
 from omnibase_infra.services.session_registry.decision_embedder import (
+    EmbeddingClient,
     ModelDecisionRecord,
     build_embedding_text,
     decision_point_id,
@@ -109,3 +110,28 @@ class TestDecisionPointId:
         id1 = decision_point_id("OMN-1234", "Use Postgres")
         id2 = decision_point_id("OMN-5678", "Use Postgres")
         assert id1 != id2
+
+
+@pytest.mark.unit
+class TestEmbeddingClientUrlInjection:
+    """EmbeddingClient requires base_url to be injected; no env-var fallback."""
+
+    def test_url_stored_from_constructor(self) -> None:
+        """base_url passed at construction is stored directly."""
+        client = EmbeddingClient(base_url="http://injected-embed:8100")
+        assert client._base_url == "http://injected-embed:8100"
+
+    def test_different_urls_produce_different_clients(self) -> None:
+        """Two clients with different URLs are independent."""
+        c1 = EmbeddingClient(base_url="http://host-a:8100")
+        c2 = EmbeddingClient(base_url="http://host-b:9000")
+        assert c1._base_url != c2._base_url
+
+    def test_no_env_var_fallback(self) -> None:
+        """EmbeddingClient never reads LLM_EMBEDDING_URL from env."""
+        import os
+
+        os.environ.pop("LLM_EMBEDDING_URL", None)
+        # Must not raise even with the env var absent.
+        client = EmbeddingClient(base_url="http://explicit-host:8100")
+        assert client._base_url == "http://explicit-host:8100"

--- a/tests/unit/services/session_registry/test_decision_embedder.py
+++ b/tests/unit/services/session_registry/test_decision_embedder.py
@@ -10,6 +10,8 @@ Part of OMN-6850, Task 12/13.
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 
 from omnibase_infra.services.session_registry.decision_embedder import (
@@ -129,9 +131,11 @@ class TestEmbeddingClientUrlInjection:
 
     def test_no_env_var_fallback(self) -> None:
         """EmbeddingClient never reads LLM_EMBEDDING_URL from env."""
-        import os
-
-        os.environ.pop("LLM_EMBEDDING_URL", None)
-        # Must not raise even with the env var absent.
-        client = EmbeddingClient(base_url="http://explicit-host:8100")
+        with patch("os.getenv", side_effect=AssertionError("env read")):
+            client = EmbeddingClient(base_url="http://explicit-host:8100")
         assert client._base_url == "http://explicit-host:8100"
+
+    def test_rejects_empty_url(self) -> None:
+        """EmbeddingClient fails fast on missing injected base_url."""
+        with pytest.raises(ValueError, match=r"EmbeddingClient\.base_url is empty"):
+            EmbeddingClient(base_url="   ")

--- a/tests/unit/services/session_registry/test_decision_search.py
+++ b/tests/unit/services/session_registry/test_decision_search.py
@@ -7,7 +7,7 @@ Part of the Multi-Session Coordination Layer (OMN-6850, Task 14).
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -15,6 +15,8 @@ from omnibase_infra.services.session_registry.decision_search import (
     DecisionSearchClient,
     ModelDecisionSearchResult,
 )
+
+_TEST_EMBEDDING_URL = "http://test-embed:8100"
 
 
 @pytest.mark.unit
@@ -139,7 +141,11 @@ class TestDecisionSearchClientSearch:
 
         embedder = MagicMock(return_value=[0.1, 0.2, 0.3])
 
-        client = DecisionSearchClient(qdrant=mock_qdrant, embedder=embedder)
+        client = DecisionSearchClient(
+            qdrant=mock_qdrant,
+            embedder=embedder,
+            embedding_base_url=_TEST_EMBEDDING_URL,
+        )
         results = await client.search("event bus choice")
 
         assert len(results) == 1
@@ -157,7 +163,11 @@ class TestDecisionSearchClientSearch:
 
         embedder = MagicMock(return_value=[0.1, 0.2, 0.3])
 
-        client = DecisionSearchClient(qdrant=mock_qdrant, embedder=embedder)
+        client = DecisionSearchClient(
+            qdrant=mock_qdrant,
+            embedder=embedder,
+            embedding_base_url=_TEST_EMBEDDING_URL,
+        )
         await client.search("test", task_id="OMN-5555")
 
         call_kwargs = mock_qdrant.query_points.call_args
@@ -209,9 +219,67 @@ class TestDecisionSearchClientSearchRelated:
         mock_query_result.points = [mock_hit]
         mock_qdrant.query_points.return_value = mock_query_result
 
-        client = DecisionSearchClient(qdrant=mock_qdrant, embedder=None)
+        client = DecisionSearchClient(
+            qdrant=mock_qdrant,
+            embedder=None,
+            embedding_base_url=_TEST_EMBEDDING_URL,
+        )
         results = await client.search_related("OMN-1234")
 
         assert len(results) == 1
         assert results[0].task_id == "OMN-5678"
         assert results[0].score == 0.85
+
+
+@pytest.mark.unit
+class TestDecisionSearchClientUrlInjection:
+    """Verify that embedding_base_url is injected at construction, not read from env."""
+
+    def test_url_stored_from_constructor(self) -> None:
+        """URL passed at construction is stored and not resolved from env."""
+        client = DecisionSearchClient(
+            embedding_base_url="http://injected-host:9999",
+        )
+        assert client._embedding_base_url == "http://injected-host:9999"
+
+    def test_model_stored_from_constructor(self) -> None:
+        """Embedding model passed at construction is stored."""
+        client = DecisionSearchClient(
+            embedding_base_url=_TEST_EMBEDDING_URL,
+            embedding_model="custom-embed-model",
+        )
+        assert client._embedding_model == "custom-embed-model"
+
+    def test_no_env_var_read_on_import(self) -> None:
+        """LLM_EMBEDDING_URL is never read from env by DecisionSearchClient."""
+        # Instantiating with an explicit URL must not access env at all.
+        with patch.dict("os.environ", {}, clear=False):
+            # Ensure the var is absent; construction must still succeed.
+            import os
+
+            os.environ.pop("LLM_EMBEDDING_URL", None)
+            client = DecisionSearchClient(
+                embedding_base_url=_TEST_EMBEDDING_URL,
+            )
+            assert client._embedding_base_url == _TEST_EMBEDDING_URL
+
+    @pytest.mark.asyncio
+    async def test_embed_uses_injected_url_not_env(self) -> None:
+        """_embed sends requests to the injected URL, ignoring any env var."""
+        injected_url = "http://injected-embed:1234"
+        embedder_mock = AsyncMock(return_value=[0.1, 0.2])
+
+        client = DecisionSearchClient(
+            qdrant=MagicMock(),
+            embedder=embedder_mock,
+            embedding_base_url=injected_url,
+        )
+        await client._embed("test text")
+        embedder_mock.assert_awaited_once_with("test text")
+
+    @pytest.mark.asyncio
+    async def test_embed_raises_on_empty_url_without_embedder(self) -> None:
+        """_embed fails fast when no custom embedder and URL is empty."""
+        client = DecisionSearchClient(qdrant=MagicMock(), embedder=None)
+        with pytest.raises(ValueError, match="embedding_base_url is empty"):
+            await client._embed("test text")

--- a/tests/unit/services/session_registry/test_decision_search.py
+++ b/tests/unit/services/session_registry/test_decision_search.py
@@ -252,30 +252,69 @@ class TestDecisionSearchClientUrlInjection:
 
     def test_no_env_var_read_on_import(self) -> None:
         """LLM_EMBEDDING_URL is never read from env by DecisionSearchClient."""
-        # Instantiating with an explicit URL must not access env at all.
-        with patch.dict("os.environ", {}, clear=False):
-            # Ensure the var is absent; construction must still succeed.
-            import os
-
-            os.environ.pop("LLM_EMBEDDING_URL", None)
+        with patch("os.getenv", side_effect=AssertionError("env read")):
             client = DecisionSearchClient(
                 embedding_base_url=_TEST_EMBEDDING_URL,
             )
-            assert client._embedding_base_url == _TEST_EMBEDDING_URL
+        assert client._embedding_base_url == _TEST_EMBEDDING_URL
 
     @pytest.mark.asyncio
     async def test_embed_uses_injected_url_not_env(self) -> None:
         """_embed sends requests to the injected URL, ignoring any env var."""
         injected_url = "http://injected-embed:1234"
-        embedder_mock = AsyncMock(return_value=[0.1, 0.2])
+        requested: dict[str, object] = {}
+
+        class _Response:
+            def raise_for_status(self) -> None:
+                pass
+
+            def json(self) -> dict[str, list[dict[str, list[float]]]]:
+                return {"data": [{"embedding": [0.1, 0.2]}]}
+
+        class _AsyncClient:
+            def __init__(self, *, timeout: float) -> None:
+                requested["timeout"] = timeout
+
+            async def __aenter__(self) -> _AsyncClient:
+                return self
+
+            async def __aexit__(
+                self,
+                exc_type: object,
+                exc: object,
+                traceback: object,
+            ) -> None:
+                pass
+
+            async def post(
+                self,
+                url: str,
+                *,
+                json: dict[str, str],
+            ) -> _Response:
+                requested["url"] = url
+                requested["json"] = json
+                return _Response()
 
         client = DecisionSearchClient(
             qdrant=MagicMock(),
-            embedder=embedder_mock,
             embedding_base_url=injected_url,
         )
-        await client._embed("test text")
-        embedder_mock.assert_awaited_once_with("test text")
+        with (
+            patch("os.getenv", side_effect=AssertionError("env read")),
+            patch(
+                "omnibase_infra.services.session_registry.decision_search.httpx.AsyncClient",
+                _AsyncClient,
+            ),
+        ):
+            result = await client._embed("test text")
+
+        assert result == [0.1, 0.2]
+        assert requested["url"] == f"{injected_url}/v1/embeddings"
+        assert requested["json"] == {
+            "input": "test text",
+            "model": "Qwen3-Embedding-8B",
+        }
 
     @pytest.mark.asyncio
     async def test_embed_raises_on_empty_url_without_embedder(self) -> None:


### PR DESCRIPTION
## Summary

- Fixes two `os.environ`/`os.getenv` reads for `LLM_EMBEDDING_URL` in the session registry layer that violated `feedback_all_urls_from_contracts`.
- `EmbeddingClient.__init__` now requires `base_url: str`; there is no env fallback.
- `decision_search.py` no longer has a module-level `_DEFAULT_EMBEDDING_URL` or call-time env fallback.
- `DecisionSearchClient` now accepts `embedding_base_url: str` and `embedding_model: str`; `_embed()` uses injected values and raises `ValueError` fast when URL is empty and no custom embedder is configured.
- Tests inject URLs explicitly and assert env reads are not used.

Evidence-Source: OCC#3344
Evidence-Ticket: OMN-13698
OCC PR: https://github.com/OmniNode-ai/onex_change_control/pull/3344

## Evidence

- `uv run ruff format --check src/omnibase_infra/services/session_registry/decision_embedder.py src/omnibase_infra/services/session_registry/decision_search.py tests/unit/services/session_registry/test_decision_embedder.py tests/unit/services/session_registry/test_decision_search.py` -> `4 files already formatted`
- `uv run ruff check src/omnibase_infra/services/session_registry/decision_embedder.py src/omnibase_infra/services/session_registry/decision_search.py tests/unit/services/session_registry/test_decision_embedder.py tests/unit/services/session_registry/test_decision_search.py` -> `All checks passed!`
- `uv run mypy src/omnibase_infra/services/session_registry/decision_embedder.py src/omnibase_infra/services/session_registry/decision_search.py --strict` -> `Success: no issues found in 2 source files`
- `uv run pytest tests/unit/services/session_registry/ -q` -> `127 passed in 0.22s`
- `rg -n 'os\.getenv|os\.environ|_DEFAULT_EMBEDDING_URL|LLM_EMBEDDING_URL' src/omnibase_infra/services/session_registry/decision_embedder.py src/omnibase_infra/services/session_registry/decision_search.py` -> no output
- `pre-commit run --files src/omnibase_infra/services/session_registry/decision_embedder.py src/omnibase_infra/services/session_registry/decision_search.py tests/unit/services/session_registry/test_decision_embedder.py tests/unit/services/session_registry/test_decision_search.py` -> passed

## OCC Evidence

- `uv run validate-yaml contracts/OMN-13698.yaml` -> passed
- `uv run python scripts/lint_contract_check_values.py contracts/OMN-13698.yaml` -> passed
- `uv run python scripts/check_dod_evidence_present.py contracts/OMN-13698.yaml` -> passed
- `uv run python -m omnibase_core.validation.validator_receipt_honesty ...OMN-13698...` -> passed
- `uv run python scripts/validation/check_receipt_hardening.py ...OMN-13698...` -> passed
- `pre-commit run --files contracts/OMN-13698.yaml drift/dod_receipts/OMN-13698/...` -> passed

## Deploy / Runtime

No deploy, restart, or runtime mutation performed.
