### PR TITLE
feat(OMN-13751): add public-surface uptime/502 alerting + k8s pod crash alerts

### DIFF
--- a/contracts/OMN-13751.yaml
+++ b/contracts/OMN-13751.yaml
@@ -1,0 +1,66 @@
+schema_version: "1.0.0"
+ticket_id: "OMN-13751"
+title: "Add public-surface uptime/502 alerting (omninode.ai/www/app/api synthetic check)"
+summary: >
+  The 2026-06-29 omniweb 502 was latent for ~34 days with no alert. This change extends the existing Prometheus monitoring stack (observability/prometheus/) with: (a) Blackbox Exporter scrape config probing https://omninode.ai/, https://www.omninode.ai/, https://app.omninode.ai/, and https://api.omninode.ai/health every 30 s, alerting via PublicSurfaceDown when any surface fails ≥ 3 consecutive probes (90 s `for` clause); and (b) k8s ImagePullBackOff/CrashLoopBackOff alerting for the onex-dev namespace via a PrometheusRule CRD (prometheus-operator path) and a CronJob (portable fallback). Alertmanager routes to the operator Slack channel. No Python source or migration changes. No prod cluster mutation — manifests require operator `kubectl apply` to activate (gated by OMN-13418).
+
+is_seam_ticket: false
+interface_change: false
+interfaces_touched: []
+emergency_bypass:
+  enabled: false
+  justification: ""
+  follow_up_ticket_id: ""
+dod_evidence:
+  - id: "dod-001"
+    description: >-
+      Prometheus rules file for public surface uptime exists and is valid YAML. The PublicSurfaceDown rule fires when probe_success{job="uptime-check"} == 0 for 90 s (≥ 3 consecutive 30 s probes). PublicSurfaceSlowResponse fires on probe_duration_seconds > 5 for 3 m.
+    source: "generated"
+    checks:
+      - check_type: "command"
+        check_value: "test -f observability/prometheus/rules/public-surface-uptime.yml && python3 -c \"import yaml; yaml.safe_load(open('observability/prometheus/rules/public-surface-uptime.yml'))\" && echo 'YAML valid'"
+      - check_type: "command"
+        check_value: "grep -q 'PublicSurfaceDown' observability/prometheus/rules/public-surface-uptime.yml && grep -q 'for: 90s' observability/prometheus/rules/public-surface-uptime.yml"
+  - id: "dod-002"
+    description: >-
+      Prometheus configuration updated to include the new rules file and Blackbox Exporter scrape config targeting all 4 public surfaces.
+    source: "generated"
+    checks:
+      - check_type: "command"
+        check_value: "grep -q 'public-surface-uptime.yml' observability/prometheus/prometheus.yml && grep -q 'uptime-check' observability/prometheus/prometheus.yml"
+      - check_type: "command"
+        check_value: "grep -q 'https://omninode.ai/' observability/prometheus/prometheus.yml && grep -q 'https://api.omninode.ai/health' observability/prometheus/prometheus.yml"
+  - id: "dod-003"
+    description: >-
+      Alertmanager config exists and routes to Slack (via ALERTMANAGER_SLACK_WEBHOOK_URL env var injected at startup with --config.expand-env=true). Inhibition rule suppresses PublicSurfaceSlowResponse when PublicSurfaceDown is already firing.
+    source: "generated"
+    checks:
+      - check_type: "command"
+        check_value: "test -f observability/prometheus/alertmanager.yml && python3 -c \"import yaml; yaml.safe_load(open('observability/prometheus/alertmanager.yml'))\" && echo 'YAML valid'"
+      - check_type: "command"
+        check_value: "grep -q 'PublicSurfaceDown' observability/prometheus/alertmanager.yml && grep -q 'slack-platform' observability/prometheus/alertmanager.yml"
+  - id: "dod-004"
+    description: >-
+      k8s PrometheusRule CRD for onex-dev namespace covers both CrashLoopBackOff and ImagePullBackOff/ErrImagePull waiting reasons via kube-state-metrics metric kube_pod_container_status_waiting_reason.
+    source: "generated"
+    checks:
+      - check_type: "command"
+        check_value: "test -f observability/k8s/alerting/pod-crash-prometheusrule.yaml && python3 -c \"import yaml; list(yaml.safe_load_all(open('observability/k8s/alerting/pod-crash-prometheusrule.yaml')))\" && echo 'YAML valid'"
+      - check_type: "command"
+        check_value: "grep -q 'CrashLoopBackOff' observability/k8s/alerting/pod-crash-prometheusrule.yaml && grep -q 'ImagePullBackOff' observability/k8s/alerting/pod-crash-prometheusrule.yaml && grep -q 'onex-dev' observability/k8s/alerting/pod-crash-prometheusrule.yaml"
+  - id: "dod-005"
+    description: >-
+      k8s CronJob (portable fallback) exists for environments without prometheus-operator. Runs every 5 m; checks pods in onex-dev namespace; fires Slack webhook on ImagePullBackOff/CrashLoopBackOff/OOMKilled. RBAC (ServiceAccount + Role + RoleBinding) declared in the same file.
+    source: "generated"
+    checks:
+      - check_type: "command"
+        check_value: "test -f observability/k8s/alerting/pod-crash-cronjob.yaml && python3 -c \"import yaml; list(yaml.safe_load_all(open('observability/k8s/alerting/pod-crash-cronjob.yaml')))\" && echo 'YAML valid'"
+      - check_type: "command"
+        check_value: "grep -q 'CrashLoopBackOff' observability/k8s/alerting/pod-crash-cronjob.yaml && grep -q 'onex-dev' observability/k8s/alerting/pod-crash-cronjob.yaml && grep -q 'ServiceAccount' observability/k8s/alerting/pod-crash-cronjob.yaml"
+  - id: "dod-deploy"
+    description: >-
+      Deploy-gate evidence: pure manifest/config/docs change — no Python source, no migration, no runtime schema, no env-for-model change. The new Prometheus rules and k8s manifests require operator `kubectl apply` and Docker Compose profile activation on .201 (both gated by OMN-13418 for any prod-cluster mutation). No autonomous prod cluster mutation performed by this PR.
+    source: "generated"
+    checks:
+      - check_type: "command"
+        check_value: "printf 'deploy gate: manifest/config-only PR; prod activation requires operator kubectl apply (OMN-13418 gate); no source or migration changes'"

