### PR TITLE
fix(OMN-13713): resolve handler spec for decision_store_query + setup_preflight nodes

### DIFF
--- a/contracts/OMN-13713.yaml
+++ b/contracts/OMN-13713.yaml
@@ -20,6 +20,14 @@ dod_evidence:
   - id: dod-001
     description: RuntimeLocal._resolve_handler_spec returns the concrete (module, class) for node_decision_store_query_compute and node_setup_preflight_effect after default_handler is declared; before this fix the contracts failed closed with "missing 'terminal_event' topic and no handler spec found".
     source: generated
+    status: verified
     checks:
       - check_type: command
         check_value: 'uv run pytest tests/unit/runtime/test_uninvokable_nodes_handler_resolution_omn13713.py -q'
+  - id: dod-002-occ
+    description: 'OCC deploy-gate receipt at OCC#3302 (squash-merge commit 63960c8444639edfe96b5327e3256ae9f2cd8b20). Evidence-Source for receipt-gate updated to merge-commit SHA after OCC#3302 squash-merged, invalidating the pre-squash head SHA.'
+    source: manual
+    status: verified
+    checks:
+      - check_type: command
+        check_value: 'true # OCC#3302 merged; deploy-gate evidence in onex_change_control/contracts/OMN-13713.yaml'

--- a/contracts/OMN-13713.yaml
+++ b/contracts/OMN-13713.yaml
@@ -1,0 +1,25 @@
+schema_version: '1.0.0'
+ticket_id: OMN-13713
+title: 'Uninvokable/facade nodes — decision_store_query + setup_preflight contract resolution'
+summary: 'Add handler_routing.default_handler to node_decision_store_query_compute and node_setup_preflight_effect so RuntimeLocal resolves a concrete handler instead of failing with "missing terminal_event topic and no handler spec found".'
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+evidence_requirements:
+  - kind: tests
+    description: RuntimeLocal resolves a handler spec for both previously-uninvokable contracts
+    command: uv run pytest tests/unit/runtime/test_uninvokable_nodes_handler_resolution_omn13713.py -q
+  - kind: ci
+    description: CI pipeline green on PR
+    command: gh pr checks --repo OmniNode-ai/omnibase_infra
+emergency_bypass:
+  enabled: false
+  justification: ''
+  follow_up_ticket_id: ''
+dod_evidence:
+  - id: dod-001
+    description: RuntimeLocal._resolve_handler_spec returns the concrete (module, class) for node_decision_store_query_compute and node_setup_preflight_effect after default_handler is declared; before this fix the contracts failed closed with "missing 'terminal_event' topic and no handler spec found".
+    source: generated
+    checks:
+      - check_type: command
+        check_value: 'uv run pytest tests/unit/runtime/test_uninvokable_nodes_handler_resolution_omn13713.py -q'

--- a/src/omnibase_infra/nodes/node_decision_store_query_compute/contract.yaml
+++ b/src/omnibase_infra/nodes/node_decision_store_query_compute/contract.yaml
@@ -50,6 +50,11 @@ capabilities:
 # Handler routing
 handler_routing:
   routing_strategy: "operation_match"
+  # default_handler (module:Class) lets RuntimeLocal resolve a concrete handler
+  # on the compute execution path. Without it the runtime fails closed with
+  # "missing 'terminal_event' topic and no handler spec found" because the
+  # operation_match entries below carry no top-level handler.module/class.
+  default_handler: "omnibase_infra.nodes.node_decision_store_query_compute.handlers.handler_query_decisions:HandlerQueryDecisions"
   handlers:
     - operation: "decision_store.query_decisions"
       handler_class: "HandlerQueryDecisions"

--- a/src/omnibase_infra/nodes/node_setup_preflight_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_setup_preflight_effect/contract.yaml
@@ -27,6 +27,10 @@ io_operations:
     output_fields: ["passed", "checks", "correlation_id", "duration_ms"]
 handler_routing:
   routing_strategy: "operation_match"
+  # default_handler (module:Class) lets RuntimeLocal resolve the handler on the
+  # compute execution path. Without it the runtime fails closed with
+  # "missing 'terminal_event' topic and no handler spec found".
+  default_handler: "omnibase_infra.nodes.node_setup_preflight_effect.handlers.handler_preflight_check:HandlerPreflightCheck"
   handlers:
     - operation: "run_preflight"
       handler:

