### PR TITLE
fix(OMN-13697): remove LLM_CODER_FAST_URL env default from ModelAgentLearningExtractionConfig

### DIFF
--- a/docker/migrations/forward/nodes/node_projection_delegation_inference_response/0001_create_projection_delegation_inference_response_text.sql
+++ b/docker/migrations/forward/nodes/node_projection_delegation_inference_response/0001_create_projection_delegation_inference_response_text.sql
@@ -1,0 +1,50 @@
+-- OMN-13088 (NC-15): Singleton snapshot table for delegation inference response text.
+-- Closes the coverage gap where omnidash declared
+-- onex.snapshot.projection.delegation.inference-response-text.v1 but no
+-- reducer was producing it (node_projection_delegation and
+-- node_llm_delegation_projection publish_topics verified not to include this topic).
+--
+-- One row per deployment (singleton_key = 'global').  Each new inference-response
+-- event from onex.evt.omnibase-infra.inference-response.v1 upserts this row,
+-- rolling the recent_responses JSONB window and updating latest_* scalars.
+
+CREATE TABLE IF NOT EXISTS projection_delegation_inference_response_text (
+    -- Singleton anchor: always 'global'
+    singleton_key             TEXT PRIMARY KEY,
+
+    -- Latest scalar fields from the most recent inference-response event
+    latest_correlation_id     TEXT    NOT NULL DEFAULT '',
+    latest_model_name         TEXT    NOT NULL DEFAULT '',
+    -- task_type is not carried by ModelInferenceResponseData; defaults to empty
+    latest_task_type          TEXT    NOT NULL DEFAULT '',
+    latest_generated_text     TEXT    NOT NULL DEFAULT '',
+    latest_prompt_tokens      INT     NOT NULL DEFAULT 0,
+    latest_completion_tokens  INT     NOT NULL DEFAULT 0,
+    latest_latency_ms         INT     NOT NULL DEFAULT 0,
+
+    -- The Kafka topic that feeds this projection
+    source_topic              TEXT    NOT NULL
+        DEFAULT 'onex.evt.omnibase-infra.inference-response.v1',
+
+    -- Rolling FIFO window of recent responses (max MAX_HISTORY = 10)
+    -- Each entry: {correlation_id, model_name, task_type, generated_text,
+    --              prompt_tokens, completion_tokens, latency_ms, captured_at}
+    recent_responses          JSONB   NOT NULL DEFAULT '[]'::jsonb,
+
+    -- When this snapshot was last materialized
+    captured_at               TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- True once the projection reducer has written at least one row
+    provisioned               BOOLEAN NOT NULL DEFAULT TRUE
+);
+
+-- Seed the singleton row so the projection-API always returns a row
+-- (avoids 404 before the first inference-response event arrives).
+INSERT INTO projection_delegation_inference_response_text
+    (singleton_key, source_topic, provisioned, recent_responses)
+VALUES
+    ('global',
+     'onex.evt.omnibase-infra.inference-response.v1',
+     FALSE,
+     '[]'::jsonb)
+ON CONFLICT (singleton_key) DO NOTHING;