--- a/docs/runbooks/public-surface-uptime.md
+++ b/docs/runbooks/public-surface-uptime.md
@@ -1,0 +1,198 @@
+# Public Surface Uptime Alerting — Runbook
+
+**Ticket:** OMN-13751
+**Severity scope:** `PublicSurfaceDown` (critical), `PublicSurfaceSlowResponse` (warning),
+`OnexPodCrashLoopBackOff` (critical), `OnexPodImagePullBackOff` (critical)
+
+---
+
+## Why this exists
+
+The 2026-06-29 omniweb outage (HTTP 502) was latent for approximately 34 days before
+an operator noticed it manually. No alert fired. This runbook documents the alerting
+stack added in OMN-13751 to close that gap.
+
+---
+
+## Alert conditions
+
+### PublicSurfaceDown
+
+**Fires when:** the Blackbox Exporter HTTP probe returns non-2xx for ≥ 3 consecutive
+30-second intervals (~90 seconds) for any of:
+
+- `https://omninode.ai/`
+- `https://www.omninode.ai/`
+- `https://app.omninode.ai/`
+- `https://api.omninode.ai/health`
+
+**Triage steps:**
+
+1. Check the surface directly: `curl -o /dev/null -s -w "%{http_code}" <URL>`
+2. Check omniweb logs on the AWS cluster:
+   `kubectl -n onex-dev logs -l app=omniweb --tail=100`
+3. Check the ALB/ingress for upstream errors.
+4. If the surface is a `502 Bad Gateway`, the backend pod is likely unhealthy —
+   check for CrashLoopBackOff or ImagePullBackOff (see below).
+
+**Silence:** do NOT silence this alert without first confirming the surface is live.
+A silence during an outage hides the problem from the next operator.
+
+### PublicSurfaceSlowResponse
+
+**Fires when:** probe duration > 5 seconds for ≥ 3 minutes on any probed surface.
+
+**Triage steps:**
+
+1. Check ALB latency metrics in the AWS console.
+2. Check CPU/memory on the backing pods: `kubectl -n onex-dev top pods`
+3. If the backing service is a container, review recent deploys:
+   `kubectl -n onex-dev rollout history deployment/<name>`
+
+### OnexPodCrashLoopBackOff
+
+**Fires when:** a container in namespace `onex-dev` has been in `CrashLoopBackOff`
+state for ≥ 5 minutes.
+
+**Triage steps:**
+
+```bash
+# Get logs from the crashing container
+kubectl -n onex-dev logs <pod-name> -c <container-name> --previous
+
+# Check pod events for OOM / startup failures
+kubectl -n onex-dev describe pod <pod-name>
+
+# Check if it is an entrypoint / init-container issue
+kubectl -n onex-dev get pod <pod-name> -o jsonpath='{.status.initContainerStatuses}'
+```
+
+If the crash is the runtime entrypoint stamp failure (schema fingerprint):
+see `docs/runbooks/apply-migrations.md` and the OMN-13666 fix.
+
+### OnexPodImagePullBackOff
+
+**Fires when:** a container in namespace `onex-dev` cannot pull its image for ≥ 5 minutes.
+
+**Triage steps:**
+
+```bash
+# Check which image is failing and why
+kubectl -n onex-dev describe pod <pod-name>
+
+# Verify ECR credentials / imagePullSecrets
+kubectl -n onex-dev get secret -o name | grep ecr
+
+# Force a re-pull by deleting and letting the deployment recreate
+kubectl -n onex-dev rollout restart deployment/<deployment-name>
+```
+
+---
+
+## Activation sequence
+
+### Part A — Prometheus uptime checking (Docker / .201)
+
+The Blackbox Exporter + Alertmanager services must be added to the observability
+Docker Compose profile on the .201 server.
+
+1. **Set required environment variables** (via Infisical / `.omnibase/.env`):
+
+   ```bash
+   ALERTMANAGER_SLACK_WEBHOOK_URL=https://hooks.slack.com/services/...
+   ALERTMANAGER_SLACK_CHANNEL=#alerts-platform
+   ```
+
+2. **Add Blackbox Exporter and Alertmanager** to the observability Docker Compose
+   profile in `docker/docker-compose.infra.yml`:
+
+   ```yaml
+   # Under the observability profile:
+   blackbox-exporter:
+     image: prom/blackbox-exporter:latest
+     profiles: [observability]
+     volumes:
+       - ./observability/prometheus/blackbox.yml:/etc/blackbox_exporter/config.yml:ro
+     ports:
+       - "9115:9115"
+
+   alertmanager:
+     image: prom/alertmanager:latest
+     profiles: [observability]
+     command:
+       - --config.file=/etc/alertmanager/alertmanager.yml
+       - --config.expand-env=true
+     volumes:
+       - ./observability/prometheus/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+     environment:
+       ALERTMANAGER_SLACK_WEBHOOK_URL: "${ALERTMANAGER_SLACK_WEBHOOK_URL}"
+       ALERTMANAGER_SLACK_CHANNEL: "${ALERTMANAGER_SLACK_CHANNEL}"
+     ports:
+       - "9093:9093"
+   ```
+
+3. **Start the observability profile**:
+
+   ```bash
+   docker compose -f docker/docker-compose.infra.yml --profile observability up -d
+   ```
+
+4. **Verify** Prometheus has picked up the uptime-check targets:
+   Open `http://<.201-host>:9090/targets` and confirm `uptime-check` shows 4 targets.
+
+5. **Verify alerts are evaluable**:
+   Open `http://<.201-host>:9090/alerts` and confirm `PublicSurfaceDown` and
+   `PublicSurfaceSlowResponse` appear in the list.
+
+### Part B — k8s pod crash alerting (onex-dev namespace)
+
+**Option 1 — PrometheusRule CRD** (if kube-prometheus-stack is installed):
+
+```bash
+kubectl apply -f observability/k8s/alerting/pod-crash-prometheusrule.yaml
+
+# Verify rule pickup (~2 m after apply)
+kubectl -n onex-dev get prometheusrule onex-pod-crash-alerts
+```
+
+**Option 2 — CronJob** (portable fallback):
+
+```bash
+# 1. Create the Slack webhook secret
+kubectl -n onex-dev create secret generic alerting-credentials \
+  --from-literal=slack_webhook_url=https://hooks.slack.com/services/...
+
+# 2. Apply all manifests (ServiceAccount, Role, RoleBinding, CronJob)
+kubectl apply -f observability/k8s/alerting/pod-crash-cronjob.yaml
+
+# 3. Test immediately (bypasses the 5-minute schedule)
+kubectl -n onex-dev create job --from=cronjob/pod-crash-alerter pod-crash-manual-test
+kubectl -n onex-dev logs -l job-name=pod-crash-manual-test
+```
+
+---
+
+## Test procedure (DoD verification)
+
+To verify a deliberately-broken surface fires the alert and clean state is quiet:
+
+```bash
+# Temporarily point a test target at an unreachable URL by manually checking
+# the Prometheus expression browser for: probe_success{instance="https://omninode.ai/"}
+# If the probe is working, the value should be 1. Block the URL at the firewall
+# or use a test target that returns 503 to verify the alert fires after 90 s.
+
+# Confirm clean state is quiet (all probes green):
+curl -s http://localhost:9090/api/v1/query?query=probe_success | \
+  python3 -c "import sys,json; d=json.load(sys.stdin); [print(r) for r in d['data']['result']]"
+```
+
+---
+
+## Related
+
+- `observability/prometheus/rules/public-surface-uptime.yml` — Alert rule definitions
+- `observability/prometheus/alertmanager.yml` — Alertmanager Slack routing config
+- `observability/k8s/alerting/pod-crash-prometheusrule.yaml` — PrometheusRule CRD
+- `observability/k8s/alerting/pod-crash-cronjob.yaml` — CronJob fallback
+- `docs/runbooks/runtime-crash-loop.md` — Runtime container crash-loop runbook

