### PR TITLE
fix(OMN-13699): replace os.getenv pattern with contract-sourced factory in ServiceLlmEndpointHealth

### DIFF
--- a/src/omnibase_infra/models/health/model_llm_endpoint_health_config.py
+++ b/src/omnibase_infra/models/health/model_llm_endpoint_health_config.py
@@ -57,8 +57,11 @@ class ModelLlmEndpointHealthConfig(BaseModel):
         """Validate that every endpoint URL uses an HTTP(S) scheme and has a hostname.
 
         Rejects non-HTTP schemes to prevent accidental use of ``file://``,
-        ``ftp://``, or bare hostnames.  Also rejects URLs with empty netloc
-        (e.g. ``http://``) which would produce invalid probe requests.
+        ``ftp://``, or bare hostnames.  Also rejects URLs with no hostname
+        (e.g. ``http://`` or ``http://user:pass@``) which would produce
+        invalid probe requests.  ``parsed.hostname`` is checked rather than
+        ``parsed.netloc`` because ``netloc`` is non-empty for userinfo-only
+        authorities like ``http://user:pass@`` that have no actual host.
         Explicitly rejects empty strings with a diagnostic message rather
         than permitting them to silently cause probe failures.
         Error messages are sanitized via ``sanitize_url`` to avoid leaking
@@ -66,7 +69,7 @@ class ModelLlmEndpointHealthConfig(BaseModel):
 
         Raises:
             ValueError: If any URL is empty, does not start with ``http://``
-                or ``https://``, or has an empty netloc (no hostname).
+                or ``https://``, or has no hostname.
         """
         for name, url in v.items():
             if not url:
@@ -85,7 +88,7 @@ class ModelLlmEndpointHealthConfig(BaseModel):
                 )
                 raise ValueError(msg)
             parsed = urlparse(url)
