### PR TITLE
fix(OMN-13746): vendor omnimarket baselines projection migrations (node-migration-sync drift)

### DIFF
--- a/docker/migrations/forward/nodes/node_projection_baselines_quality/001_create_baselines_quality_snapshots.sql
+++ b/docker/migrations/forward/nodes/node_projection_baselines_quality/001_create_baselines_quality_snapshots.sql
@@ -1,0 +1,62 @@
+-- SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+-- SPDX-License-Identifier: MIT
+-- OMN-13076: Baselines quality snapshot projection table.
+--
+-- Backs the projection topic
+--   onex.snapshot.projection.baselines.quality.v1
+-- consumed by the omnidash quality-baseline-panel widget.
+--
+-- Source: per-snapshot ModelBaselinesComputedEvent carried on the topic
+-- onex.evt.omnibase-infra.baselines-computed.v1.
+-- One projection row per snapshot_id (upserted; latest per snapshot wins).
+-- Fields:
+--   patterns_compared       — total patterns compared in the snapshot window.
+--   patterns_recommended    — patterns for which a recommendation was produced.
+--   high_confidence_count   — comparisons where confidence == "high".
+--   medium_confidence_count — comparisons where confidence == "medium".
+--   low_confidence_count    — comparisons where confidence == "low" (or unknown tier).
+--   quality_score           — weighted avg: (high*1.0 + medium*0.5 + low*0.25)
+--                             / max(1, total_comparisons).
+--   recommend_rate          — patterns_recommended / max(1, patterns_compared).
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS baselines_quality_snapshots (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    -- Identity — upsert conflict key
+    snapshot_id TEXT NOT NULL,
+    -- Source event timestamp
+    captured_at TEXT NOT NULL,
+    -- Pattern counts from the snapshot
+    patterns_compared INTEGER NOT NULL DEFAULT 0 CHECK (patterns_compared >= 0),
+    patterns_recommended INTEGER NOT NULL DEFAULT 0 CHECK (patterns_recommended >= 0),
+    -- Confidence tier counts
+    high_confidence_count INTEGER NOT NULL DEFAULT 0 CHECK (high_confidence_count >= 0),
+    medium_confidence_count INTEGER NOT NULL DEFAULT 0 CHECK (medium_confidence_count >= 0),
+    low_confidence_count INTEGER NOT NULL DEFAULT 0 CHECK (low_confidence_count >= 0),
+    -- Derived quality metrics
+    quality_score NUMERIC(8, 6) NOT NULL DEFAULT 0 CHECK (quality_score >= 0 AND quality_score <= 1),
+    recommend_rate NUMERIC(8, 6) NOT NULL DEFAULT 0 CHECK (recommend_rate >= 0 AND recommend_rate <= 1),
+    -- Projection metadata
+    projected_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_baselines_quality_snapshots_snapshot_id
+    ON baselines_quality_snapshots (snapshot_id);
+
+CREATE INDEX IF NOT EXISTS ix_baselines_quality_snapshots_projected_at
+    ON baselines_quality_snapshots (projected_at DESC);
+
+CREATE OR REPLACE FUNCTION refresh_baselines_quality_snapshots_projected_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.projected_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_baselines_quality_snapshots_projected_at ON baselines_quality_snapshots;
+CREATE TRIGGER trg_baselines_quality_snapshots_projected_at
+    BEFORE UPDATE ON baselines_quality_snapshots
+    FOR EACH ROW
+    EXECUTE FUNCTION refresh_baselines_quality_snapshots_projected_at();

--- a/docker/migrations/forward/nodes/node_projection_baselines_roi/001_create_baselines_roi_snapshots.sql
+++ b/docker/migrations/forward/nodes/node_projection_baselines_roi/001_create_baselines_roi_snapshots.sql
@@ -1,0 +1,59 @@
+-- SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
+-- SPDX-License-Identifier: MIT
+-- OMN-13075: Baselines ROI snapshot projection table.
+--
+-- Backs the projection topic
+--   onex.snapshot.projection.baselines.roi.v1
+-- consumed by the omnidash BaselinesROICard widget (roi-trend, roi-by-model).
+--
+-- Source: per-snapshot ModelBaselinesComputedEvent carried on the topic
+-- onex.evt.omnibase-infra.baselines-computed.v1.
+-- One projection row per snapshot_id (upserted; latest per snapshot wins).
+-- Fields:
+--   token_delta   — sum of comparison.token_delta across all comparisons.
+--   time_delta_ms — sum of comparison.time_delta_s * 1000 across all comparisons.
+--   retry_delta   — sum of retry_count across all retry_counts.
+--   recommendations — JSONB counting actions: promote / shadow / suppress / fork.
+--   confidence    — average mapped confidence score across comparisons
+--                   (high=1.0, medium=0.5, low=0.25; 0.0 when no comparisons).
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS baselines_roi_snapshots (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    -- Identity — upsert conflict key
+    snapshot_id TEXT NOT NULL,
+    -- Source event timestamp
+    captured_at TEXT NOT NULL,
+    -- ROI aggregates
+    token_delta BIGINT NOT NULL DEFAULT 0,
+    time_delta_ms NUMERIC(18, 3) NOT NULL DEFAULT 0,
+    retry_delta INTEGER NOT NULL DEFAULT 0 CHECK (retry_delta >= 0),
+    -- Recommendation action counts stored as JSONB for structured access
+    -- Shape: {"promote": N, "shadow": N, "suppress": N, "fork": N}
+    recommendations JSONB NOT NULL DEFAULT '{"promote": 0, "shadow": 0, "suppress": 0, "fork": 0}',
+    -- Average confidence score [0.0, 1.0]
+    confidence NUMERIC(8, 6) NOT NULL DEFAULT 0 CHECK (confidence >= 0 AND confidence <= 1),
+    -- Projection metadata
+    projected_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_baselines_roi_snapshots_snapshot_id
+    ON baselines_roi_snapshots (snapshot_id);
+
+CREATE INDEX IF NOT EXISTS ix_baselines_roi_snapshots_projected_at
+    ON baselines_roi_snapshots (projected_at DESC);
+
+CREATE OR REPLACE FUNCTION refresh_baselines_roi_snapshots_projected_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.projected_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_baselines_roi_snapshots_projected_at ON baselines_roi_snapshots;
+CREATE TRIGGER trg_baselines_roi_snapshots_projected_at
+    BEFORE UPDATE ON baselines_roi_snapshots
+    FOR EACH ROW
+    EXECUTE FUNCTION refresh_baselines_roi_snapshots_projected_at();


### PR DESCRIPTION
## OMN-13746 — vendor omnimarket baselines projection migrations

Fixes the `node-migration-sync` drift discovered during OMN-13707 skill-e2e execution.

**Root cause:** `node_projection_baselines_quality` and `node_projection_baselines_roi` (omnimarket) ship migration SQL under `src/omnimarket/nodes/<node>/migrations/*.sql` but were merged without vendoring the copies into `docker/migrations/forward/nodes/<node>/`. The `node-migration-sync` gate (OMN-13124) checks out omnimarket@dev and runs `scripts/sync-node-migrations.sh --check`; the un-vendored copies fail it on every new infra PR — blocking OMN-13712 (#2147) and OMN-13715 (#2144).

**Fix:** ran `scripts/sync-node-migrations.sh` to vendor the two existing source migrations. No hand-authored SQL — byte-identical copies of the omnimarket source.

**dod_evidence (OMN-13746):**
- Before: `scripts/sync-node-migrations.sh --check` → `DRIFT: node_projection_baselines_quality/...` + `..._roi/...` → OUT OF SYNC.
- After: `scripts/sync-node-migrations.sh --check` → `check: in sync.` (exit 0).
- Diff: only the 2 vendored `.sql` files under `docker/migrations/forward/nodes/node_projection_baselines_{quality,roi}/`.

Evidence-Source: OCC#3313
Evidence-Ticket: OMN-13746

Unblocks OMN-13712, OMN-13715. Not merged — merging is owned by the separate merge-sweep.