--- a/observability/k8s/alerting/pod-crash-cronjob.yaml
+++ b/observability/k8s/alerting/pod-crash-cronjob.yaml
@@ -1,0 +1,173 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# k8s CronJob — pod crash / image-pull alerting for onex-dev namespace (OMN-13751).
+#
+# Purpose: Portable fallback for when kube-prometheus-stack (prometheus-operator +
+# kube-state-metrics) is NOT installed. Runs every 5 minutes; inspects all pods in
+# the onex-dev namespace for ImagePullBackOff and CrashLoopBackOff conditions; fires
+# a Slack alert via incoming webhook when any are found.
+#
+# Prerequisites:
+#   1. A Kubernetes Secret named `alerting-credentials` in the onex-dev namespace
+#      with key `slack_webhook_url` containing the Slack incoming-webhook URL.
+#      Create with:
+#        kubectl -n onex-dev create secret generic alerting-credentials \
+#          --from-literal=slack_webhook_url=https://hooks.slack.com/services/...
+#   2. A ClusterRole / ClusterRoleBinding granting the `onex-alerter` ServiceAccount
+#      `get` + `list` on pods in the onex-dev namespace (defined below).
+#
+# Apply with:
+#   kubectl apply -f observability/k8s/alerting/pod-crash-cronjob.yaml
+#
+# Test immediately (bypass the 5-minute schedule):
+#   kubectl -n onex-dev create job --from=cronjob/pod-crash-alerter pod-crash-manual-test
+#   kubectl -n onex-dev logs -l job-name=pod-crash-manual-test
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: onex-alerter
+  namespace: onex-dev
+  labels:
+    app.kubernetes.io/part-of: onex
+    app.kubernetes.io/component: alerting
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: onex-alerter-pod-reader
+  namespace: onex-dev
+  labels:
+    app.kubernetes.io/part-of: onex
+    app.kubernetes.io/component: alerting
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: onex-alerter-pod-reader
+  namespace: onex-dev
+  labels:
+    app.kubernetes.io/part-of: onex
+    app.kubernetes.io/component: alerting
+subjects:
+  - kind: ServiceAccount
+    name: onex-alerter
+    namespace: onex-dev
+roleRef:
+  kind: Role
+  name: onex-alerter-pod-reader
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: pod-crash-alerter
+  namespace: onex-dev
+  labels:
+    app.kubernetes.io/part-of: onex
+    app.kubernetes.io/component: alerting
+    app.kubernetes.io/name: pod-crash-alerter
+  annotations:
+    onex.ai/ticket: OMN-13751
+    onex.ai/purpose: >-
+      Alerts on ImagePullBackOff and CrashLoopBackOff pods in onex-dev via Slack webhook. Fallback for environments without prometheus-operator.
+spec:
+  # Run every 5 minutes.
+  schedule: "*/5 * * * *"
+  # Keep the last 3 successful and 1 failed job for debugging.
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
+  # If a previous job is still running when the next schedule fires, skip the
+  # new run rather than running concurrently (avoids duplicate alerts).
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      # Fail the job if it doesn't complete within 4 minutes.
+      activeDeadlineSeconds: 240
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/part-of: onex
+            app.kubernetes.io/component: alerting
+        spec:
+          serviceAccountName: onex-alerter
+          restartPolicy: Never
+          containers:
+            - name: crash-checker
+              # Uses the standard kubectl image — no custom image required.
+              image: bitnami/kubectl:latest
+              imagePullPolicy: IfNotPresent
+              env:
+                - name: SLACK_WEBHOOK_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: alerting-credentials
+                      key: slack_webhook_url
+                - name: NAMESPACE
+                  value: onex-dev
+              command:
+                - /bin/bash
+                - -euo
+                - pipefail
+                - -c
+                - |
+                  # Collect all pods with waiting containers in crash/pull-error states.
+                  REASONS="CrashLoopBackOff|ImagePullBackOff|ErrImagePull|OOMKilled"
+                  PROBLEM_PODS=$(
+                    kubectl get pods -n "${NAMESPACE}" -o json |
+                    python3 -c "
+                  import sys, json
+                  data = json.load(sys.stdin)
+                  hits = []
+                  for pod in data.get('items', []):
+                      name = pod['metadata']['name']
+                      for cs in pod.get('status', {}).get('containerStatuses', []):
+                          w = cs.get('state', {}).get('waiting', {})
+                          reason = w.get('reason', '')
+                          if reason in ('CrashLoopBackOff', 'ImagePullBackOff', 'ErrImagePull', 'OOMKilled'):
+                              hits.append(f'{name}/{cs[\"name\"]} [{reason}]')
+                  print('\n'.join(hits))
+                  "
+                  )
+
+                  if [ -z "${PROBLEM_PODS}" ]; then
+                    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) [OK] No crash/pull-error pods in ${NAMESPACE}"
+                    exit 0
+                  fi
+
+                  echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) [ALERT] Problem pods found:"
+                  echo "${PROBLEM_PODS}"
+
+                  # Format a Slack message and POST to the webhook.
+                  PAYLOAD=$(python3 -c "
+                  import json, os, sys
+                  pods = os.environ['PROBLEM_PODS']
+                  ns = os.environ['NAMESPACE']
+                  lines = [f'• {p}' for p in pods.strip().split('\n')]
+                  body = {
+                    'text': (
+                      f':rotating_light: *k8s pod crash alert — {ns}*\n'
+                      + '\n'.join(lines)
+                      + '\n\nInspect with: \`kubectl -n {ns} describe pod <name>\`'
+                    )
+                  }
+                  print(json.dumps(body))
+                  " PROBLEM_PODS="${PROBLEM_PODS}")
+
+                  curl -fsSL -X POST \
+                    -H 'Content-Type: application/json' \
+                    -d "${PAYLOAD}" \
+                    "${SLACK_WEBHOOK_URL}"
+
+                  echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) [SENT] Slack alert delivered"
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  cpu: 200m
+                  memory: 128Mi