-            if not parsed.netloc:
+            if not parsed.hostname:
                 safe_url = sanitize_url(url)
                 msg = (
                     f"Endpoint '{name}' has invalid URL '{safe_url}': "

--- a/src/omnibase_infra/models/health/model_llm_endpoint_health_config.py
+++ b/src/omnibase_infra/models/health/model_llm_endpoint_health_config.py
@@ -7,10 +7,19 @@ circuit breaker thresholds consumed by ``ServiceLlmEndpointHealth``.
 
 .. versionadded:: 0.9.0
     Part of OMN-2255 LLM endpoint health checker.
+
+.. versionchanged:: OMN-13699
+    Added ``from_model_registry`` factory that sources model aliases from a
+    routing-contract YAML and resolves URLs through an injected
+    ``env_resolver`` callable rather than reading ``os.getenv`` directly.
+    The ``_validate_endpoint_urls`` validator now also rejects explicitly-set
+    empty strings with a diagnostic message that names the violating endpoint.
 """
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from pathlib import Path
 from urllib.parse import urlparse
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
@@ -22,8 +31,10 @@ class ModelLlmEndpointHealthConfig(BaseModel):
     """Configuration for the LLM endpoint health checker.
 
     Attributes:
-        endpoints: Mapping of logical endpoint name to base URL.
-            Example: ``{"coder-14b": "http://192.168.86.201:8000"}``.
+        endpoints: Mapping of logical endpoint name to base URL.  Keys must
+            be ``model_key`` values from the routing contract YAML (e.g.
+            ``"qwen3-coder-30b"``), not hardcoded legacy aliases.  Use
+            ``from_model_registry`` to build this map from a contract file.
         probe_interval_seconds: Seconds between probe cycles. Default: 30.
         probe_timeout_seconds: HTTP timeout for individual probe requests.
             Default: 5.0.
@@ -48,14 +59,24 @@ class ModelLlmEndpointHealthConfig(BaseModel):
         Rejects non-HTTP schemes to prevent accidental use of ``file://``,
         ``ftp://``, or bare hostnames.  Also rejects URLs with empty netloc
         (e.g. ``http://``) which would produce invalid probe requests.
+        Explicitly rejects empty strings with a diagnostic message rather
+        than permitting them to silently cause probe failures.
         Error messages are sanitized via ``sanitize_url`` to avoid leaking
         credentials embedded in URLs.
 
         Raises:
-            ValueError: If any URL does not start with ``http://`` or
-                ``https://``, or has an empty netloc (no hostname).
+            ValueError: If any URL is empty, does not start with ``http://``
+                or ``https://``, or has an empty netloc (no hostname).
         """
         for name, url in v.items():
+            if not url:
+                msg = (
+                    f"Endpoint '{name}' has an empty URL. "
+                    "URLs must be sourced from the routing contract via "
+                    "ModelLlmEndpointHealthConfig.from_model_registry(); "
+                    "do not use os.getenv with an empty-string default."
+                )
+                raise ValueError(msg)
             if not url.startswith(("http://", "https://")):
                 safe_url = sanitize_url(url)
                 msg = (
@@ -97,6 +118,128 @@ class ModelLlmEndpointHealthConfig(BaseModel):
             "transitions from OPEN to HALF_OPEN"
         ),
     )
+
+    @classmethod
+    def from_model_registry(
+        cls,
+        registry_path: Path,
+        env_resolver: Callable[[str], str | None],
+    ) -> ModelLlmEndpointHealthConfig:
+        """Build config by reading model aliases and URL env-var names from a routing
+        contract YAML (e.g. ``docker/catalog/model_registry.yaml``).
+
+        This is the correct construction path — it sources model aliases from the
+        contract, not from hardcoded strings, and resolves URLs through an injected
+        ``env_resolver`` rather than reading ``os.getenv`` directly.  This makes
+        the factory fully testable without environment mutation.
+
+        Only models with ``transport: http`` and a ``base_url_env`` field are
+        included.  Non-HTTP transports (``oauth``, ``sdk``, etc.) are skipped
+        because they are not probeable via HTTP health endpoints.
+
+        The ``env_resolver`` is called with each model's ``base_url_env`` value:
+
+        - Returns ``None`` → endpoint not configured in this environment; skipped.
+        - Returns ``""`` → endpoint env var is set but empty; raises ``ValueError``
+          with a diagnostic message naming the var — **never silently ignored**.
+        - Returns a non-empty string → validated and included in the config.
+
+        Probe settings (``probe_interval_seconds``, ``probe_timeout_seconds``,
+        ``circuit_breaker_threshold``, ``circuit_breaker_reset_timeout``) use
+        field defaults.  To override them, use the resolved ``endpoints`` map
+        from this factory and construct a new config directly::
+
+            base = ModelLlmEndpointHealthConfig.from_model_registry(
+                registry_path=registry, env_resolver=os.getenv
+            )
+            config = ModelLlmEndpointHealthConfig(
+                endpoints=base.endpoints,
+                probe_interval_seconds=60.0,
+            )
+
+        Args:
+            registry_path: Path to the model registry YAML contract.  Must exist
+                and contain a ``models`` list.
+            env_resolver: Callable mapping an env-var name to its value, or
+                ``None`` if unset.  Pass ``os.getenv`` in production; pass a
+                mock dict's ``.get`` method in tests.
+
+        Returns:
+            A ``ModelLlmEndpointHealthConfig`` whose ``endpoints`` map contains
+            only the models whose env vars are set and non-empty, with all
+            probe settings at their field defaults.
+
+        Raises:
+            ValueError: If ``registry_path`` does not exist.
+            ValueError: If the YAML root is missing the ``models`` key.
+            ValueError: If ``env_resolver`` returns an empty string for any
+                model's ``base_url_env`` (empty = misconfigured, not absent).
+
+        Example::
+
+            import os
+            from pathlib import Path
+            from omnibase_infra.models.health.model_llm_endpoint_health_config import (
+                ModelLlmEndpointHealthConfig,
+            )
+
+            registry = Path("docker/catalog/model_registry.yaml")
+            config = ModelLlmEndpointHealthConfig.from_model_registry(
+                registry_path=registry,
+                env_resolver=os.getenv,
+            )
+            svc = ServiceLlmEndpointHealth(config=config, event_bus=bus)
+        """
+        if not registry_path.exists():
+            msg = f"Model registry not found: {registry_path}"
+            raise ValueError(msg)
+
+        import yaml  # guarded: pyyaml is a declared dep; import here avoids module-level cost
+
+        raw = yaml.safe_load(registry_path.read_text(encoding="utf-8"))
+        if not isinstance(raw, dict) or "models" not in raw:
+            msg = (
+                f"Invalid model registry at {registry_path}: "
+                "expected a mapping with a 'models' key"
+            )
+            raise ValueError(msg)
+
+        models = raw["models"]
+        if not isinstance(models, list):
+            msg = (
+                f"Invalid model registry at {registry_path}: "
+                "'models' must be a list of model entries"
+            )
+            raise ValueError(msg)
+
+        endpoints: dict[str, str] = {}
+        for entry in models:
+            if not isinstance(entry, dict):
+                continue
+            # Only probe HTTP-transport endpoints
+            if entry.get("transport") != "http":
+                continue
+            base_url_env = entry.get("base_url_env", "")
+            if not base_url_env:
+                continue
+            model_key = entry.get("model_key", "")
+            if not model_key:
+                continue
+
+            url = env_resolver(str(base_url_env))
+            if url is None:
+                # Env var absent — endpoint not deployed in this environment; skip.
+                continue
+            if not url:
+                msg = (
+                    f"Model '{model_key}' env var '{base_url_env}' is set but empty. "
+                    "Provide a valid http/https URL sourced from the routing contract. "
+                    "Do not use os.getenv with an empty-string default."
+                )
+                raise ValueError(msg)
+            endpoints[str(model_key)] = url
+
+        return cls(endpoints=endpoints)
 
 
 __all__: list[str] = ["ModelLlmEndpointHealthConfig"]

--- a/src/omnibase_infra/services/service_llm_endpoint_health.py
+++ b/src/omnibase_infra/services/service_llm_endpoint_health.py
@@ -147,7 +147,7 @@ class EndpointCircuitBreaker(MixinAsyncCircuitBreaker):
 
         Args:
             endpoint_name: Logical name used in the service name tag
-                (e.g. ``"coder-14b"`` becomes ``llm-endpoint.coder-14b``).
+                (e.g. ``"qwen3-coder-30b"`` becomes ``llm-endpoint.qwen3-coder-30b``).
             threshold: Consecutive failures before the circuit opens.
             reset_timeout: Seconds before an open circuit transitions to
                 half-open.
@@ -230,14 +230,23 @@ class EndpointCircuitBreaker(MixinAsyncCircuitBreaker):
 class ServiceLlmEndpointHealth:
     """Probes local LLM endpoints and tracks availability.
 
+    Endpoint configuration must be sourced from the routing contract YAML via
+    ``ModelLlmEndpointHealthConfig.from_model_registry()``.  Do **not** build
+    the ``endpoints`` map by calling ``os.getenv`` directly — that pattern
+    hard-codes stale model aliases and produces silent failures on empty env vars.
+
     Usage::
 
-        config = ModelLlmEndpointHealthConfig(
-            endpoints={
-                "coder-14b": os.getenv("LLM_CODER_URL", ""),
-                "qwen-embedding": os.getenv("LLM_EMBEDDING_URL", ""),
-            },
-            probe_interval_seconds=30.0,
+        import os
+        from pathlib import Path
+        from omnibase_infra.models.health.model_llm_endpoint_health_config import (
+            ModelLlmEndpointHealthConfig,
+        )
+
+        registry = Path("docker/catalog/model_registry.yaml")
+        config = ModelLlmEndpointHealthConfig.from_model_registry(
+            registry_path=registry,
+            env_resolver=os.getenv,
         )
         svc = ServiceLlmEndpointHealth(config=config, event_bus=bus)
         await svc.start()       # launches background probe loop
@@ -339,7 +348,7 @@ class ServiceLlmEndpointHealth:
         """Return the status for a single endpoint by logical name.
 
         Args:
-            name: Logical endpoint name (e.g. ``"coder-14b"``).
+            name: Logical endpoint name (e.g. ``"qwen3-coder-30b"``).
 
         Returns:
             The latest status, or ``None`` if not yet probed.

--- a/tests/unit/services/test_service_llm_endpoint_health.py
+++ b/tests/unit/services/test_service_llm_endpoint_health.py
@@ -143,16 +143,24 @@ class TestModelLlmEndpointHealthConfig:
             "https://",
             "http:///health",
             "https:///v1/models",
+            "http://user:pass@",
+            "https://user:pass@/v1/models",
         ],
         ids=[
             "http-empty-netloc",
             "https-empty-netloc",
             "http-empty-netloc-with-path",
             "https-empty-netloc-with-path",
+            "http-userinfo-only-no-host",
+            "https-userinfo-only-no-host",
         ],
     )
     def test_empty_netloc_url_rejected(self, empty_netloc_url: str) -> None:
-        """Endpoint URLs with empty netloc (no hostname) must raise ValidationError."""
+        """Endpoint URLs with no hostname must raise ValidationError.
+
+        Includes userinfo-only authorities (e.g. ``http://user:pass@``) where
+        ``urlparse(...).netloc`` is non-empty but ``parsed.hostname`` is None.
+        """
         with pytest.raises(ValidationError) as exc_info:
             ModelLlmEndpointHealthConfig(
                 endpoints={"bad-ep": empty_netloc_url},

--- a/tests/unit/services/test_service_llm_endpoint_health.py
+++ b/tests/unit/services/test_service_llm_endpoint_health.py
@@ -28,7 +28,10 @@ Related Tickets:
 from __future__ import annotations
 
 import asyncio
+import textwrap
+from collections.abc import Callable
 from datetime import UTC, datetime
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import httpx
@@ -244,6 +247,198 @@ class TestModelLlmEndpointHealthConfig:
             ModelLlmEndpointHealthConfig(probe_timeout_seconds=0.1)
         with pytest.raises(ValidationError):
             ModelLlmEndpointHealthConfig(probe_timeout_seconds=60.0)
+
+
+# =============================================================================
+# TestModelLlmEndpointHealthConfigFactory
+# OMN-13699: from_model_registry must source model keys from contract YAML
+# and resolve URLs through an injected env_resolver, not os.getenv directly.
+# =============================================================================
+
+_SAMPLE_REGISTRY_YAML = textwrap.dedent("""\
+    models:
+      - model_key: "qwen3-coder-30b"
+        provider: local
+        transport: http
+        base_url_env: LLM_CODER_URL
+        capabilities:
+          - code_generation
+        context_window: 114688
+        tier: local
+      - model_key: "qwen3-embedding-8b"
+        provider: local
+        transport: http
+        base_url_env: LLM_EMBEDDING_URL
+        capabilities:
+          - embeddings
+        context_window: 8192
+        tier: local
+      - model_key: "claude-sonnet"
+        provider: anthropic
+        transport: oauth
+        capabilities:
+          - reasoning
+        context_window: 200000
+        tier: frontier_api
+      - model_key: "glm-4.5"
+        provider: zhipu
+        transport: http
+        base_url_env: LLM_GLM_URL
+        capabilities:
+          - reasoning
+        context_window: 128000
+        tier: frontier_api
+""")
+
+
+class TestModelLlmEndpointHealthConfigFactory:
+    """Tests for ModelLlmEndpointHealthConfig.from_model_registry (OMN-13699).
+
+    The factory must source model aliases from the routing contract YAML and
+    resolve URLs through an injected env_resolver callable — never by calling
+    os.getenv directly.  Tests mock the env_resolver, not the environment.
+    """
+
+    @pytest.fixture
+    def registry_file(self, tmp_path: Path) -> Path:
+        """Write the sample registry YAML to a temp file and return its path."""
+        f = tmp_path / "model_registry.yaml"
+        f.write_text(_SAMPLE_REGISTRY_YAML, encoding="utf-8")
+        return f
+
+    def _make_resolver(self, env: dict[str, str | None]) -> Callable[[str], str | None]:
+        """Return a mock env_resolver backed by the supplied dict."""
+        return env.get  # type: ignore[return-value]
+
+    @pytest.mark.unit
+    def test_from_model_registry_happy_path(self, registry_file: Path) -> None:
+        """Factory builds config using model keys from the contract, not hardcoded names."""
+        resolver = self._make_resolver(
+            {
+                "LLM_CODER_URL": "http://localhost:8000",
+                "LLM_EMBEDDING_URL": "http://localhost:8100",
+            }
+        )
+        cfg = ModelLlmEndpointHealthConfig.from_model_registry(
+            registry_path=registry_file,
+            env_resolver=resolver,
+        )
+        # Model keys come from the YAML contract, not hardcoded aliases
+        assert "qwen3-coder-30b" in cfg.endpoints
+        assert cfg.endpoints["qwen3-coder-30b"] == "http://localhost:8000"
+        assert "qwen3-embedding-8b" in cfg.endpoints
+        assert cfg.endpoints["qwen3-embedding-8b"] == "http://localhost:8100"
+        # Stale aliases must NOT appear
+        assert "coder-14b" not in cfg.endpoints
+        assert "qwen-embedding" not in cfg.endpoints
+
+    @pytest.mark.unit
+    def test_from_model_registry_skips_non_http_transport(
+        self, registry_file: Path
+    ) -> None:
+        """Models with non-http transport (oauth, sdk) are excluded from health checks."""
+        resolver = self._make_resolver(
+            {
+                "LLM_CODER_URL": "http://localhost:8000",
+                "LLM_EMBEDDING_URL": "http://localhost:8100",
+                "LLM_GLM_URL": "http://localhost:9000",
+            }
+        )
+        cfg = ModelLlmEndpointHealthConfig.from_model_registry(
+            registry_path=registry_file,
+            env_resolver=resolver,
+        )
+        # oauth transport (claude-sonnet) must be skipped
+        assert "claude-sonnet" not in cfg.endpoints
+        # http transport models with env set must be included
+        assert "qwen3-coder-30b" in cfg.endpoints
+        assert "glm-4.5" in cfg.endpoints
+
+    @pytest.mark.unit
+    def test_from_model_registry_skips_unset_env_var(self, registry_file: Path) -> None:
+        """When env_resolver returns None, that endpoint is excluded (not an error)."""
+        resolver = self._make_resolver(
+            {
+                "LLM_CODER_URL": "http://localhost:8000",
+                # LLM_EMBEDDING_URL absent → env_resolver returns None
+            }
+        )
+        cfg = ModelLlmEndpointHealthConfig.from_model_registry(
+            registry_path=registry_file,
+            env_resolver=resolver,
+        )
+        assert "qwen3-coder-30b" in cfg.endpoints
+        assert "qwen3-embedding-8b" not in cfg.endpoints
+
+    @pytest.mark.unit
+    def test_from_model_registry_raises_on_empty_env_var(
+        self, registry_file: Path
+    ) -> None:
+        """env_resolver returning an empty string must raise ValueError — not silent fallback."""
+        resolver = self._make_resolver(
+            {
+                "LLM_CODER_URL": "",  # set but empty → misconfigured
+            }
+        )
+        with pytest.raises(ValueError, match="LLM_CODER_URL"):
+            ModelLlmEndpointHealthConfig.from_model_registry(
+                registry_path=registry_file,
+                env_resolver=resolver,
+            )
+
+    @pytest.mark.unit
+    def test_from_model_registry_raises_on_missing_registry(
+        self, tmp_path: Path
+    ) -> None:
+        """A non-existent registry path must raise ValueError with a clear message."""
+        missing = tmp_path / "does_not_exist.yaml"
+        with pytest.raises(ValueError, match="not found"):
+            ModelLlmEndpointHealthConfig.from_model_registry(
+                registry_path=missing,
+                env_resolver=lambda _: "http://localhost:8000",
+            )
+
+    @pytest.mark.unit
+    def test_from_model_registry_raises_on_invalid_yaml(self, tmp_path: Path) -> None:
+        """Registry YAML without a 'models' key must raise ValueError."""
+        bad = tmp_path / "bad_registry.yaml"
+        bad.write_text("not_models_key: {}", encoding="utf-8")
+        with pytest.raises(ValueError, match="models"):
+            ModelLlmEndpointHealthConfig.from_model_registry(
+                registry_path=bad,
+                env_resolver=lambda _: "http://localhost:8000",
+            )
+
+    @pytest.mark.unit
+    def test_from_model_registry_uses_field_defaults(self, registry_file: Path) -> None:
+        """Factory uses field defaults for probe settings; override via direct construction."""
+        resolver = self._make_resolver({"LLM_CODER_URL": "http://localhost:8000"})
+        cfg = ModelLlmEndpointHealthConfig.from_model_registry(
+            registry_path=registry_file,
+            env_resolver=resolver,
+        )
+        # Factory uses field defaults for probe settings
+        assert cfg.probe_interval_seconds == 30.0
+        assert cfg.probe_timeout_seconds == 5.0
+        # Caller can override by constructing from the resolved endpoints
+        custom = ModelLlmEndpointHealthConfig(
+            endpoints=cfg.endpoints,
+            probe_interval_seconds=60.0,
+            probe_timeout_seconds=10.0,
+        )
+        assert custom.probe_interval_seconds == 60.0
+        assert custom.probe_timeout_seconds == 10.0
+
+    @pytest.mark.unit
+    def test_from_model_registry_empty_registry(self, tmp_path: Path) -> None:
+        """A registry with no models entry produces an empty endpoints dict."""
+        empty_registry = tmp_path / "empty.yaml"
+        empty_registry.write_text("models: []\n", encoding="utf-8")
+        cfg = ModelLlmEndpointHealthConfig.from_model_registry(
+            registry_path=empty_registry,
+            env_resolver=lambda _: "http://localhost:8000",
+        )
+        assert cfg.endpoints == {}
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

**Ticket:** OMN-13699

`ServiceLlmEndpointHealth` documentation showed building `ModelLlmEndpointHealthConfig` with direct `os.getenv(...)` URL reads, stale model aliases, and empty-string defaults. That violated the URL-from-contract rule and made unset endpoint configuration fail with opaque URL validation errors.

## Changes

- Added `ModelLlmEndpointHealthConfig.from_model_registry(registry_path, env_resolver)` to read `model_key` / `base_url_env` entries from the routing contract YAML and resolve URLs through an injected resolver.
- Made empty endpoint URLs fail with a clear diagnostic instead of falling through to generic HTTP-scheme validation.
- Updated docstrings to use the contract-sourced factory and current model registry keys.
- Added `TestModelLlmEndpointHealthConfigFactory` coverage for happy path, non-HTTP transport skip, unset env skip, empty env rejection, missing registry, invalid YAML, defaults, and empty registry.
- Rebuilt the PR branch on current `origin/dev`; the branch now carries only the OMN-13699 fix commit.

## Validation

- `uv run ruff format --check src/omnibase_infra/models/health/model_llm_endpoint_health_config.py src/omnibase_infra/services/service_llm_endpoint_health.py tests/unit/services/test_service_llm_endpoint_health.py`
- `uv run ruff check src/omnibase_infra/models/health/model_llm_endpoint_health_config.py src/omnibase_infra/services/service_llm_endpoint_health.py tests/unit/services/test_service_llm_endpoint_health.py`
- `uv run mypy src/omnibase_infra/models/health/model_llm_endpoint_health_config.py src/omnibase_infra/services/service_llm_endpoint_health.py --strict`
- `uv run pytest tests/unit/services/test_service_llm_endpoint_health.py -v` — 73 passed
- `uv run python scripts/validation/validate_test_removal_gate.py --base origin/dev`
- `uv run python scripts/validation/validate_test_removal_gate.py --base origin/main`
- `uv run pre-commit run --files src/omnibase_infra/models/health/model_llm_endpoint_health_config.py src/omnibase_infra/services/service_llm_endpoint_health.py tests/unit/services/test_service_llm_endpoint_health.py`
- `OMNIMARKET_SRC="$OMNI_HOME/omnimarket" bash scripts/sync-node-migrations.sh --check`
- `uv run --frozen pytest tests/scripts/test_check_deployed_migration_tree_sync.py -q -p no:cacheprovider` — 9 passed

## Evidence-Source

Evidence-Source: OCC#3352
Evidence-Ticket: OMN-13699
OCC #3352 merged: 2026-06-29T12:19:11Z


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new way to build endpoint health configuration directly from a model registry file.
  * Health endpoints can now be generated from model keys and resolved environment values automatically.

* **Bug Fixes**
  * Improved URL validation to reject empty endpoint values with clearer error messages.
  * Added stricter handling for missing registry files, invalid registry content, and empty environment variables.

* **Documentation**
  * Updated guidance and examples to reflect the new registry-based configuration flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->