### PR TITLE
fix(OMN-13747): move runtime build+push to hosted runner to fix ECR push EOF

### DIFF
--- a/.github/workflows/build-and-push-runtime.yml
+++ b/.github/workflows/build-and-push-runtime.yml
@@ -156,7 +156,7 @@ jobs:
       - name: Free disk space (hosted runner)
         shell: bash
         run: |
-          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android /opt/hostedtoolcache/CodeQL /usr/local/share/boost "$AGENT_TOOLSDIRECTORY" 2>/dev/null || true
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android /opt/hostedtoolcache/CodeQL /usr/local/share/boost 2>/dev/null || true
           sudo docker image prune -af 2>/dev/null || true
           df -h /
 

--- a/.github/workflows/build-and-push-runtime.yml
+++ b/.github/workflows/build-and-push-runtime.yml
@@ -58,14 +58,8 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    # OMNI_RUNNER_SELECTOR_V1 — trusted Docker jobs default to self-hosted omnibase-ci; public forks default to ubuntu-latest
-    runs-on: >-
-      ${{
-        (github.event_name == 'pull_request' &&
-         github.event.pull_request.head.repo.full_name != github.repository)
-        && fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
-        || fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
-      }}
+    # OMN-13747: build+push runs on a hosted runner — the .201 self-hosted runner EOFs on docker push to ECR (clean cloud egress required). IAM push grant verified (ECRPushOmninodeRuntimeOMN13687).
+    runs-on: ubuntu-latest
     # Timeout breakdown (cold cache worst case):
     #   Docker build:        ~30 min (protobuf upgrade + cold cache adds ~16 min vs baseline)
     #   ECR push:            ~5 min
@@ -158,6 +152,13 @@ jobs:
       - name: Generate build timestamp
         id: timestamp
         run: echo "build_date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
+
+      - name: Free disk space (hosted runner)
+        shell: bash
+        run: |
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android /opt/hostedtoolcache/CodeQL /usr/local/share/boost "$AGENT_TOOLSDIRECTORY" 2>/dev/null || true
+          sudo docker image prune -af 2>/dev/null || true
+          df -h /
 
       - name: Build runtime image (local)
         id: build-local

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -989,6 +989,7 @@ jobs:
         with:
           name: test-results-${{ matrix.split }}
           path: junit-${{ matrix.split }}.xml
+          overwrite: true
           retention-days: 7
 
       - name: Upload test durations (for split rebalancing)
@@ -997,6 +998,7 @@ jobs:
         with:
           name: test-durations-split-${{ matrix.split }}
           path: .test_durations
+          overwrite: true
           retention-days: 7
 
   # ---------------------------------------------------------------------------

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -985,20 +985,18 @@ jobs:
 
       - name: Upload test results
         if: always()
-        continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
-          name: test-results-${{ matrix.split }}
+          name: test-results-attempt-${{ github.run_attempt }}-${{ matrix.split }}
           path: junit-${{ matrix.split }}.xml
           overwrite: true
           retention-days: 7
 
       - name: Upload test durations (for split rebalancing)
         if: always()
-        continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
-          name: test-durations-split-${{ matrix.split }}
+          name: test-durations-attempt-${{ github.run_attempt }}-${{ matrix.split }}
           path: .test_durations
           overwrite: true
           retention-days: 7
@@ -1302,10 +1300,9 @@ jobs:
 
       - name: Download all JUnit XML shards
         if: needs.test-parallel.result == 'success' || needs.test-parallel.result == 'failure'
-        continue-on-error: true
         uses: actions/download-artifact@v8
         with:
-          pattern: test-results-*
+          pattern: test-results-attempt-${{ github.run_attempt }}-*
           path: junit-shards
           merge-multiple: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -985,6 +985,7 @@ jobs:
 
       - name: Upload test results
         if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
           name: test-results-${{ matrix.split }}
@@ -994,6 +995,7 @@ jobs:
 
       - name: Upload test durations (for split rebalancing)
         if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
           name: test-durations-split-${{ matrix.split }}
@@ -1300,6 +1302,7 @@ jobs:
 
       - name: Download all JUnit XML shards
         if: needs.test-parallel.result == 'success' || needs.test-parallel.result == 'failure'
+        continue-on-error: true
         uses: actions/download-artifact@v8
         with:
           pattern: test-results-*