--- a/observability/k8s/alerting/pod-crash-prometheusrule.yaml
+++ b/observability/k8s/alerting/pod-crash-prometheusrule.yaml
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# PrometheusRule CRD — k8s pod crash alerting for onex-dev namespace (OMN-13751).
+#
+# Prerequisite: kube-prometheus-stack (or prometheus-operator + kube-state-metrics)
+# must be installed and configured to scrape the onex-dev namespace. If the
+# prometheus-operator is not available, use pod-crash-cronjob.yaml instead.
+#
+# Metrics source: kube-state-metrics
+#   kube_pod_container_status_waiting_reason — exposes the waiting reason per
+#   container, which includes "ImagePullBackOff", "ErrImagePull", and
+#   "CrashLoopBackOff" among others.
+#
+# Apply with:
+#   kubectl apply -f observability/k8s/alerting/pod-crash-prometheusrule.yaml
+#
+# Verify rule pickup (after ~2 m Prometheus re-evaluation):
+#   kubectl -n onex-dev get prometheusrule onex-pod-crash-alerts
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: onex-pod-crash-alerts
+  namespace: onex-dev
+  labels:
+    # Label selectors must match the Prometheus CR's ruleSelector — adjust if
+    # your kube-prometheus-stack uses different label keys.
+    prometheus: kube-prometheus
+    role: alert-rules
+    team: platform
+    app.kubernetes.io/part-of: onex
+spec:
+  groups:
+    - name: onex-pod-health
+      rules:
+        # -----------------------------------------------------------------------
+        # Critical: CrashLoopBackOff in onex-dev
+        # -----------------------------------------------------------------------
+        # kube_pod_container_status_waiting_reason == 1 for CrashLoopBackOff
+        # means a container is actively failing its startup command. The `for: 5m`
+        # clause absorbs one-time init failures (e.g. migration jobs that run once)
+        # while catching persistent crash loops within ~7 minutes of onset.
+        - alert: OnexPodCrashLoopBackOff
+          expr: |
+            kube_pod_container_status_waiting_reason{
+              namespace="onex-dev",
+              reason="CrashLoopBackOff"
+            } == 1
+          for: 5m
+          labels:
+            severity: critical
+            team: platform
+            namespace: onex-dev
+          annotations:
+            summary: "CrashLoopBackOff: {{ $labels.pod }}/{{ $labels.container }}"
+            description: >-
+              Container {{ $labels.container }} in pod {{ $labels.pod }} (namespace onex-dev) has been in CrashLoopBackOff for at least 5 minutes. Inspect with: kubectl -n onex-dev logs {{ $labels.pod }} -c {{ $labels.container }} and: kubectl -n onex-dev describe pod {{ $labels.pod }}
+            runbook: "https://github.com/OmniNode-ai/omnibase_infra/blob/main/docs/runbooks/public-surface-uptime.md"
+        # -----------------------------------------------------------------------
+        # Critical: ImagePullBackOff in onex-dev
+        # -----------------------------------------------------------------------
+        # ImagePullBackOff means the node cannot pull the container image — this
+        # blocks ALL containers on the pod from starting. The `for: 5m` clause
+        # avoids alerting on brief throttle back-offs during a fresh deploy.
+        - alert: OnexPodImagePullBackOff
+          expr: |
+            kube_pod_container_status_waiting_reason{
+              namespace="onex-dev",
+              reason=~"ImagePullBackOff|ErrImagePull"
+            } == 1
+          for: 5m
+          labels:
+            severity: critical
+            team: platform
+            namespace: onex-dev
+          annotations:
+            summary: "ImagePullBackOff: {{ $labels.pod }}/{{ $labels.container }}"
+            description: >-
+              Container {{ $labels.container }} in pod {{ $labels.pod }} (namespace onex-dev) cannot pull its image (reason: {{ $labels.reason }}). This prevents the pod from starting. Check the image tag, ECR credentials, and the pod's imagePullSecrets. Inspect with: kubectl -n onex-dev describe pod {{ $labels.pod }}
+            runbook: "https://github.com/OmniNode-ai/omnibase_infra/blob/main/docs/runbooks/public-surface-uptime.md"