--- a/docker/migrations/forward/nodes/node_projection_intent_classification/0000_create_intent_classification_events.sql
+++ b/docker/migrations/forward/nodes/node_projection_intent_classification/0000_create_intent_classification_events.sql
@@ -1,0 +1,42 @@
+-- OMN-13078: intent_classification_events projection table.
+-- Target DB: omnidash_analytics (omnibase_infra postgres on .201:5436)
+-- Node: node_projection_intent_classification
+-- UPSERT key: correlation_id (latest-wins)
+-- Feeds omnidash widgets: intent-distribution, session-timeline
+
+CREATE TABLE IF NOT EXISTS intent_classification_events (
+    id             BIGSERIAL PRIMARY KEY,
+    correlation_id TEXT UNIQUE NOT NULL,
+    session_id     TEXT NOT NULL,
+    intent_class   TEXT NOT NULL,
+    confidence     FLOAT NOT NULL DEFAULT 0.0,
+    keywords       TEXT[] NOT NULL DEFAULT '{}',
+    emitted_at     TIMESTAMPTZ NOT NULL,
+    ingested_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_intent_classification_events_session_id
+    ON intent_classification_events (session_id);
+
+CREATE INDEX IF NOT EXISTS idx_intent_classification_events_intent_class
+    ON intent_classification_events (intent_class);
+
+CREATE INDEX IF NOT EXISTS idx_intent_classification_events_emitted_at
+    ON intent_classification_events (emitted_at);
+
+CREATE OR REPLACE FUNCTION refresh_intent_classification_events_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_intent_classification_events_updated_at
+    ON intent_classification_events;
+CREATE TRIGGER trg_intent_classification_events_updated_at
+    BEFORE UPDATE ON intent_classification_events
+    FOR EACH ROW
+    EXECUTE FUNCTION refresh_intent_classification_events_updated_at();

--- a/docker/migrations/forward/nodes/node_projection_live_events/0000_create_live_events.sql
+++ b/docker/migrations/forward/nodes/node_projection_live_events/0000_create_live_events.sql
@@ -1,0 +1,39 @@
+-- OMN-13079: Create the live_events projection table.
+-- DDL owner: omnimarket.nodes.node_projection_live_events
+-- Do not add a duplicate CREATE TABLE migration for this table in omnibase_infra.
+--
+-- Purpose: stores recent platform-wide bus events for the omnidash
+-- live-event-stream widget (onex.snapshot.projection.live-events.v1).
+-- Dedup key: event_id (UNIQUE). Retention: latest 1000 rows enforced
+-- by the projection handler after each UPSERT.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS live_events (
+  id             UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_id       TEXT        UNIQUE NOT NULL,
+  type           TEXT        NOT NULL DEFAULT 'ACTION',
+  timestamp      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  source         TEXT        NOT NULL DEFAULT 'platform',
+  topic          TEXT        NOT NULL DEFAULT '',
+  summary        TEXT        NOT NULL DEFAULT '',
+  payload        TEXT        NOT NULL DEFAULT '{}',
+  correlation_id TEXT,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_live_events_created_at
+  ON live_events (created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_live_events_topic
+  ON live_events (topic);
+
+CREATE INDEX IF NOT EXISTS idx_live_events_source
+  ON live_events (source);
+
+CREATE INDEX IF NOT EXISTS idx_live_events_correlation_id
+  ON live_events (correlation_id)
+  WHERE correlation_id IS NOT NULL;
+
+COMMENT ON TABLE live_events IS
+  'Platform-wide bus event projection — feeds the omnidash live-event-stream widget.';

--- a/docker/migrations/forward/nodes/node_projection_mcp_tools/0001_create_mcp_tools.sql
+++ b/docker/migrations/forward/nodes/node_projection_mcp_tools/0001_create_mcp_tools.sql
@@ -1,0 +1,28 @@
+-- OMN-13080: Create the mcp_tools snapshot projection table.
+-- DDL owner: omnimarket.nodes.node_projection_mcp_tools.
+-- Consumed by: omnidash mcp-tools widget via onex.snapshot.projection.mcp-tools.v1.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS mcp_tools (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tool_name TEXT UNIQUE NOT NULL,
+  description TEXT NOT NULL DEFAULT '',
+  model_id TEXT NOT NULL DEFAULT '',
+  correlation_id TEXT NOT NULL DEFAULT '',
+  status TEXT NOT NULL DEFAULT 'active',
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  mcp_tags TEXT[] NOT NULL DEFAULT '{}',
+  metadata JSONB NOT NULL DEFAULT '{}',
+  registered_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  projected_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_mcp_tools_status
+  ON mcp_tools (status);
+
+CREATE INDEX IF NOT EXISTS idx_mcp_tools_registered_at
+  ON mcp_tools (registered_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_mcp_tools_is_active
+  ON mcp_tools (is_active);

--- a/docker/migrations/forward/nodes/node_projection_receipt_gate/0000_create_receipt_gate_projection_table.sql
+++ b/docker/migrations/forward/nodes/node_projection_receipt_gate/0000_create_receipt_gate_projection_table.sql
@@ -1,0 +1,30 @@
+-- Migration: 0000_create_receipt_gate_projection_table.sql
+-- Node: node_projection_receipt_gate
+-- Ticket: OMN-13081
+-- Creates receipt_gate_rows table for the receipt-gate projection API.
+-- This table backs the projection API endpoint for
+-- onex.snapshot.projection.receipt-gate.v1, consumed by the omnidash
+-- receipt-gate widget.
+
+CREATE TABLE IF NOT EXISTS receipt_gate_rows (
+    id BIGSERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    pass BOOLEAN NOT NULL,
+    detail TEXT NOT NULL DEFAULT '',
+    pr_ref TEXT,
+    worker TEXT,
+    verifier TEXT,
+    evidence_count INTEGER,
+    evidence_hash TEXT,
+    signed_at TEXT,
+    observed_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS receipt_gate_rows_observed_at_idx
+    ON receipt_gate_rows (observed_at DESC);
+
+CREATE INDEX IF NOT EXISTS receipt_gate_rows_name_idx
+    ON receipt_gate_rows (name);
+
+CREATE INDEX IF NOT EXISTS receipt_gate_rows_pass_idx
+    ON receipt_gate_rows (pass);

--- a/docker/migrations/forward/nodes/node_projection_sandbox_decisions/0001_create_sandbox_decisions.sql
+++ b/docker/migrations/forward/nodes/node_projection_sandbox_decisions/0001_create_sandbox_decisions.sql
@@ -1,0 +1,25 @@
+-- OMN-13085: sandbox_decisions projection table.
+-- Target DB: omnidash_analytics (omnibase_infra postgres on .201:5436)
+-- Node: node_projection_sandbox_decisions
+-- Append-only: conflict key = correlation_id (INSERT ... ON CONFLICT DO NOTHING)
+-- Source: onex.evt.omnimarket.generated-node-invoked.v1
+
+CREATE TABLE IF NOT EXISTS sandbox_decisions (
+    correlation_id   TEXT PRIMARY KEY,
+    node_name        TEXT NOT NULL,
+    status           TEXT NOT NULL CHECK (status IN ('completed', 'failed')),
+    runtime_backend  TEXT NOT NULL DEFAULT 'sandbox'
+                     CHECK (runtime_backend IN ('sandbox', 'runtime')),
+    hot_load         BOOLEAN NOT NULL DEFAULT FALSE,
+    error            TEXT,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_sandbox_decisions_created_at
+    ON sandbox_decisions (created_at);
+
+CREATE INDEX IF NOT EXISTS idx_sandbox_decisions_status
+    ON sandbox_decisions (status);
+
+CREATE INDEX IF NOT EXISTS idx_sandbox_decisions_node_name
+    ON sandbox_decisions (node_name);

--- a/docker/migrations/forward/nodes/node_projection_session_replay/0001_create_session_replay_snapshots.sql
+++ b/docker/migrations/forward/nodes/node_projection_session_replay/0001_create_session_replay_snapshots.sql
@@ -1,0 +1,50 @@
+-- OMN-13087: session_replay_snapshots projection table.
+-- Target DB: omnidash_analytics (omnibase_infra postgres on .201:5436)
+-- Node: node_projection_session_replay
+-- UPSERT key: snapshot_id (deterministic UUID from session_id + sequence)
+--
+-- WHY THIS EXISTS
+--   omnidash declares topic onex.snapshot.projection.session.replay.v1 in
+--   shared/types/topics.ts. The SessionReplayPage widget renders rows from
+--   this projection. Without a matching table + reducer contract the topic
+--   is DEGRADED at projection API startup. This migration creates the table
+--   that node_projection_session_replay materialises into.
+--
+--   Vendored by omnibase_infra/scripts/sync-node-migrations.sh into
+--   docker/migrations/forward/nodes/node_projection_session_replay/ and
+--   applied to NODE_POSTGRES_DB (omnidash_analytics) by
+--   run-forward-migrations.sh under the namespaced migration id
+--   node:node_projection_session_replay:<file>.
+--
+-- Idempotency: CREATE TABLE / INDEX guarded by IF NOT EXISTS.
+
+-- ============================================================================
+-- SESSION_REPLAY_SNAPSHOTS TABLE
+-- ============================================================================
+-- One row per session event, ordered by (session_id, sequence).
+CREATE TABLE IF NOT EXISTS public.session_replay_snapshots (
+    snapshot_id         TEXT             PRIMARY KEY,
+    session_id          TEXT             NOT NULL,
+    sequence            INT              NOT NULL DEFAULT 0,
+    timestamp           TIMESTAMPTZ      NOT NULL DEFAULT NOW(),
+    event_type          TEXT             NOT NULL,
+    node_name           TEXT             NOT NULL DEFAULT '',
+    state_delta         JSONB            NOT NULL DEFAULT '{}',
+    cumulative_tokens   INT              NOT NULL DEFAULT 0,
+    is_checkpoint       BOOLEAN          NOT NULL DEFAULT FALSE,
+    ingested_at         TIMESTAMPTZ      NOT NULL DEFAULT NOW(),
+    UNIQUE (session_id, sequence)
+);
+
+-- Primary lookup: all snapshots for a session in order.
+CREATE INDEX IF NOT EXISTS idx_session_replay_session_sequence
+    ON public.session_replay_snapshots (session_id, sequence ASC);
+
+-- Freshness: most-recently ingested snapshot first.
+CREATE INDEX IF NOT EXISTS idx_session_replay_ingested_at
+    ON public.session_replay_snapshots (ingested_at DESC);
+
+-- Checkpoint fast-path: filter to checkpoint rows only.
+CREATE INDEX IF NOT EXISTS idx_session_replay_is_checkpoint
+    ON public.session_replay_snapshots (session_id, is_checkpoint)
+    WHERE is_checkpoint = TRUE;

--- a/docker/migrations/forward/nodes/node_projection_voice_sessions/0001_create_voice_sessions.sql
+++ b/docker/migrations/forward/nodes/node_projection_voice_sessions/0001_create_voice_sessions.sql
@@ -1,0 +1,41 @@
+-- OMN-13086: voice_sessions projection table.
+-- Target DB: omnidash_analytics (omnibase_infra postgres on .201:5436)
+-- Node: node_projection_voice_sessions
+-- UPSERT key: session_id (latest-state-wins)
+-- Snapshot topic: onex.snapshot.projection.voice.sessions.v1
+
+CREATE TABLE IF NOT EXISTS voice_sessions (
+    session_id          TEXT PRIMARY KEY,
+    started_at          TIMESTAMPTZ NOT NULL,
+    ended_at            TIMESTAMPTZ,
+    is_active           BOOLEAN NOT NULL DEFAULT TRUE,
+    total_turns         INTEGER NOT NULL DEFAULT 0,
+    total_duration_ms   BIGINT NOT NULL DEFAULT 0,
+    agent_name          TEXT NOT NULL DEFAULT '',
+    transcript_turns    JSONB NOT NULL DEFAULT '[]',
+    ingested_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_voice_sessions_started_at
+    ON voice_sessions (started_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_voice_sessions_is_active
+    ON voice_sessions (is_active);
+
+CREATE INDEX IF NOT EXISTS idx_voice_sessions_agent_name
+    ON voice_sessions (agent_name);
+
+CREATE OR REPLACE FUNCTION refresh_voice_sessions_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_voice_sessions_updated_at ON voice_sessions;
+CREATE TRIGGER trg_voice_sessions_updated_at
+    BEFORE UPDATE ON voice_sessions
+    FOR EACH ROW
+    EXECUTE FUNCTION refresh_voice_sessions_updated_at();

--- a/src/omnibase_infra/services/agent_learning_extraction/config.py
+++ b/src/omnibase_infra/services/agent_learning_extraction/config.py
@@ -5,8 +5,6 @@
 
 from __future__ import annotations
 
-import os
-
 from pydantic import BaseModel, ConfigDict, Field
 
 from omnibase_infra.topics.platform_topic_suffixes import (
@@ -33,8 +31,12 @@ class ModelAgentLearningExtractionConfig(BaseModel):
         description="Kafka consumer group ID",
     )
     llm_summary_url: str = Field(
-        default_factory=lambda: os.environ["LLM_CODER_FAST_URL"],
-        description="LLM endpoint for generating resolution summaries",
+        ...,
+        description=(
+            "LLM endpoint for generating resolution summaries. "
+            "Must be injected from the node's routing contract authority via the DI "
+            "container — never read from an environment variable directly."
+        ),
     )
     llm_summary_timeout_seconds: float = Field(
         default=30.0,

--- a/tests/unit/services/test_agent_learning_extraction.py
+++ b/tests/unit/services/test_agent_learning_extraction.py
@@ -7,8 +7,12 @@ from datetime import UTC, datetime
 from uuid import uuid4
 
 import pytest
+from pydantic import ValidationError
 
 from omnibase_infra.models.agent_learning import EnumLearningTaskType
+from omnibase_infra.services.agent_learning_extraction.config import (
+    ModelAgentLearningExtractionConfig,
+)
 from omnibase_infra.services.agent_learning_extraction.consumer import (
     build_learning_record,
     classify_task_type,
@@ -124,3 +128,27 @@ class TestBuildLearningRecord:
         assert record.repo == "omnibase_infra"
         assert record.ticket_id == "OMN-7100"
         assert record.task_type == EnumLearningTaskType.CI_FIX
+
+
+@pytest.mark.unit
+class TestModelAgentLearningExtractionConfig:
+    """OMN-13697: llm_summary_url must be a required field — no env-var default."""
+
+    def test_missing_llm_summary_url_raises_validation_error(self) -> None:
+        """Config must raise ValidationError (not KeyError) when url is omitted."""
+        with pytest.raises(ValidationError):
+            ModelAgentLearningExtractionConfig()  # type: ignore[call-arg]
+
+    def test_explicit_url_accepted(self) -> None:
+        """Config is valid when llm_summary_url is explicitly provided."""
+        cfg = ModelAgentLearningExtractionConfig(
+            llm_summary_url="http://localhost:8001/v1"
+        )
+        assert cfg.llm_summary_url == "http://localhost:8001/v1"
+
+    def test_no_env_var_side_effect(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Config instantiation must not read LLM_CODER_FAST_URL from the environment."""
+        monkeypatch.delenv("LLM_CODER_FAST_URL", raising=False)
+        # Should raise ValidationError for missing field, never KeyError from os.environ
+        with pytest.raises(ValidationError):
+            ModelAgentLearningExtractionConfig()  # type: ignore[call-arg]


### PR DESCRIPTION
## Summary

Removes the prohibited `LLM_CODER_FAST_URL` environment variable default from `ModelAgentLearningExtractionConfig.llm_summary_url`, and rebases the PR onto current `dev`.

Evidence-Ticket: OMN-13697
Evidence-Source: 51e969ce7b2376bf561839ffad5036051dedebc1

## Defect

`llm_summary_url` used `default_factory=lambda: os.environ["LLM_CODER_FAST_URL"]`, which:

1. Bypassed the routing contract authority for an LLM endpoint.
2. Violated URL/endpoint contract ownership expectations.
3. Raised `KeyError` during model instantiation when the env var was absent.

## Fix

- `llm_summary_url` is now required via `Field(...)`, with no default and no env-var read.
- Removed the now-unused `os` import from the config module.
- Added unit coverage proving omitted URL raises `ValidationError`, explicit URL is accepted, and missing `LLM_CODER_FAST_URL` does not produce an env-read side effect.
- Rebuilt the branch on current `origin/dev` and dropped stale merge-side runtime-local/workflow noise.
- Synced current `omnimarket dev` node migrations into `docker/migrations/forward/nodes/` so the PR passes the node migration vendor sync gate.

## Files Changed

- `src/omnibase_infra/services/agent_learning_extraction/config.py`
- `tests/unit/services/test_agent_learning_extraction.py`
- `docker/migrations/forward/nodes/node_projection_delegation_inference_response/0001_create_projection_delegation_inference_response_text.sql`
- `docker/migrations/forward/nodes/node_projection_intent_classification/0000_create_intent_classification_events.sql`
- `docker/migrations/forward/nodes/node_projection_live_events/0000_create_live_events.sql`
- `docker/migrations/forward/nodes/node_projection_mcp_tools/0001_create_mcp_tools.sql`
- `docker/migrations/forward/nodes/node_projection_receipt_gate/0000_create_receipt_gate_projection_table.sql`
- `docker/migrations/forward/nodes/node_projection_sandbox_decisions/0001_create_sandbox_decisions.sql`
- `docker/migrations/forward/nodes/node_projection_session_replay/0001_create_session_replay_snapshots.sql`
- `docker/migrations/forward/nodes/node_projection_voice_sessions/0001_create_voice_sessions.sql`

## Validation

- `uv run ruff format src/omnibase_infra/services/agent_learning_extraction/config.py tests/unit/services/test_agent_learning_extraction.py`
- `uv run ruff check src/omnibase_infra/services/agent_learning_extraction/config.py tests/unit/services/test_agent_learning_extraction.py`
- `uv run pytest tests/unit/services/test_agent_learning_extraction.py -v` (15 passed)
- `uv run mypy src/omnibase_infra/services/agent_learning_extraction/ --strict` (6 files, no issues)
- `uv run --frozen pytest tests/scripts/test_check_deployed_migration_tree_sync.py -q -p no:cacheprovider` (9 passed)
- `OMNIMARKET_SRC=<clean omnimarket origin/dev snapshot> bash scripts/sync-node-migrations.sh --check` (in sync)
- `uv run ruff format --check src/ tests/ && uv run ruff check src/ tests/` (passed; existing invalid-noqa warnings only)
- `uv run pre-commit run --all-files` was attempted; failures were unrelated pre-existing URL-authority all-files findings plus the local node-migration hook reading the dirty/behind canonical `$OMNI_HOME/omnimarket` clone instead of CI's clean dev checkout. The CI-equivalent migration sync check above passes against a clean `omnimarket origin/dev` snapshot.