### PR TITLE
fix(OMN-13718): change plan_to_tickets plan-path to named --plan-path arg

### DIFF
--- a/src/omnibase_infra/cli/skill_mapping.yaml
+++ b/src/omnibase_infra/cli/skill_mapping.yaml
@@ -241,7 +241,7 @@ skills:
     node_name: node_plan_to_tickets
     result_model: omnimarket.nodes.node_plan_to_tickets.handlers.handler_plan_to_tickets.ModelPlanToTicketsResult
     args:
-      - {name: plan-path, payload_field: plan_path, arg_type: string, positional: true, required: true}
+      - {name: plan-path, payload_field: plan_path, arg_type: string, required: true}
       - {name: project, payload_field: project, arg_type: string}
       - {name: epic-title, payload_field: epic_title, arg_type: string}
       - {name: no-create-epic, payload_field: no_create_epic, arg_type: boolean, default: false}

--- a/tests/unit/cli/test_cli_skill.py
+++ b/tests/unit/cli/test_cli_skill.py
@@ -884,3 +884,29 @@ def test_command_writes_payload_under_state_root_not_tmp(
     # Payload scratch lives under the state root, never /tmp.
     assert state_root in seen_paths[0].parents
     assert "tmp" in seen_paths[0].parts
+
+
+def test_plan_to_tickets_plan_path_is_named_not_positional() -> None:
+    """plan_to_tickets plan-path must be a named --plan-path flag (OMN-13718).
+
+    Regression guard: the original mapping declared plan-path with
+    positional=True, which registered it as a positional argument instead of
+    a named option. This caused `--plan-path` to be rejected as an unknown flag.
+    The fix removes positional=True so --plan-path is the accepted form.
+    """
+    registry = load_skill_registry()
+    skill = registry.get("plan_to_tickets")
+    assert skill is not None, "plan_to_tickets is absent from skill_mapping.yaml"
+
+    plan_path_args = [a for a in skill.args if a.name == "plan-path"]
+    assert plan_path_args, "plan-path arg is absent from plan_to_tickets mapping"
+    arg = plan_path_args[0]
+
+    # The arg must be required (named option, not positional).
+    assert arg.required is True, "plan-path must be required=True"
+    # Must NOT be positional — positional=True causes --plan-path to be rejected.
+    assert not arg.positional, (
+        "plan-path must NOT be positional; positional=True registers it as a "
+        "positional CLI arg and causes `--plan-path <file>` to be rejected as "
+        "'No such option: --plan-path' (OMN-13718 regression)"
+    )


### PR DESCRIPTION
## Summary

Fixes OMN-13718 (omnibase_infra side): `skill_mapping.yaml` declared `plan-path` with `positional: true`, registering it as a positional argument instead of a named option. This caused `--plan-path` to be rejected as an unknown flag.

**Fix:** Remove `positional: true` from the `plan-path` entry, registering it as a required named option `--plan-path <file>`.

Also syncs two vendored node migration files that the pre-commit `ONEX Node Migration Vendor Sync Check` gate required.

## Before fix

```
$ onex skill plan_to_tickets /path/to/plan.md --dry-run
Error: No such option: --plan-path
```

## After fix

`--plan-path <file>` is a named required option (matching documented usage).

## dod_evidence

Ticket: OMN-13718
omnimarket PR (contract fix + RuntimeLocal proof): OmniNode-ai/omnimarket#1513

Before: `--plan-path` rejected as unknown arg; positional form → RuntimeLocal input_model error.
After: named `--plan-path` accepted; combined with omnimarket contract fix → invocation works end-to-end.

See omnimarket#1513 for full proof: test `test_omn_13718_plan_to_tickets_runtime_local.py::test_runtime_local_resolves_input_model` → PASS, result=completed, status=parsed, entry_count=2.

Evidence-Source: OCC#3315
Evidence-Ticket: OMN-13718