--- a/observability/prometheus/alertmanager.yml
+++ b/observability/prometheus/alertmanager.yml
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# Alertmanager configuration for ONEX runtime + public-surface alerting (OMN-13751).
+#
+# Wiring: Prometheus evaluates alert rules; Alertmanager routes firing alerts to
+# the operator Slack channel. Start Alertmanager with `--config.expand-env=true`
+# so ${VAR} references resolve at startup from the environment/Infisical.
+#
+# Required environment variables (set via Infisical or the operator .env):
+#   ALERTMANAGER_SLACK_WEBHOOK_URL  — Slack incoming-webhook URL (non-bot token path).
+#                                     Create at: https://api.slack.com/apps → Incoming Webhooks.
+#   ALERTMANAGER_SLACK_CHANNEL     — Channel name to post to (e.g. #alerts-platform).
+#
+# See docs/runbooks/public-surface-uptime.md for the full activation sequence.
+global:
+  # How long to wait before declaring an alert resolved after the condition clears.
+  resolve_timeout: 5m
+  # Slack webhook URL injected from env at Alertmanager startup.
+  slack_api_url: ${ALERTMANAGER_SLACK_WEBHOOK_URL}
+route:
+  # Default route — all alerts go to the platform Slack channel.
+  group_by:
+    - alertname
+    - team
+    - job
+  # Wait up to 30 s to batch multiple alerts in the same group before sending.
+  group_wait: 30s
+  # Once a group notification has been sent, wait 5 m before sending again for
+  # new alerts in the same group.
+  group_interval: 5m
+  # Re-notify every 4 h while an alert remains firing.
+  repeat_interval: 4h
+  receiver: slack-platform
+receivers:
+  - name: slack-platform
+    slack_configs:
+      - channel: ${ALERTMANAGER_SLACK_CHANNEL}
+        send_resolved: true
+        icon_emoji: ":rotating_light:"
+        title: |
+          [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }}
+        text: |
+          {{ range .Alerts }}
+          *Surface/Service:* {{ .Labels.instance }}
+          *Severity:* {{ .Labels.severity }}
+          *Summary:* {{ .Annotations.summary }}
+          *Description:* {{ .Annotations.description }}
+          *Runbook:* {{ .Annotations.runbook }}
+          *Started:* {{ .StartsAt.Format "2006-01-02 15:04:05 UTC" }}
+          {{ end }}
+inhibit_rules:
+  # Suppress PublicSurfaceSlowResponse warnings for a surface when PublicSurfaceDown
+  # is already firing — the operator is already paged about the harder failure.
+  - source_matchers:
+      - alertname="PublicSurfaceDown"
+    target_matchers:
+      - alertname="PublicSurfaceSlowResponse"
+    equal:
+      - instance

