### PR TITLE
fix(OMN-13718): change plan_to_tickets plan-path to named --plan-path arg

### DIFF
--- a/src/omnibase_infra/cli/skill_mapping.yaml
+++ b/src/omnibase_infra/cli/skill_mapping.yaml
@@ -241,7 +241,7 @@ skills:
     node_name: node_plan_to_tickets
     result_model: omnimarket.nodes.node_plan_to_tickets.handlers.handler_plan_to_tickets.ModelPlanToTicketsResult
     args:
-      - {name: plan-path, payload_field: plan_path, arg_type: string, positional: true, required: true}
+      - {name: plan-path, payload_field: plan_path, arg_type: string, required: true}
       - {name: project, payload_field: project, arg_type: string}
       - {name: epic-title, payload_field: epic_title, arg_type: string}
       - {name: no-create-epic, payload_field: no_create_epic, arg_type: boolean, default: false}


### PR DESCRIPTION
## Summary

Fixes the CLI arg mapping side of OMN-13718. Before this fix, `onex skill plan_to_tickets --plan-path <file>`
was rejected with:

```
Error: Unknown argument '--plan-path' for skill 'plan_to_tickets'.
```

Because `plan-path` was declared with `positional: true` in `skill_mapping.yaml`, making it a bare
positional arg only. The documented invocation `onex skill plan_to_tickets --plan-path <file>` requires
a named flag.

**Fix:** Remove `positional: true` from the `plan-path` arg entry, making it a standard named
`--plan-path <path>` option (with `required: true` retained). This mirrors how `design_to_plan`
maps its `plan-path` arg.

**Paired PR:** OmniNode-ai/omnimarket#1510 fixes the other half: adds top-level `input_model` to
`node_plan_to_tickets/contract.yaml` so RuntimeLocal can build the payload from the mapped arg.

Both PRs together fix the full invocation: `onex skill plan_to_tickets --plan-path <file> --dry-run`

## dod_evidence

- **Before:** `Error: Unknown argument '--plan-path' for skill 'plan_to_tickets'`
- **After:** arg accepted, forwarded as `plan_path` in the payload dict
- Paired omnimarket test `test_omn_13718_plan_to_tickets_runtime_local.py::test_runtime_local_resolves_input_model` passes (COMPLETED, status=parsed)
- 1-line targeted change in skill_mapping.yaml; no other entries touched

Ticket: OMN-13718