--- a/docker/migrations/forward/nodes/node_projection_delegation_inference_response/0001_create_projection_delegation_inference_response_text.sql
+++ b/docker/migrations/forward/nodes/node_projection_delegation_inference_response/0001_create_projection_delegation_inference_response_text.sql
@@ -18,9 +18,9 @@ CREATE TABLE IF NOT EXISTS projection_delegation_inference_response_text (
     -- task_type is not carried by ModelInferenceResponseData; defaults to empty
     latest_task_type          TEXT    NOT NULL DEFAULT '',
     latest_generated_text     TEXT    NOT NULL DEFAULT '',
-    latest_prompt_tokens      INT     NOT NULL DEFAULT 0,
-    latest_completion_tokens  INT     NOT NULL DEFAULT 0,
-    latest_latency_ms         INT     NOT NULL DEFAULT 0,
+    latest_prompt_tokens      INT     NOT NULL DEFAULT 0 CHECK (latest_prompt_tokens >= 0),
+    latest_completion_tokens  INT     NOT NULL DEFAULT 0 CHECK (latest_completion_tokens >= 0),
+    latest_latency_ms         INT     NOT NULL DEFAULT 0 CHECK (latest_latency_ms >= 0),
 
     -- The Kafka topic that feeds this projection
     source_topic              TEXT    NOT NULL
@@ -29,13 +29,16 @@ CREATE TABLE IF NOT EXISTS projection_delegation_inference_response_text (
     -- Rolling FIFO window of recent responses (max MAX_HISTORY = 10)
     -- Each entry: {correlation_id, model_name, task_type, generated_text,
     --              prompt_tokens, completion_tokens, latency_ms, captured_at}
-    recent_responses          JSONB   NOT NULL DEFAULT '[]'::jsonb,
+    recent_responses          JSONB   NOT NULL DEFAULT '[]'::jsonb
+        CHECK (jsonb_typeof(recent_responses) = 'array'),
 
     -- When this snapshot was last materialized
     captured_at               TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 
     -- True once the projection reducer has written at least one row
-    provisioned               BOOLEAN NOT NULL DEFAULT TRUE
+    provisioned               BOOLEAN NOT NULL DEFAULT TRUE,
+
+    CHECK (singleton_key = 'global')
 );
 
 -- Seed the singleton row so the projection-API always returns a row

--- a/docker/migrations/forward/nodes/node_projection_voice_sessions/0001_create_voice_sessions.sql
+++ b/docker/migrations/forward/nodes/node_projection_voice_sessions/0001_create_voice_sessions.sql
@@ -9,12 +9,15 @@ CREATE TABLE IF NOT EXISTS voice_sessions (
     started_at          TIMESTAMPTZ NOT NULL,
     ended_at            TIMESTAMPTZ,
     is_active           BOOLEAN NOT NULL DEFAULT TRUE,
-    total_turns         INTEGER NOT NULL DEFAULT 0,
-    total_duration_ms   BIGINT NOT NULL DEFAULT 0,
+    total_turns         INTEGER NOT NULL DEFAULT 0 CHECK (total_turns >= 0),
+    total_duration_ms   BIGINT NOT NULL DEFAULT 0 CHECK (total_duration_ms >= 0),
     agent_name          TEXT NOT NULL DEFAULT '',
-    transcript_turns    JSONB NOT NULL DEFAULT '[]',
+    transcript_turns    JSONB NOT NULL DEFAULT '[]'::jsonb
+        CHECK (jsonb_typeof(transcript_turns) = 'array'),
     ingested_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CHECK (ended_at IS NULL OR ended_at >= started_at)
 );
 
 CREATE INDEX IF NOT EXISTS idx_voice_sessions_started_at


### PR DESCRIPTION
## Summary

Fixes the real prod-image-pipeline blocker: `build-and-push-runtime.yml` builds the runtime image fine, but the `docker push` to ECR fails with a network EOF when the `build-and-push` job runs on the **.201 self-hosted runner**.

Ticket: OMN-13747

## Root cause (CI evidence)

CI job `83890173986`:

```
failed to do request: Head https://272493677981.dkr.ecr.us-east-1.amazonaws.com/v2/omninode-runtime/blobs/sha256:…: EOF
```

All 5 retries failed, each on a **different blob** — a connection/egress problem on the self-hosted runner, not a single bad layer.

This is **NOT an IAM/auth problem**:
- The live IAM policy `GitHubActionsLeastPrivilege` already grants push via statement `ECRPushOmninodeRuntimeOMN13687` (verified).
- The `omninode-runtime` ECR repo exists (verified).

The .201 self-hosted runner does not have clean cloud egress to ECR; the push TLS/HTTP handshake EOFs.

## Fix

- `build-and-push` job `runs-on:` changed from the `OMNI_RUNNER_SELECTOR_V1` self-hosted selector (`["self-hosted","omnibase-ci"]`) to `ubuntu-latest` (GitHub-hosted runner with clean cloud egress to ECR).
- Added a dependency-free **"Free disk space (hosted runner)"** step immediately before "Build runtime image (local)" so the large runtime image + Trivy scan fit on the ~14GB hosted runner.
- `lineage-guard` job left **unchanged** — it is a pure git-ancestry check on self-hosted, no ECR involved, fine as-is.

## dod_evidence

DoD: the next push to `main` (matching the runtime paths) builds and **pushes a clean digest** to the `omninode-runtime` ECR repo from the hosted runner, and `attest-source-hash` passes.

## Validation note

This **cannot be validated pre-merge**: the lineage guard requires a promoted-main HEAD, and the OIDC role only trusts omnibase_infra `main`/`dev`, so the hosted-runner push path is only exercised when this rides dev→main and the next auto-build runs.

Tradeoff: hosted runner = cold Docker cache (~30min builds) vs self-hosted local cache; acceptable for correctness. GHA cache (`cache-from`/`cache-to`) can be added later as an optimization.


Evidence-Ticket: OMN-13747
Evidence-Source: OCC#3354


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new database-backed projections for live events, session replay snapshots, voice sessions, intent classification events, MCP tool snapshots, receipt gate rows, sandbox decisions, and delegation inference response text.

* **Chores**
  * Improved runtime image builds by standardizing on hosted runners and adding pre-build disk cleanup to reduce build failures.
  * Enhanced CI test artifact handling by allowing shard uploads/downloads to continue even if individual steps fail, improving overall pipeline resilience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->