--- a/observability/prometheus/prometheus.yml
+++ b/observability/prometheus/prometheus.yml
@@ -17,6 +17,7 @@ global:
   scrape_timeout: 10s
 rule_files:
   - "rules/runtime-health.yml"
+  - "rules/public-surface-uptime.yml"
 alerting:
   alertmanagers:
     - static_configs:
@@ -46,4 +47,32 @@ scrape_configs:
     static_configs:
       - targets: ["omninode-runtime-effects:9090"]
     metrics_path: /metrics
+    scrape_interval: 30s
+  # ---------------------------------------------------------------------------
+  # Blackbox Exporter — external HTTP uptime probes (OMN-13751)
+  # ---------------------------------------------------------------------------
+  # Probes the four public-facing OmniNode surfaces every 30 s using the
+  # http_2xx module (HTTP 200-299 = success). probe_success == 0 for ≥ 3
+  # consecutive intervals triggers the PublicSurfaceDown alert in
+  # rules/public-surface-uptime.yml.
+  #
+  # Requires: blackbox_exporter running at blackbox-exporter:9115 (add to the
+  # observability Docker Compose profile).
+  - job_name: "uptime-check"
+    metrics_path: /probe
+    params:
+      module: [http_2xx]
+    static_configs:
+      - targets:
+          - https://omninode.ai/
+          - https://www.omninode.ai/
+          - https://app.omninode.ai/
+          - https://api.omninode.ai/health
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: blackbox-exporter:9115
     scrape_interval: 30s

