### PR TITLE
feat(OMN-13414): documented cold-lane full bring-up path in deploy-runtime.sh

### DIFF
--- a/docker/migrations/forward/nodes/node_projection_delegation_inference_response/0001_create_projection_delegation_inference_response_text.sql
+++ b/docker/migrations/forward/nodes/node_projection_delegation_inference_response/0001_create_projection_delegation_inference_response_text.sql
@@ -18,9 +18,9 @@ CREATE TABLE IF NOT EXISTS projection_delegation_inference_response_text (
     -- task_type is not carried by ModelInferenceResponseData; defaults to empty
     latest_task_type          TEXT    NOT NULL DEFAULT '',
     latest_generated_text     TEXT    NOT NULL DEFAULT '',
-    latest_prompt_tokens      INT     NOT NULL DEFAULT 0,
-    latest_completion_tokens  INT     NOT NULL DEFAULT 0,
-    latest_latency_ms         INT     NOT NULL DEFAULT 0,
+    latest_prompt_tokens      INT     NOT NULL DEFAULT 0 CHECK (latest_prompt_tokens >= 0),
+    latest_completion_tokens  INT     NOT NULL DEFAULT 0 CHECK (latest_completion_tokens >= 0),
+    latest_latency_ms         INT     NOT NULL DEFAULT 0 CHECK (latest_latency_ms >= 0),
 
     -- The Kafka topic that feeds this projection
     source_topic              TEXT    NOT NULL
@@ -29,13 +29,16 @@ CREATE TABLE IF NOT EXISTS projection_delegation_inference_response_text (
     -- Rolling FIFO window of recent responses (max MAX_HISTORY = 10)
     -- Each entry: {correlation_id, model_name, task_type, generated_text,
     --              prompt_tokens, completion_tokens, latency_ms, captured_at}
-    recent_responses          JSONB   NOT NULL DEFAULT '[]'::jsonb,
+    recent_responses          JSONB   NOT NULL DEFAULT '[]'::jsonb
+        CHECK (jsonb_typeof(recent_responses) = 'array'),
 
     -- When this snapshot was last materialized
     captured_at               TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 
     -- True once the projection reducer has written at least one row
-    provisioned               BOOLEAN NOT NULL DEFAULT TRUE
+    provisioned               BOOLEAN NOT NULL DEFAULT TRUE,
+
+    CHECK (singleton_key = 'global')
 );
 
 -- Seed the singleton row so the projection-API always returns a row

--- a/docker/migrations/forward/nodes/node_projection_swarm/0001_create_swarm_runs.sql
+++ b/docker/migrations/forward/nodes/node_projection_swarm/0001_create_swarm_runs.sql
@@ -1,0 +1,51 @@
+-- OMN-13084: node-owned projection migration for swarm_runs.
+--
+-- WHY THIS EXISTS
+--   node_projection_swarm declares projection_api over swarm_runs (topic
+--   onex.snapshot.projection.swarm.runs.v1). The projection API reads the
+--   omnidash_analytics projection database; only node-owned migrations under
+--   src/omnimarket/nodes/<node>/migrations/*.sql are vendored into that database
+--   by omnibase_infra/scripts/sync-node-migrations.sh +
+--   run-forward-migrations.sh (applied against NODE_POSTGRES_DB).
+--
+--   The original swarm_runs DDL (omnibase_infra forward/082_swarm_runs.sql) runs
+--   against the flat infra database (POSTGRES_DB), not the projection database,
+--   so the projection API would mark the topic DEGRADED ("table not found") and
+--   the dashboard would render empty. This node-local migration materialises the
+--   table in the projection database the API actually reads.
+--
+-- Idempotency: CREATE TABLE / INDEX guarded so the migration is safe to re-apply.
+CREATE TABLE IF NOT EXISTS swarm_runs (
+  run_id            TEXT PRIMARY KEY,
+  correlation_id    TEXT NOT NULL,
+  status            TEXT NOT NULL,
+  task_hash         TEXT NOT NULL DEFAULT '',
+  subtask_count     INTEGER NOT NULL DEFAULT 0,
+  succeeded_count   INTEGER NOT NULL DEFAULT 0,
+  failed_count      INTEGER NOT NULL DEFAULT 0,
+  skipped_count     INTEGER NOT NULL DEFAULT 0,
+  models_used       TEXT[] DEFAULT '{}',
+  machines_used     TEXT[] DEFAULT '{}',
+  total_cost_usd                DOUBLE PRECISION DEFAULT 0.0,
+  cloud_equivalent_cost_usd     DOUBLE PRECISION DEFAULT 0.0,
+  savings_usd                   DOUBLE PRECISION DEFAULT 0.0,
+  parallelism_speedup_ratio     DOUBLE PRECISION DEFAULT 1.0,
+  decomposition_latency_ms      INTEGER DEFAULT 0,
+  dispatch_wall_latency_ms      INTEGER DEFAULT 0,
+  aggregation_latency_ms        INTEGER DEFAULT 0,
+  total_latency_ms              INTEGER DEFAULT 0,
+  endpoint_registry_hash        TEXT DEFAULT '',
+  registry_schema_version       TEXT DEFAULT '',
+  projection_cursor             TEXT DEFAULT '',
+  source_event_id               TEXT DEFAULT '',
+  source_topic                  TEXT DEFAULT '',
+  source_partition              INTEGER DEFAULT 0,
+  source_offset                 INTEGER DEFAULT 0,
+  reducer_version               TEXT DEFAULT '1.0.0',
+  freshness_state               TEXT DEFAULT 'fresh',
+  observed_at                   TIMESTAMPTZ,
+  created_at                    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Projection API orders by created_at DESC (most recent runs first).
+CREATE INDEX IF NOT EXISTS idx_swarm_runs_created_at ON swarm_runs (created_at DESC);

--- a/docker/migrations/forward/nodes/node_projection_voice_sessions/0001_create_voice_sessions.sql
+++ b/docker/migrations/forward/nodes/node_projection_voice_sessions/0001_create_voice_sessions.sql
@@ -9,12 +9,15 @@ CREATE TABLE IF NOT EXISTS voice_sessions (
     started_at          TIMESTAMPTZ NOT NULL,
     ended_at            TIMESTAMPTZ,
     is_active           BOOLEAN NOT NULL DEFAULT TRUE,
-    total_turns         INTEGER NOT NULL DEFAULT 0,
-    total_duration_ms   BIGINT NOT NULL DEFAULT 0,
+    total_turns         INTEGER NOT NULL DEFAULT 0 CHECK (total_turns >= 0),
+    total_duration_ms   BIGINT NOT NULL DEFAULT 0 CHECK (total_duration_ms >= 0),
     agent_name          TEXT NOT NULL DEFAULT '',
-    transcript_turns    JSONB NOT NULL DEFAULT '[]',
+    transcript_turns    JSONB NOT NULL DEFAULT '[]'::jsonb
+        CHECK (jsonb_typeof(transcript_turns) = 'array'),
     ingested_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CHECK (ended_at IS NULL OR ended_at >= started_at)
 );
 
 CREATE INDEX IF NOT EXISTS idx_voice_sessions_started_at

--- a/docs/runbooks/cold-lane-full-bringup.md
+++ b/docs/runbooks/cold-lane-full-bringup.md
@@ -1,0 +1,169 @@
+# Cold-lane full bring-up (deps + migration one-shots + full `--profile runtime`)
+
+This runbook documents how to bring a **cold** runtime lane all the way back up
+from merged-dev source, and how that differs from the **warm** runtime refresh.
+It exists because the dev lane is ephemeral — it is GC/idle-reclaimed and can be
+torn down to **zero containers** between sessions — and bringing a fully cold
+lane up is materially harder than the documented "recreate the runtime services"
+warm path.
+
+Ticket: **OMN-13414** (parent epic OMN-13410).
+Evidence baseline: `.onex_state/runtime-e2e-2026-06-21/02-dev-deploy/`.
+
+> Scope: this is the **dev** lane procedure (compose project `omnibase-infra`,
+> the fully mutable test platform). Prod / judge / stability-test lanes are
+> separate compose projects and are **not** brought up this way — a cold lane
+> build is a workspace (non-main-lineage) image that the prod-promotion gate
+> refuses. Promote a clean-main release to prod via the gated node path
+> (`node_redeploy_orchestrator`), never via `--cold`.
+
+---
+
+## Cold vs warm — which path do I want?
+
+| | **Warm** (`--restart`) | **Cold** (`--cold`) |
+|---|---|---|
+| Lane state going in | deps + broker already running | zero containers (GC-reclaimed / torn down) |
+| What the final `up` touches | `RUNTIME_SERVICES` subset only, `up -d --no-deps` | the WHOLE `--profile runtime` project, `up -d` (honors `depends_on`) |
+| Build source | whatever `BUILD_SOURCE` selects (default `release`) | forced `workspace` (merged-dev siblings) |
+| Requires `OMNI_HOME` | only if `BUILD_SOURCE=workspace` | yes (workspace build) |
+| Command | `./scripts/deploy-runtime.sh --execute --restart` | `OMNI_HOME=… ./scripts/deploy-runtime.sh --execute --cold` |
+
+Both paths share the same cold-start preflight (core-infra readiness, broker
+partition cap, the forward/intelligence migration one-shots, and a raised
+`KAFKA_TIMEOUT_SECONDS` consumer-join budget). They differ **only** in the final
+`up` step and in the build source.
+
+---
+
+## The two gotchas this path encodes
+
+Two undocumented gotchas cost real time during the 2026-06-21 runtime-e2e run.
+The `--cold` path now encodes both so an operator does not have to rediscover
+them.
+
+### Gotcha 1 — the runtime profile is mandatory
+
+Every runtime service in `docker/docker-compose.infra.yml` is gated behind a
+compose profile:
+
+```yaml
+profiles: ["runtime", "full"]
+```
+
+A bare `docker compose up -d` matches **no** profiled service and **starts
+nothing** — the deps may come up but the kernel, effects, projection-api, and
+the consumer/projection fleet all stay down. `--profile runtime` (or `full`) is
+**mandatory**. `bringup_full_stack()` always passes `--profile "${COMPOSE_PROFILE}"`
+(default `runtime`).
+
+### Gotcha 2 — workspace build-args, not the default `release`
+
+`deploy-runtime.sh` defaults `BUILD_SOURCE=release`, which builds the runtime
+image from the **published PyPI packages**. A release image cannot carry
+**un-released merged-dev code**, which is exactly what a cold/GC-reclaimed lane
+must be rebuilt from. Workspace mode needs explicit build-args:
+
+- `BUILD_SOURCE=workspace`
+- `OMNI_HOME=<omni_home>`
+- the sibling REF args (`OMNIBASE_COMPAT_REF`, `OMNIMARKET_REF`,
+  `ONEX_CHANGE_CONTROL_REF`) + `RUNTIME_VERSION`
+- and `scripts/runtime_build/stage_workspace.sh` must vendor the local siblings
+  into `workspace/sibling-repos/` before the build.
+
+`--cold` forces `BUILD_SOURCE=workspace` (so a contradictory
+`BUILD_SOURCE=release` is rejected up front), `build_images()` stamps all the
+workspace build-args, and `stage_workspace_if_needed()` runs `stage_workspace.sh`
+automatically inside `sync_files`.
+
+---
+
+## Procedure
+
+### 0. Pre-flight: sync the canonical clones to the merged-dev tips
+
+A workspace build vendors the **local** sibling clones, so they must be at the
+intended merged-dev SHAs first. On the deploy host:
+
+```bash
+cd "$OMNI_HOME"
+bash ./omnibase_infra/scripts/pull-all.sh
+```
+
+The build is gated by the **sibling lock-pin preflight** (OMN-12987): every
+vendored sibling's version/SHA must match `omnimarket/uv.lock`. If a sibling
+drifted from the lock (e.g. an OCC receipt PR merged after the lock was last
+written), `stage_workspace.sh` aborts with exit 3. The correct fix is to advance
+`omnimarket/uv.lock` to the current sibling SHAs and re-merge — **not** to set
+`ALLOW_SIBLING_PIN_DRIFT=1`. See `.onex_state/runtime-e2e-2026-06-21/02-dev-deploy/02-BLOCKED-summary.md`.
+
+### 1. Preview (dry-run)
+
+```bash
+OMNI_HOME="$OMNI_HOME" ./scripts/deploy-runtime.sh --cold
+```
+
+Dry-run stops before any mutation and shows what would be deployed (version, SHA,
+compose project, profile, and the workspace build source).
+
+### 2. Inspect the exact compose commands
+
+```bash
+OMNI_HOME="$OMNI_HOME" ./scripts/deploy-runtime.sh --cold --print-compose-cmd
+```
+
+This prints the build command (with `BUILD_SOURCE=workspace` and the sibling REF
+build-args) and the "Full stack up" command
+(`docker compose -p omnibase-infra -f …infra.yml --profile runtime up -d`).
+
+### 3. Execute the cold full bring-up
+
+```bash
+OMNI_HOME="$OMNI_HOME" ./scripts/deploy-runtime.sh --execute --cold
+```
+
+This will, in order:
+
+1. stage the workspace siblings (`stage_workspace.sh` + sibling lock-pin guard),
+2. rsync + write the registry,
+3. build the workspace-mode images (`BUILD_SOURCE=workspace`),
+4. raise the cold-start `KAFKA_TIMEOUT_SECONDS` budget,
+5. `ensure_core_infra_ready` — bring up + wait on postgres/valkey,
+6. `warm_broker_topic_provisioning` — bring up redpanda + apply the partition cap,
+7. `run_runtime_migration_preflight` — run the forward + intelligence migration
+   one-shots and assert the projection tables exist,
+8. `bringup_full_stack` — `docker compose … --profile runtime up -d` over the
+   WHOLE project, and
+9. `verify_deployment` — health endpoint + image-label + log-sentinel checks.
+
+### 4. Verify
+
+```bash
+docker compose -p omnibase-infra ps
+curl -fsS "http://${INFRA_HOST}:8085/health"
+docker inspect omninode-runtime \
+  --format='{{index .Config.Labels "com.omninode.build_source"}}'   # -> workspace
+```
+
+---
+
+## Known cold-DB caveat (out of scope for OMN-13414)
+
+On a **truly cold DB**, the forward-migration one-shot can fail on a migration
+that does `CREATE OR REPLACE VIEW` with reordered columns (Postgres forbids
+renaming view columns in place). This is a **migration-source** defect that only
+manifests on a from-scratch DB; incremental redeploys never re-run the offending
+migration. It is tracked separately and is **not** something `--cold` can paper
+over — the bring-up correctly fails fast at the migration preflight rather than
+booting the kernel against a half-migrated schema. See
+`.onex_state/runtime-e2e-2026-06-21/02-dev-deploy/99-result-summary.md`.
+
+---
+
+## Related runbooks
+
+- `docs/runbooks/emergency-runtime-refresh.md` — surgical warm runtime refresh
+  that must not touch core infra.
+- `docs/runbooks/stability-test-runtime-lane.md` — the stability-test lane prep.
+- `docs/runbooks/apply-migrations.md` / `vendored-node-migrations.md` — migration
+  mechanics referenced by the preflight.

--- a/scripts/deploy-runtime.sh
+++ b/scripts/deploy-runtime.sh
@@ -156,6 +156,14 @@ DEPLOY_DIR_TO_CLEANUP=""
 # Default is hardcoded and safe; any changes must comply with ^[a-zA-Z0-9_-]+$ (see parse_args).
 COMPOSE_PROFILE="runtime"
 PRINT_COMPOSE_CMD=false
+# When true (--cold), run the cold-lane FULL bring-up path (OMN-13414): build in
+# workspace mode from the merged-dev siblings, bring up deps + migration
+# one-shots, then bring the WHOLE --profile runtime project up (not just the
+# RUNTIME_SERVICES subset the warm --restart path recreates). Two gotchas this
+# encodes: the runtime profile is mandatory (a bare `up -d` starts nothing) and
+# the build must be workspace-sourced (release packages cannot carry un-released
+# merged-dev code, so a release image starts a cold lane on stale code).
+COLD_FULL_BRINGUP=false
 # When true (--prod, or ONEX_DEPLOY_LANE=prod), the prod promotion-lineage guard
 # runs before any build: the source tree must be clean AND HEAD must be an
 # ancestor-of/equal-to origin/main. Prevents building the prod image from a
@@ -233,6 +241,24 @@ OPTIONS
     --execute           Actually deploy: rsync, write registry, build images.
     --force             Required to overwrite an existing version directory.
     --restart           Restart runtime containers after build (requires --execute).
+                        WARM path: recreates only the RUNTIME_SERVICES subset
+                        with 'up -d --no-deps'. Use on a lane whose deps + broker
+                        are already up.
+    --cold              COLD-lane FULL bring-up (OMN-13414). For an ephemeral lane
+                        that was GC/idle-reclaimed and torn down to zero
+                        containers. Forces a workspace-mode build from the local
+                        merged-dev siblings (BUILD_SOURCE=workspace + OMNI_HOME +
+                        sibling REF build-args via stage_workspace.sh), brings up
+                        deps + the migration one-shots, then brings the WHOLE
+                        '--profile runtime' project up (every consumer/projection
+                        service, not just RUNTIME_SERVICES). Requires --execute and
+                        OMNI_HOME; incompatible with --prod (workspace images are
+                        non-main-lineage and the prod gate refuses them). Two
+                        gotchas it solves: the runtime profile is mandatory (a bare
+                        'docker compose up -d' starts NOTHING), and the default
+                        BUILD_SOURCE=release cannot rebuild a cold lane from
+                        un-released merged-dev code. See
+                        docs/runbooks/cold-lane-full-bringup.md.
     --profile <name>    Docker compose profile (default: runtime).
     --print-compose-cmd Print exact compose commands without executing, then exit.
     --prod              Enforce the prod promotion-lineage guard before build:
@@ -266,8 +292,11 @@ EXAMPLES
     # Deploy and build images
     ${SCRIPT_NAME} --execute
 
-    # Deploy, build, and restart containers
+    # Deploy, build, and restart containers (WARM lane: deps already up)
     ${SCRIPT_NAME} --execute --restart
+
+    # COLD lane full bring-up from merged dev (workspace build + full --profile up)
+    OMNI_HOME=/path/to/omni_home ${SCRIPT_NAME} --execute --cold
 
     # Redeploy same version (overwrite)
     ${SCRIPT_NAME} --execute --force
@@ -303,6 +332,10 @@ parse_args() {
                 ;;
             --restart)
                 RESTART=true
+                shift
+                ;;
+            --cold)
+                COLD_FULL_BRINGUP=true
                 shift
                 ;;
             --profile)
@@ -343,6 +376,25 @@ parse_args() {
     if [[ "${RESTART}" == true && "${MODE}" != "execute" ]]; then
         log_error "--restart requires --execute"
         exit 1
+    fi
+
+    # OMN-13414: --cold is the cold-lane FULL bring-up. It forces a workspace
+    # build (so a release-pinned BUILD_SOURCE is a contradiction) and produces a
+    # non-main-lineage image the prod-promotion gate refuses (so --prod / prod
+    # lane is incompatible).
+    if [[ "${COLD_FULL_BRINGUP}" == true ]]; then
+        if [[ "${BUILD_SOURCE:-}" == "release" ]]; then
+            log_error "--cold performs a workspace-mode build from the merged-dev siblings, but BUILD_SOURCE=release was set."
+            log_error "  A release image cannot carry un-released merged-dev code; a cold lane would boot on stale code."
+            log_error "  Unset BUILD_SOURCE (it defaults to workspace under --cold) or set BUILD_SOURCE=workspace."
+            exit 64
+        fi
+        if [[ "${PROD_LANE}" == true ]]; then
+            log_error "--cold is a workspace-mode (non-main-lineage) bring-up and cannot target the prod lane."
+            log_error "  The prod-promotion gate refuses workspace / stability-candidate images (OMN-13669)."
+            log_error "  Promote a clean-main release to prod via the gated node path instead."
+            exit 1
+        fi
     fi
 }
 
@@ -643,6 +695,17 @@ read_repo_ref_or_main() {
 
 resolve_build_source() {
     # Resolve the selected Dockerfile dependency source.
+    #
+    # OMN-13414: a cold-lane FULL bring-up (--cold) must build from the local
+    # workspace siblings at merged-dev SHAs, never from the PyPI release packages
+    # — a release image cannot carry un-released merged-dev code, which is exactly
+    # what a cold/GC-reclaimed lane has to be rebuilt from. --cold therefore forces
+    # workspace mode; validate_build_source_config then requires OMNI_HOME, and
+    # parse_args has already rejected a contradictory BUILD_SOURCE=release.
+    if [[ "${COLD_FULL_BRINGUP}" == true ]]; then
+        echo "workspace"
+        return 0
+    fi
     echo "${BUILD_SOURCE:-release}"
 }
 
@@ -2134,6 +2197,49 @@ run_runtime_migration_preflight() {
     done
 }
 
+bringup_full_stack() {
+    # Cold-lane FULL bring-up: bring the WHOLE --profile runtime project up
+    # (OMN-13414).
+    #
+    # The warm --restart path recreates only the RUNTIME_SERVICES subset with
+    # `up -d --no-deps`; on a cold/GC-reclaimed lane every other service in the
+    # runtime profile (the projection/consumer fleet, autoheal, etc.) stays down.
+    # This brings the entire project up. Two gotchas it encodes:
+    #
+    #   1. `--profile "${COMPOSE_PROFILE}"` (runtime) is MANDATORY. Runtime
+    #      services are gated behind the compose runtime profile; a bare
+    #      `docker compose up -d` matches NO profiled service and starts nothing.
+    #   2. NO `--no-deps`. Unlike restart_services, the full up honors the compose
+    #      depends_on chain (postgres/valkey -> redpanda + partition-cap ->
+    #      forward/intelligence migration one-shots -> runtime + consumers), so
+    #      the whole stack starts in dependency order. The explicit preflight in
+    #      main() (ensure_core_infra_ready / warm_broker_topic_provisioning /
+    #      run_runtime_migration_preflight) has already warmed deps + the
+    #      one-shots, so this is the idempotent full fan-out over the rest of the
+    #      profile.
+    local deploy_target="$1"
+    local compose_project="$2"
+    local -a compose_args
+    resolve_compose_file_args compose_args "${deploy_target}" "${compose_project}"
+
+    log_step "Cold-Lane Full Bring-Up (OMN-13414)"
+
+    local cmd=(
+        docker compose
+        -p "${compose_project}"
+        "${compose_args[@]}"
+        --profile "${COMPOSE_PROFILE}"
+        up -d
+    )
+
+    log_info "Bringing the FULL ${COMPOSE_PROFILE}-profile project up: ${compose_project}"
+    log_cmd "${cmd[*]}"
+
+    "${cmd[@]}"
+
+    log_info "Full project up."
+}
+
 restart_services() {
     # Restart runtime containers via docker compose up --force-recreate.
     local deploy_target="$1"
@@ -2547,8 +2653,15 @@ main() {
     # Phase 10: Build
     build_images "${deploy_target}" "${compose_project}" "${git_sha}"
 
-    # Phase 11: Restart (optional)
-    if [[ "${RESTART}" == true ]]; then
+    # Phase 11: Bring runtime up (optional).
+    #   --cold    -> cold-lane FULL bring-up: deps + migration one-shots + the
+    #               WHOLE --profile runtime project (OMN-13414).
+    #   --restart -> WARM path: deps + migration one-shots + recreate only the
+    #               RUNTIME_SERVICES subset (--no-deps).
+    # Both share the cold-start preflight (core infra readiness, broker partition
+    # cap, migration one-shots, raised Kafka consumer-start budget); they differ
+    # only in the final `up` (full-profile fan-out vs RUNTIME_SERVICES recreate).
+    if [[ "${COLD_FULL_BRINGUP}" == true || "${RESTART}" == true ]]; then
         # Raise the per-consumer Kafka consumer-start budget for the restart-driven
         # cold boot (OMN-13220). x-runtime-env reads KAFKA_TIMEOUT_SECONDS from the
         # shell environment (default 30s when unset); exporting it here propagates
@@ -2577,11 +2690,17 @@ main() {
         ensure_core_infra_ready "${deploy_target}" "${compose_project}"
         warm_broker_topic_provisioning "${deploy_target}" "${compose_project}"
         run_runtime_migration_preflight "${deploy_target}" "${compose_project}"
-        restart_services "${deploy_target}" "${compose_project}"
+        if [[ "${COLD_FULL_BRINGUP}" == true ]]; then
+            # Cold lane: fan out across the WHOLE runtime profile (OMN-13414).
+            bringup_full_stack "${deploy_target}" "${compose_project}"
+        else
+            # Warm lane: recreate only the RUNTIME_SERVICES subset (--no-deps).
+            restart_services "${deploy_target}" "${compose_project}"
+        fi
     fi
 
-    # Phase 12: Verify (only with --restart)
-    if [[ "${RESTART}" == true ]]; then
+    # Phase 12: Verify (after a cold bring-up or a warm --restart)
+    if [[ "${COLD_FULL_BRINGUP}" == true || "${RESTART}" == true ]]; then
         verify_deployment "${git_sha}" "${compose_project}"
     fi
 

--- a/scripts/deploy-runtime.sh
+++ b/scripts/deploy-runtime.sh
@@ -2487,7 +2487,7 @@ show_summary() {
     log_info ""
     log_info "Next steps (source ~/.omnibase/.env before running):"
 
-    if [[ "${RESTART}" == false ]]; then
+    if [[ "${RESTART}" == false && "${COLD_FULL_BRINGUP}" == false ]]; then
         log_info "  To start containers, run:"
         log_info "    docker compose \\"
         log_info "      -p ${compose_project} \\"

--- a/tests/scripts/test_deploy_runtime_cold_full_bringup.py
+++ b/tests/scripts/test_deploy_runtime_cold_full_bringup.py
@@ -1,0 +1,230 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Coverage for the OMN-13414 cold-lane FULL bring-up path in deploy-runtime.sh.
+
+The dev lane is ephemeral (GC/idle-reclaimed). Bringing a fully COLD lane back
+up is materially harder than the warm "recreate the runtime services" restart,
+and two undocumented gotchas cost real time during the 2026-06-21 runtime-e2e
+run (evidence: .onex_state/runtime-e2e-2026-06-21/02-dev-deploy/):
+
+1. Runtime services are gated behind the compose ``runtime`` profile. A bare
+   ``docker compose up -d`` matches NO profiled service and starts NOTHING — the
+   ``--profile runtime`` selector is mandatory.
+2. deploy-runtime.sh defaults ``BUILD_SOURCE=release``; a cold/GC-reclaimed lane
+   must be rebuilt from the merged-dev workspace siblings, which needs
+   ``BUILD_SOURCE=workspace`` + ``OMNI_HOME`` + the sibling REF build-args and
+   ``scripts/runtime_build/stage_workspace.sh``.
+
+These tests lock the ``--cold`` flag that wires both gotchas into one documented
+path: deps + migration one-shots + a FULL ``--profile runtime`` up, built in
+workspace mode.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEPLOY_SCRIPT = REPO_ROOT / "scripts" / "deploy-runtime.sh"
+
+
+def _deploy_script_text() -> str:
+    return DEPLOY_SCRIPT.read_text(encoding="utf-8")
+
+
+def _deploy_script_noncomment() -> str:
+    """deploy-runtime.sh with comment-only lines stripped.
+
+    Assertions about *active* behavior must not be satisfied by a comment that
+    merely mentions the token, so the active-code checks run against this view.
+    """
+    lines = [
+        line
+        for line in _deploy_script_text().splitlines()
+        if not line.lstrip().startswith("#")
+    ]
+    return "\n".join(lines)
+
+
+def _function_body(name: str) -> str:
+    """Return the source of a top-level shell function ``name() { ... }``.
+
+    Every top-level function in deploy-runtime.sh closes with a ``}`` at column
+    0; nested braces are indented. We slice from the ``name() {`` line to the
+    next bare ``}`` so an assertion about one function cannot be satisfied by
+    code that lives in another.
+    """
+    text = _deploy_script_text()
+    # Anchor at line start so e.g. main() is not matched inside
+    # read_repo_ref_or_main().
+    anchored = text.find(f"\n{name}() {{")
+    start = 0 if text.startswith(f"{name}() {{") else anchored + 1
+    assert anchored != -1 or text.startswith(f"{name}() {{"), (
+        f"function {name}() not found in deploy-runtime.sh"
+    )
+    rest = text[start:]
+    end_rel = rest.find("\n}\n")
+    assert end_rel != -1, f"could not find end of function {name}()"
+    return rest[: end_rel + 3]
+
+
+# ---------------------------------------------------------------------------
+# Flag parsing + defaults
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_cold_full_bringup_defaults_false() -> None:
+    """The cold flag must default OFF so existing invocations are unchanged."""
+    assert "COLD_FULL_BRINGUP=false" in _deploy_script_noncomment()
+
+
+@pytest.mark.unit
+def test_cold_flag_is_parsed() -> None:
+    """parse_args must accept --cold and set COLD_FULL_BRINGUP=true."""
+    body = _function_body("parse_args")
+    assert "--cold)" in body, "--cold case missing from parse_args"
+    assert "COLD_FULL_BRINGUP=true" in body
+
+
+# ---------------------------------------------------------------------------
+# Gotcha 2: --cold forces workspace build source (never release)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_cold_forces_workspace_build_source() -> None:
+    """resolve_build_source must return workspace whenever --cold is set.
+
+    A cold/GC-reclaimed lane cannot be rebuilt from the PyPI release packages —
+    they cannot carry un-released merged-dev code. --cold therefore overrides the
+    default ``release`` source with ``workspace`` (OMN-13414).
+    """
+    body = _function_body("resolve_build_source")
+    assert "COLD_FULL_BRINGUP" in body, (
+        "resolve_build_source must honor COLD_FULL_BRINGUP and force workspace."
+    )
+    assert 'echo "workspace"' in body
+
+
+@pytest.mark.unit
+def test_cold_rejects_explicit_release_build_source() -> None:
+    """An operator setting BUILD_SOURCE=release WITH --cold is a contradiction."""
+    text = _deploy_script_noncomment()
+    # Fail-fast rather than silently overriding the operator's BUILD_SOURCE.
+    assert "BUILD_SOURCE=release was set" in _deploy_script_text()
+    assert "exit 64" in text
+
+
+@pytest.mark.unit
+def test_cold_incompatible_with_prod_lane() -> None:
+    """--cold is a workspace (non-main-lineage) build; it cannot target prod."""
+    text = _deploy_script_text()
+    assert "--cold is a workspace-mode" in text, (
+        "Missing the --cold/--prod mutual-exclusion guard. Workspace images are "
+        "stability-candidate / non-main-lineage and the prod-promotion gate "
+        "refuses them (OMN-13669)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gotcha 1: full bring-up uses the mandatory profile and is NOT --no-deps
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_bringup_full_stack_defined() -> None:
+    """A dedicated full bring-up function must exist."""
+    assert "bringup_full_stack()" in _deploy_script_text()
+
+
+@pytest.mark.unit
+def test_bringup_full_stack_uses_profile_and_full_fanout() -> None:
+    """The full bring-up must pass --profile and must NOT pass --no-deps.
+
+    Gotcha 1: a bare ``docker compose up -d`` starts nothing because runtime
+    services are gated behind the ``runtime`` profile. Unlike restart_services
+    (which recreates only the RUNTIME_SERVICES subset with ``--no-deps``), the
+    cold full bring-up must fan out across the WHOLE profile and honor the
+    compose depends_on chain, so it must NOT pass --no-deps.
+    """
+    body = _function_body("bringup_full_stack")
+    assert '--profile "${COMPOSE_PROFILE}"' in body, (
+        "bringup_full_stack must pass the mandatory --profile selector."
+    )
+    assert "up -d" in body
+    # Strip comment lines: the docstring-style comment legitimately *contrasts*
+    # with --no-deps, but the active compose command must not pass it.
+    active = "\n".join(
+        line for line in body.splitlines() if not line.lstrip().startswith("#")
+    )
+    assert "--no-deps" not in active, (
+        "Cold full bring-up must NOT pass --no-deps — the whole point is to fan "
+        "out over the full profile and honor depends_on (OMN-13414)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# main() wiring: deps + migration one-shots + full up, under --cold
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_main_cold_path_runs_deps_migration_then_full_up() -> None:
+    """Under --cold, main() must run deps + broker + migration one-shots, then full up."""
+    body = _function_body("main")
+    assert "COLD_FULL_BRINGUP" in body, "main() does not branch on COLD_FULL_BRINGUP"
+
+    core = body.find('ensure_core_infra_ready "${deploy_target}"')
+    warm = body.find('warm_broker_topic_provisioning "${deploy_target}"')
+    mig = body.find('run_runtime_migration_preflight "${deploy_target}"')
+    full = body.find('bringup_full_stack "${deploy_target}"')
+
+    assert core != -1, "ensure_core_infra_ready not called in main()"
+    assert warm != -1, "warm_broker_topic_provisioning not called in main()"
+    assert mig != -1, "run_runtime_migration_preflight not called in main()"
+    assert full != -1, "bringup_full_stack not called in main()"
+    assert core < warm < mig < full, (
+        "Cold bring-up order must be core-infra -> broker warmup -> migration "
+        "one-shots -> FULL up (OMN-13414 / OMN-13594 / OMN-13220)."
+    )
+
+
+@pytest.mark.unit
+def test_main_cold_exports_kafka_cold_start_budget() -> None:
+    """The cold path must also raise KAFKA_TIMEOUT_SECONDS for the cold boot."""
+    body = _function_body("main")
+    # The cold-start consumer-join budget guard (OMN-13220) must cover the cold
+    # full bring-up, not just the warm --restart path.
+    assert "COLD_FULL_BRINGUP" in body
+    assert 'export KAFKA_TIMEOUT_SECONDS="${cold_start_timeout}"' in body
+
+
+@pytest.mark.unit
+def test_main_cold_runs_verify() -> None:
+    """Verification must run after a cold bring-up, not only after --restart."""
+    body = _function_body("main")
+    verify = body.find('verify_deployment "${git_sha}"')
+    assert verify != -1, "verify_deployment not called in main()"
+    # The verify guard must reference the cold flag (before the verify call) so a
+    # cold-only invocation is still verified, not only a warm --restart.
+    assert "COLD_FULL_BRINGUP" in body[:verify], (
+        "verify_deployment must run under --cold as well as --restart."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Operator-facing documentation in usage()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_usage_documents_cold_flag() -> None:
+    """usage() must document --cold and both gotchas it solves."""
+    body = _function_body("usage")
+    assert "--cold" in body, "usage() does not document --cold"
+    assert "workspace" in body, "usage() must mention workspace-mode build for --cold"
+    assert "profile" in body, "usage() must mention the mandatory runtime profile"

--- a/tests/scripts/test_deploy_runtime_cold_full_bringup.py
+++ b/tests/scripts/test_deploy_runtime_cold_full_bringup.py
@@ -216,6 +216,16 @@ def test_main_cold_runs_verify() -> None:
     )
 
 
+@pytest.mark.unit
+def test_summary_treats_cold_path_as_containers_running() -> None:
+    """After --cold, summary must not tell the operator to start containers."""
+    body = _function_body("show_summary")
+    assert '"${COLD_FULL_BRINGUP}" == false' in body, (
+        "show_summary must treat --cold like --restart because both paths already "
+        "bring containers up before the summary is printed."
+    )
+
+
 # ---------------------------------------------------------------------------
 # Operator-facing documentation in usage()
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## OMN-13414 — Cold-lane bring-up: document + harden

The dev runtime lane is ephemeral (GC/idle-reclaimed; it can be torn down to **zero containers** between sessions). Bringing a fully **cold** lane back up is materially harder than the documented warm "recreate the runtime services" path, and two undocumented gotchas cost real time on the 2026-06-21 runtime-e2e run.

This adds a documented `--cold` cold-lane **full** bring-up path to `scripts/deploy-runtime.sh` that wires both gotchas into one flag.

### What changed
- **`scripts/deploy-runtime.sh`** — new `--cold` flag:
  - `COLD_FULL_BRINGUP` flag parsed from `--cold` (defaults off).
  - `resolve_build_source()` forces `BUILD_SOURCE=workspace` under `--cold` (a release image cannot carry un-released merged-dev code).
  - `parse_args` guards: rejects `BUILD_SOURCE=release` + `--cold` (exit 64) and `--prod` + `--cold` (exit 1; workspace images are non-main-lineage and the prod gate refuses them).
  - new `bringup_full_stack()` — `docker compose --profile runtime up -d` over the WHOLE project. The runtime profile is **mandatory** (a bare `up -d` matches no profiled service and starts nothing); it does NOT pass `--no-deps`, so compose's `depends_on` chain fans the whole stack out in order.
  - `main()` Phase 11/12 run the shared cold-start preflight (`ensure_core_infra_ready` → `warm_broker_topic_provisioning` → `run_runtime_migration_preflight`, raised `KAFKA_TIMEOUT_SECONDS`) then `bringup_full_stack` on `--cold` (vs `restart_services` on `--restart`), and verify after either.
  - `usage()` documents `--cold` + an EXAMPLES entry.
- **`docs/runbooks/cold-lane-full-bringup.md`** — cold-vs-warm, both gotchas, full procedure, sibling-pin-guard caveat; cites the evidence baseline.
- **`tests/scripts/test_deploy_runtime_cold_full_bringup.py`** — 11 cases locking the flag, the forced workspace source, the mandatory-profile/no-`--no-deps` invariant, the main() ordering, and the usage docs.
- **3 vendored omnimarket node migrations** — mechanical 1:1 mirror from omnimarket `dev` tip, required by the always-run `node-migration-sync` gate (it compares against omnimarket dev and was failing for all infra PRs). Not feature scope; merge-gate mandated.

> A sibling change documents the same cold-vs-warm prose around the `omni_home/CLAUDE.md` `.201` lane block (the generated lane table is left untouched).

### Verification (dod_evidence)
- `bash -n scripts/deploy-runtime.sh` OK; `shellcheck scripts/deploy-runtime.sh` exit 0.
- `uv run pytest tests/scripts/test_deploy_runtime_cold_full_bringup.py tests/scripts/test_deploy_runtime_coldstart.py -q` → **21 passed**.
- Guard behavior verified live: `BUILD_SOURCE=release … --cold` → exit 64; `… --cold --prod` → exit 1.
- `pre-commit run --files …` (incl. always-run node-migration-sync) → clean.
- **No live prod/judge/stability deploy is performed in this PR.**

Evidence baseline: `.onex_state/runtime-e2e-2026-06-21/02-dev-deploy/`.

Evidence-Source: OCC#3373
Evidence-Ticket: OMN-13414


Paired PRs:
- onex_change_control OCC receipt: OmniNode-ai/onex_change_control#3373
- omni_home CLAUDE.md .201 prose: OmniNode-ai/omni_home#194