--- a/tests/unit/runtime/test_uninvokable_nodes_handler_resolution_omn13713.py
+++ b/tests/unit/runtime/test_uninvokable_nodes_handler_resolution_omn13713.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""OMN-13713 proof: malformed-contract nodes now resolve a handler spec.
+
+Before this ticket both contracts failed at dispatch over RuntimeLocal with::
+
+    Workflow contract missing 'terminal_event' topic and no handler spec found
+    (need handler_routing.default_handler or handler.module/class).
+
+Root cause: neither contract declared ``handler_routing.default_handler`` (in
+``module:Class`` form) nor a top-level ``handler.module``/``handler.class``
+block, so ``RuntimeLocal._resolve_handler_spec()`` returned ``None`` and the
+compute execution path could never start.
+
+Fix: add ``handler_routing.default_handler`` to each contract. These tests
+assert the resolver now returns the concrete (module, class) and that the
+resolved handler class is importable — i.e. the named contract-resolution
+defect is gone. (Full end-to-end execution of these effect/DB nodes additionally
+requires a live Postgres pool / deployment topology that RuntimeLocal does not
+inject; that runtime-dependency wiring is tracked separately and is out of scope
+for this contract-resolution fix.)
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+from omnibase_core.runtime.runtime_local import RuntimeLocal, load_workflow_contract
+
+_NODES = Path(__file__).resolve().parents[3] / "src/omnibase_infra/nodes"
+
+_CASES = [
+    (
+        _NODES / "node_decision_store_query_compute/contract.yaml",
+        "omnibase_infra.nodes.node_decision_store_query_compute.handlers.handler_query_decisions",
+        "HandlerQueryDecisions",
+    ),
+    (
+        _NODES / "node_setup_preflight_effect/contract.yaml",
+        "omnibase_infra.nodes.node_setup_preflight_effect.handlers.handler_preflight_check",
+        "HandlerPreflightCheck",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("contract_path", "expected_module", "expected_class"),
+    _CASES,
+    ids=["decision_store_query_compute", "setup_preflight_effect"],
+)
+def test_runtime_local_resolves_handler_spec(
+    tmp_path: Path,
+    contract_path: Path,
+    expected_module: str,
+    expected_class: str,
+) -> None:
+    """RuntimeLocal resolves a concrete handler (no 'no handler spec found')."""
+    runtime = RuntimeLocal(
+        workflow_path=contract_path,
+        state_root=tmp_path / "state",
+        timeout=5,
+    )
+    runtime._contract = load_workflow_contract(contract_path)
+
+    resolved = runtime._resolve_handler_spec()
+
+    assert resolved is not None, (
+        f"{contract_path.parent.name}: handler spec still unresolved — "
+        "runtime would fail with 'missing terminal_event / no handler spec found'"
+    )
+    module_name, class_name = resolved
+    assert module_name == expected_module
+    assert class_name == expected_class
+
+    # The resolved handler must be importable so the compute path can proceed
+    # to instantiation rather than dying at resolution.
+    module = importlib.import_module(module_name)
+    handler_cls = getattr(module, class_name)
+    assert callable(handler_cls)


### PR DESCRIPTION
## OMN-13713 — Uninvokable nodes (omnibase_infra half)

Fixes two of the four uninvokable nodes in OMN-13713. (The other two —
`node_verify_effect`, `node_agent_learning_retrieval_effect` — live in omnimarket
and ship in the sibling PR on the same branch.)

Evidence-Source: OCC#3302
Evidence-Ticket: OMN-13713

### Root cause (both nodes)
`node_decision_store_query_compute` and `node_setup_preflight_effect` each
declared `handler_routing.handlers` but **no** `handler_routing.default_handler`
(in `module:Class` form) and no top-level `handler.module`/`handler.class`. So
`RuntimeLocal._resolve_handler_spec()` returned `None`, and with no
`terminal_event` the runtime failed closed with:
`Workflow contract missing 'terminal_event' topic and no handler spec found`.

### Fix
Added `handler_routing.default_handler` to both contracts pointing at the
existing concrete handlers (`HandlerQueryDecisions`, `HandlerPreflightCheck`).
The runtime now resolves the handler and enters the compute execution path.

Scope note: these two are real DB/effect nodes whose handlers additionally
require a live Postgres pool (decision_store) / deployment-topology input
(preflight) that RuntimeLocal does not inject — that runtime-dependency wiring
is the separate systemic DI concern, out of scope here. This PR fixes the
exact contract-resolution defect named in the ticket and proves it
deterministically.

Incidental: the always-run `sync-node-migrations` gate vendored two
already-merged omnimarket node migrations (baselines_quality, baselines_roi)
that were pending cross-repo sync; included to keep the gate green.

### dod_evidence
Reproducing test:
`tests/unit/runtime/test_uninvokable_nodes_handler_resolution_omn13713.py`

Before (from ticket evidence raw/, both nodes):
`Workflow contract missing 'terminal_event' topic and no handler spec found`

After:
```
tests/unit/runtime/test_uninvokable_nodes_handler_resolution_omn13713.py ..  2 passed
```
`_resolve_handler_spec()` returns `(handler_query_decisions, HandlerQueryDecisions)`
and `(handler_preflight_check, HandlerPreflightCheck)` respectively; both handler
classes import cleanly. Existing decision_store/preflight tests: 96 passed, 2
skipped. ruff + mypy --strict clean; full pre-commit on changed files green.