--- a/observability/prometheus/rules/public-surface-uptime.yml
+++ b/observability/prometheus/rules/public-surface-uptime.yml
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# Prometheus alerting rules for public-surface HTTP uptime (OMN-13751).
+#
+# Metric source: Blackbox Exporter (prom/blackbox-exporter)
+# Targets: https://omninode.ai/, https://www.omninode.ai/,
+#          https://app.omninode.ai/, https://api.omninode.ai/health
+#
+# Root cause for these rules (OMN-13751): the 2026-06-29 omniweb 502 was
+# latent for ~34 days with zero alerting. These rules close that gap by
+# probing each surface every 30 s and alerting on sustained non-2xx.
+#
+# Activation: add the blackbox_exporter + alertmanager services to the
+# observability Docker Compose profile (see prometheus.yml for scrape config).
+# See docs/runbooks/public-surface-uptime.md for full wiring instructions.
+groups:
+  - name: public-surface-uptime
+    rules:
+      # -----------------------------------------------------------------------
+      # Critical: public surface returning non-2xx or unreachable (≥ 3 consecutive
+      # -----------------------------------------------------------------------
+      # probe_success == 0 means the HTTP check failed (non-2xx or TCP timeout).
+      # The `for: 90s` clause means the metric must be 0 for three consecutive
+      # 30 s scrape intervals before the alert fires — matching the N=3 spec
+      # in OMN-13751. This eliminates transient 502s from rolling deploys while
+      # catching sustained outages within ~2 minutes of onset.
+      - alert: PublicSurfaceDown
+        expr: probe_success{job="uptime-check"} == 0
+        for: 90s
+        labels:
+          severity: critical
+          team: platform
+        annotations:
+          summary: "PUBLIC SURFACE DOWN: {{ $labels.instance }}"
+          description: >-
+            The HTTP probe for {{ $labels.instance }} has returned non-2xx (or is unreachable) for at least 3 consecutive intervals (90 s). This mirrors the 2026-06-29 omniweb 502 pattern which went undetected for ~34 days. Investigate the surface immediately.
+          runbook: "https://github.com/OmniNode-ai/omnibase_infra/blob/main/docs/runbooks/public-surface-uptime.md"
+      # -----------------------------------------------------------------------
+      # Warning: slow response (probe_duration_seconds > 5 s for 3 minutes)
+      # -----------------------------------------------------------------------
+      # A sustained slow response can precede a hard 502 or indicate upstream
+      # saturation. Lower urgency than a hard outage but worth investigating.
+      - alert: PublicSurfaceSlowResponse
+        expr: probe_duration_seconds{job="uptime-check"} > 5
+        for: 3m
+        labels:
+          severity: warning
+          team: platform
+        annotations:
+          summary: "Slow response on {{ $labels.instance }} ({{ $value | humanizeDuration }})"
+          description: >-
+            The HTTP probe for {{ $labels.instance }} has been taking > 5 s for at least 3 minutes. This may precede a hard 502 or indicate upstream saturation. Review application logs and upstream health.
+          runbook: "https://github.com/OmniNode-ai/omnibase_infra/blob/main/docs/runbooks/public-surface-uptime.md"


### PR DESCRIPTION
## Summary

Ticket: OMN-13751

The 2026-06-29 omniweb 502 was latent for ~34 days with no alert. This PR extends the existing Prometheus monitoring stack with:

**a) Public surface HTTP uptime checking (Prometheus Blackbox Exporter)**
- `observability/prometheus/prometheus.yml` — adds `uptime-check` scrape job probing all 4 public surfaces every 30 s via Blackbox Exporter
- `observability/prometheus/rules/public-surface-uptime.yml` — `PublicSurfaceDown` (critical: non-2xx for >= 3 consecutive probes / 90 s) + `PublicSurfaceSlowResponse` (warning: >5 s for 3 m)
- `observability/prometheus/alertmanager.yml` — Alertmanager Slack routing config (uses ALERTMANAGER_SLACK_WEBHOOK_URL via --config.expand-env=true)

**b) k8s pod crash alerting for onex-dev namespace**
- `observability/k8s/alerting/pod-crash-prometheusrule.yaml` — PrometheusRule CRD for kube-state-metrics: OnexPodCrashLoopBackOff + OnexPodImagePullBackOff/ErrImagePull (both for: 5m)
- `observability/k8s/alerting/pod-crash-cronjob.yaml` — portable CronJob fallback (every 5 m, RBAC included) for environments without prometheus-operator

**Runbook:** `docs/runbooks/public-surface-uptime.md` — activation sequence, triage steps, test procedure

No Python source, no migration, no schema changes. Manifests require operator kubectl apply to activate in-cluster (gated by OMN-13418).

### Alert conditions (exact)

| Alert | Condition | `for` |
|-------|-----------|-------|
| PublicSurfaceDown | probe_success{job="uptime-check"} == 0 | 90s (>=3 consecutive 30s probes) |
| PublicSurfaceSlowResponse | probe_duration_seconds{job="uptime-check"} > 5 | 3m |
| OnexPodCrashLoopBackOff | kube_pod_container_status_waiting_reason{ns="onex-dev", reason="CrashLoopBackOff"} == 1 | 5m |
| OnexPodImagePullBackOff | kube_pod_container_status_waiting_reason{ns="onex-dev", reason="ImagePullBackOff|ErrImagePull"} == 1 | 5m |

### dod_evidence

All DoD checks verified locally:
- grep -q 'PublicSurfaceDown' + 'for: 90s' in public-surface-uptime.yml -> passed
- grep -q 'uptime-check' + 'https://api.omninode.ai/health' in prometheus.yml -> passed
- python3 YAML validate pod-crash-prometheusrule.yaml (1 doc) -> passed
- python3 YAML validate pod-crash-cronjob.yaml (4 docs: SA, Role, RoleBinding, CronJob) -> passed
- yamlfmt pre-commit hook -> Passed on all 7 changed files
- reject-deploy-gate-skip-token -> Passed
- ruff format/check -> Passed (no Python files changed)

Evidence-Ticket: OMN-13751
Evidence-Source: OCC#3356
