### PR TITLE
refactor(OMN-7334): Move 4 hardcoded topic constants to central registry

### DIFF
--- a/docker/migrations/forward/nodes/node_projection_delegation_inference_response/0001_create_projection_delegation_inference_response_text.sql
+++ b/docker/migrations/forward/nodes/node_projection_delegation_inference_response/0001_create_projection_delegation_inference_response_text.sql
@@ -18,9 +18,9 @@ CREATE TABLE IF NOT EXISTS projection_delegation_inference_response_text (
     -- task_type is not carried by ModelInferenceResponseData; defaults to empty
     latest_task_type          TEXT    NOT NULL DEFAULT '',
     latest_generated_text     TEXT    NOT NULL DEFAULT '',
-    latest_prompt_tokens      INT     NOT NULL DEFAULT 0,
-    latest_completion_tokens  INT     NOT NULL DEFAULT 0,
-    latest_latency_ms         INT     NOT NULL DEFAULT 0,
+    latest_prompt_tokens      INT     NOT NULL DEFAULT 0 CHECK (latest_prompt_tokens >= 0),
+    latest_completion_tokens  INT     NOT NULL DEFAULT 0 CHECK (latest_completion_tokens >= 0),
+    latest_latency_ms         INT     NOT NULL DEFAULT 0 CHECK (latest_latency_ms >= 0),
 
     -- The Kafka topic that feeds this projection
     source_topic              TEXT    NOT NULL
@@ -29,13 +29,16 @@ CREATE TABLE IF NOT EXISTS projection_delegation_inference_response_text (
     -- Rolling FIFO window of recent responses (max MAX_HISTORY = 10)
     -- Each entry: {correlation_id, model_name, task_type, generated_text,
     --              prompt_tokens, completion_tokens, latency_ms, captured_at}
-    recent_responses          JSONB   NOT NULL DEFAULT '[]'::jsonb,
+    recent_responses          JSONB   NOT NULL DEFAULT '[]'::jsonb
+        CHECK (jsonb_typeof(recent_responses) = 'array'),
 
     -- When this snapshot was last materialized
     captured_at               TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 
     -- True once the projection reducer has written at least one row
-    provisioned               BOOLEAN NOT NULL DEFAULT TRUE
+    provisioned               BOOLEAN NOT NULL DEFAULT TRUE,
+
+    CHECK (singleton_key = 'global')
 );
 
 -- Seed the singleton row so the projection-API always returns a row

--- a/docker/migrations/forward/nodes/node_projection_swarm/0001_create_swarm_runs.sql
+++ b/docker/migrations/forward/nodes/node_projection_swarm/0001_create_swarm_runs.sql
@@ -1,0 +1,51 @@
+-- OMN-13084: node-owned projection migration for swarm_runs.
+--
+-- WHY THIS EXISTS
+--   node_projection_swarm declares projection_api over swarm_runs (topic
+--   onex.snapshot.projection.swarm.runs.v1). The projection API reads the
+--   omnidash_analytics projection database; only node-owned migrations under
+--   src/omnimarket/nodes/<node>/migrations/*.sql are vendored into that database
+--   by omnibase_infra/scripts/sync-node-migrations.sh +
+--   run-forward-migrations.sh (applied against NODE_POSTGRES_DB).
+--
+--   The original swarm_runs DDL (omnibase_infra forward/082_swarm_runs.sql) runs
+--   against the flat infra database (POSTGRES_DB), not the projection database,
+--   so the projection API would mark the topic DEGRADED ("table not found") and
+--   the dashboard would render empty. This node-local migration materialises the
+--   table in the projection database the API actually reads.
+--
+-- Idempotency: CREATE TABLE / INDEX guarded so the migration is safe to re-apply.
+CREATE TABLE IF NOT EXISTS swarm_runs (
+  run_id            TEXT PRIMARY KEY,
+  correlation_id    TEXT NOT NULL,
+  status            TEXT NOT NULL,
+  task_hash         TEXT NOT NULL DEFAULT '',
+  subtask_count     INTEGER NOT NULL DEFAULT 0,
+  succeeded_count   INTEGER NOT NULL DEFAULT 0,
+  failed_count      INTEGER NOT NULL DEFAULT 0,
+  skipped_count     INTEGER NOT NULL DEFAULT 0,
+  models_used       TEXT[] DEFAULT '{}',
+  machines_used     TEXT[] DEFAULT '{}',
+  total_cost_usd                DOUBLE PRECISION DEFAULT 0.0,
+  cloud_equivalent_cost_usd     DOUBLE PRECISION DEFAULT 0.0,
+  savings_usd                   DOUBLE PRECISION DEFAULT 0.0,
+  parallelism_speedup_ratio     DOUBLE PRECISION DEFAULT 1.0,
+  decomposition_latency_ms      INTEGER DEFAULT 0,
+  dispatch_wall_latency_ms      INTEGER DEFAULT 0,
+  aggregation_latency_ms        INTEGER DEFAULT 0,
+  total_latency_ms              INTEGER DEFAULT 0,
+  endpoint_registry_hash        TEXT DEFAULT '',
+  registry_schema_version       TEXT DEFAULT '',
+  projection_cursor             TEXT DEFAULT '',
+  source_event_id               TEXT DEFAULT '',
+  source_topic                  TEXT DEFAULT '',
+  source_partition              INTEGER DEFAULT 0,
+  source_offset                 INTEGER DEFAULT 0,
+  reducer_version               TEXT DEFAULT '1.0.0',
+  freshness_state               TEXT DEFAULT 'fresh',
+  observed_at                   TIMESTAMPTZ,
+  created_at                    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Projection API orders by created_at DESC (most recent runs first).
+CREATE INDEX IF NOT EXISTS idx_swarm_runs_created_at ON swarm_runs (created_at DESC);

--- a/docker/migrations/forward/nodes/node_projection_voice_sessions/0001_create_voice_sessions.sql
+++ b/docker/migrations/forward/nodes/node_projection_voice_sessions/0001_create_voice_sessions.sql
@@ -9,12 +9,15 @@ CREATE TABLE IF NOT EXISTS voice_sessions (
     started_at          TIMESTAMPTZ NOT NULL,
     ended_at            TIMESTAMPTZ,
     is_active           BOOLEAN NOT NULL DEFAULT TRUE,
-    total_turns         INTEGER NOT NULL DEFAULT 0,
-    total_duration_ms   BIGINT NOT NULL DEFAULT 0,
+    total_turns         INTEGER NOT NULL DEFAULT 0 CHECK (total_turns >= 0),
+    total_duration_ms   BIGINT NOT NULL DEFAULT 0 CHECK (total_duration_ms >= 0),
     agent_name          TEXT NOT NULL DEFAULT '',
-    transcript_turns    JSONB NOT NULL DEFAULT '[]',
+    transcript_turns    JSONB NOT NULL DEFAULT '[]'::jsonb
+        CHECK (jsonb_typeof(transcript_turns) = 'array'),
     ingested_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CHECK (ended_at IS NULL OR ended_at >= started_at)
 );
 
 CREATE INDEX IF NOT EXISTS idx_voice_sessions_started_at

--- a/src/omnibase_infra/nodes/node_baselines_batch_compute/contract.yaml
+++ b/src/omnibase_infra/nodes/node_baselines_batch_compute/contract.yaml
@@ -7,8 +7,8 @@ node_type: "EFFECT_GENERIC"
 contract_version:
   major: 1
   minor: 0
-  patch: 0
-node_version: "1.0.0"
+  patch: 1
+node_version: "1.0.1"
 description: >
   EFFECT node: 3-phase baselines batch computation. Derives treatment/control comparison data from agent_routing_decisions and agent_actions tables. Emits onex.evt.omnibase-infra.baselines-computed.v1 for omnidash Baselines dashboard when rows are written (D5: no emit on zero rows).
 
@@ -34,3 +34,6 @@ handler_routing:
         module: "omnibase_infra.nodes.node_baselines_batch_compute.handlers.handler_baselines_batch_compute"
 metadata:
   description: "Derives treatment/control comparison batches for A/B evaluation through 3-phase computation: session selection, metric aggregation, and statistical summary"
+  topic_registry_source: "omnibase_infra.topics.SUFFIX_BASELINES_COMPUTED"
+  updated: "2026-06-30"
+  ticket: "OMN-7334"

--- a/src/omnibase_infra/nodes/node_baselines_batch_compute/handlers/handler_baselines_batch_compute.py
+++ b/src/omnibase_infra/nodes/node_baselines_batch_compute/handlers/handler_baselines_batch_compute.py
@@ -61,7 +61,6 @@ from omnibase_infra.utils.util_error_sanitization import sanitize_error_message
 
 logger = logging.getLogger(__name__)
 
-_TOPIC_BASELINES_COMPUTED = SUFFIX_BASELINES_COMPUTED
 _EVENT_TYPE_BASELINES_COMPUTED = "baselines.computed"
 
 
@@ -314,7 +313,7 @@ class HandlerBaselinesBatchCompute:
 
         await self._publish(
             event_type=_EVENT_TYPE_BASELINES_COMPUTED,
-            topic=_TOPIC_BASELINES_COMPUTED,
+            topic=SUFFIX_BASELINES_COMPUTED,
             payload=payload,
             correlation_id=correlation_id,
         )
@@ -327,7 +326,7 @@ class HandlerBaselinesBatchCompute:
                 "comparisons": len(comparisons),
                 "trend": len(trend),
                 "breakdown": len(breakdown),
-                "topic": _TOPIC_BASELINES_COMPUTED,
+                "topic": SUFFIX_BASELINES_COMPUTED,
             },
         )
 

--- a/src/omnibase_infra/nodes/node_gmail_intent_poller_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_gmail_intent_poller_effect/contract.yaml
@@ -18,11 +18,11 @@ node_name: "node_gmail_intent_poller_effect"
 contract_version:
   major: 1
   minor: 0
-  patch: 0
+  patch: 1
 node_version:
   major: 1
   minor: 0
-  patch: 0
+  patch: 1
 node_type: "EFFECT_GENERIC"
 description: >
   Effect node that drains configured Gmail source labels on demand. For each message it applies an idempotency marker label, fetches the full message, extracts URLs, appends a gmail-intent-received event payload to pending_events, then archives the message. A recovery pass runs first to handle crashed mid-run states. Emits to onex.evt.omnibase_infra.gmail-intent-received.v1 with partition key = message_id.
@@ -217,7 +217,9 @@ metadata:
   author: "OmniNode Team"
   license: "MIT"
   created: "2026-02-24"
-  updated: "2026-02-24"
+  updated: "2026-06-30"
+  ticket: "OMN-7334"
+  topic_registry_source: "omnibase_infra.topics.SUFFIX_GMAIL_INTENT_RECEIVED"
   tags:
     - effect
     - gmail

--- a/src/omnibase_infra/nodes/node_gmail_intent_poller_effect/handlers/handler_gmail_intent_poll.py
+++ b/src/omnibase_infra/nodes/node_gmail_intent_poller_effect/handlers/handler_gmail_intent_poll.py
@@ -58,9 +58,6 @@ from omnibase_infra.topics import SUFFIX_GMAIL_INTENT_RECEIVED
 
 logger = logging.getLogger(__name__)
 
-# Event topic for gmail intent received events
-_GMAIL_INTENT_TOPIC: str = SUFFIX_GMAIL_INTENT_RECEIVED
-
 # Maximum body_text length for event payloads
 _BODY_TEXT_MAX_CHARS: int = 4096
 
@@ -282,7 +279,7 @@ class HandlerGmailIntentPoll:
 
                 # iii. Append event payload to pending_events
                 event_payload: JsonType = {
-                    "event_type": _GMAIL_INTENT_TOPIC,
+                    "event_type": SUFFIX_GMAIL_INTENT_RECEIVED,
                     "message_id": msg.message_id,
                     "subject": msg.subject,
                     "body_text": body_text,

--- a/src/omnibase_infra/nodes/node_reward_binder_effect/contract.yaml
+++ b/src/omnibase_infra/nodes/node_reward_binder_effect/contract.yaml
@@ -7,8 +7,8 @@ node_type: "EFFECT_GENERIC"
 contract_version:
   major: 1
   minor: 0
-  patch: 0
-node_version: "1.0.0"
+  patch: 1
+node_version: "1.0.1"
 description: >
   EFFECT node that emits structured reward events to Kafka after ScoringReducer produces an EvaluationResult. Publishes two event types in order: RewardAssignedEvent and PolicyStateUpdatedEvent. This is the only node in the objective pipeline that performs I/O. No scoring logic — only emits what ScoringReducer produced. (RunEvaluatedEvent removed in OMN-2929 — canonical event now in node_evidence_collection_effect.)
 
@@ -42,11 +42,13 @@ capabilities:
   - "reward.emit.reward_assigned"
   - "reward.emit.policy_state_updated"
 metadata:
-  description: "Emits structured reward events to Kafka after ScoringReducer produces an EvaluationResult, publishing RunEvaluated, RewardAssigned, and PolicyStateUpdated events"
+  description: "Emits structured reward events to Kafka after ScoringReducer produces an EvaluationResult, publishing RewardAssigned and PolicyStateUpdated events"
   author: "OmniNode Team"
   license: "MIT"
   created: "2026-02-24"
-  ticket: "OMN-2552"
+  updated: "2026-06-30"
+  ticket: "OMN-7334"
+  topic_registry_source: "omnibase_infra.topics SUFFIX_OMNIMEMORY_REWARD_ASSIGNED and SUFFIX_OMNIMEMORY_POLICY_STATE_UPDATED"
   tags:
     - effect
     - reward

--- a/src/omnibase_infra/nodes/node_reward_binder_effect/handlers/handler_reward_binder.py
+++ b/src/omnibase_infra/nodes/node_reward_binder_effect/handlers/handler_reward_binder.py
@@ -77,14 +77,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# ==============================================================================
-# Topics — declared in contract.yaml event_bus.publish_topics.
-# These constants mirror the contract for use in handler code.
-# Source of truth: contract.yaml
-# ==============================================================================
-_TOPIC_REWARD_ASSIGNED = SUFFIX_OMNIMEMORY_REWARD_ASSIGNED
-_TOPIC_POLICY_STATE_UPDATED = SUFFIX_OMNIMEMORY_POLICY_STATE_UPDATED
-
 
 def _compute_objective_fingerprint(spec: ModelObjectiveSpec) -> str:
     """Compute a tamper-evident SHA-256 fingerprint of the ModelObjectiveSpec.
@@ -340,7 +332,7 @@ class HandlerRewardBinder:
         )
         await self._publish(
             event_type="reward.assigned",
-            topic=_TOPIC_REWARD_ASSIGNED,
+            topic=SUFFIX_OMNIMEMORY_REWARD_ASSIGNED,
             payload=json.loads(reward_event.model_dump_json()),
             correlation_id=corr_id,
         )
@@ -361,7 +353,7 @@ class HandlerRewardBinder:
         )
         await self._publish(
             event_type="policy.state.updated",
-            topic=_TOPIC_POLICY_STATE_UPDATED,
+            topic=SUFFIX_OMNIMEMORY_POLICY_STATE_UPDATED,
             payload=json.loads(policy_event.model_dump_json()),
             correlation_id=corr_id,
         )
@@ -372,8 +364,8 @@ class HandlerRewardBinder:
 
         # Build output
         topics: tuple[str, ...] = (
-            _TOPIC_REWARD_ASSIGNED,
-            _TOPIC_POLICY_STATE_UPDATED,
+            SUFFIX_OMNIMEMORY_REWARD_ASSIGNED,
+            SUFFIX_OMNIMEMORY_POLICY_STATE_UPDATED,
         )
         output = ModelRewardBinderOutput(
             success=True,

--- a/tests/integration/nodes/test_node_reward_binder_effect.py
+++ b/tests/integration/nodes/test_node_reward_binder_effect.py
@@ -24,8 +24,8 @@ import pytest
 
 from omnibase_core.models.objective.model_score_vector import ModelScoreVector
 from omnibase_infra.nodes.node_reward_binder_effect.handlers.handler_reward_binder import (
-    _TOPIC_POLICY_STATE_UPDATED,
-    _TOPIC_REWARD_ASSIGNED,
+    SUFFIX_OMNIMEMORY_POLICY_STATE_UPDATED,
+    SUFFIX_OMNIMEMORY_REWARD_ASSIGNED,
     HandlerRewardBinder,
     _compute_objective_fingerprint,
 )
@@ -147,8 +147,8 @@ class TestRewardBinderKafkaIntegration:
             publisher = PublisherTopicScoped(
                 event_bus=bus,
                 allowed_topics={
-                    _TOPIC_REWARD_ASSIGNED,
-                    _TOPIC_POLICY_STATE_UPDATED,
+                    SUFFIX_OMNIMEMORY_REWARD_ASSIGNED,
+                    SUFFIX_OMNIMEMORY_POLICY_STATE_UPDATED,
                 },
                 environment="dev",
             )
@@ -180,8 +180,8 @@ class TestRewardBinderKafkaIntegration:
             assert output.policy_state_updated_event_id is not None
 
             # Verify two topics published (run-evaluated topic retired in OMN-2929)
-            assert _TOPIC_REWARD_ASSIGNED in output.topics_published
-            assert _TOPIC_POLICY_STATE_UPDATED in output.topics_published
+            assert SUFFIX_OMNIMEMORY_REWARD_ASSIGNED in output.topics_published
+            assert SUFFIX_OMNIMEMORY_POLICY_STATE_UPDATED in output.topics_published
         finally:
             await bus.stop()
 

--- a/tests/unit/nodes/node_reward_binder_effect/test_handler_reward_binder.py
+++ b/tests/unit/nodes/node_reward_binder_effect/test_handler_reward_binder.py
@@ -28,8 +28,6 @@ import pytest
 from omnibase_core.enums.enum_policy_type import EnumPolicyType
 from omnibase_core.models.objective.model_score_vector import ModelScoreVector
 from omnibase_infra.nodes.node_reward_binder_effect.handlers.handler_reward_binder import (
-    _TOPIC_POLICY_STATE_UPDATED,
-    _TOPIC_REWARD_ASSIGNED,
     HandlerRewardBinder,
     _compute_idempotency_key,
     _compute_objective_fingerprint,
@@ -49,6 +47,10 @@ from omnibase_infra.nodes.node_reward_binder_effect.models.model_objective_spec 
 )
 from omnibase_infra.nodes.node_reward_binder_effect.models.model_reward_binder_output import (
     ModelRewardBinderOutput,
+)
+from omnibase_infra.topics import (
+    SUFFIX_OMNIMEMORY_POLICY_STATE_UPDATED,
+    SUFFIX_OMNIMEMORY_REWARD_ASSIGNED,
 )
 
 pytestmark = pytest.mark.unit
@@ -304,9 +306,9 @@ class TestHandlerRewardBinderExecute:
         assert publisher.call_count == 2
 
         calls = publisher.call_args_list
-        assert calls[0].kwargs["topic"] == _TOPIC_REWARD_ASSIGNED
+        assert calls[0].kwargs["topic"] == SUFFIX_OMNIMEMORY_REWARD_ASSIGNED
         assert calls[0].kwargs["event_type"] == "reward.assigned"
-        assert calls[1].kwargs["topic"] == _TOPIC_POLICY_STATE_UPDATED
+        assert calls[1].kwargs["topic"] == SUFFIX_OMNIMEMORY_POLICY_STATE_UPDATED
         assert calls[1].kwargs["event_type"] == "policy.state.updated"
 
     @pytest.mark.asyncio
@@ -336,7 +338,10 @@ class TestHandlerRewardBinderExecute:
 
         # Call index 0 is now RewardAssigned (RunEvaluated removed)
         reward_payload = publisher.call_args_list[0].kwargs["payload"]
-        assert publisher.call_args_list[0].kwargs["topic"] == _TOPIC_REWARD_ASSIGNED
+        assert (
+            publisher.call_args_list[0].kwargs["topic"]
+            == SUFFIX_OMNIMEMORY_REWARD_ASSIGNED
+        )
         sv = result.score_vector
         assert reward_payload["correctness"] == sv.correctness
         assert reward_payload["safety"] == sv.safety
@@ -471,8 +476,8 @@ class TestHandlerRewardBinderExecute:
 
         output = handler_output.result
         assert isinstance(output, ModelRewardBinderOutput)
-        assert _TOPIC_REWARD_ASSIGNED in output.topics_published
-        assert _TOPIC_POLICY_STATE_UPDATED in output.topics_published
+        assert SUFFIX_OMNIMEMORY_REWARD_ASSIGNED in output.topics_published
+        assert SUFFIX_OMNIMEMORY_POLICY_STATE_UPDATED in output.topics_published
         # TOPIC_RUN_EVALUATED removed in OMN-2929 (orphan topic, zero consumers)
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Closes OMN-7334.

Move 4 hardcoded topic constants to the central registry. Three handler modules
each declared a redundant module-level `_TOPIC_*` / `_GMAIL_INTENT_TOPIC` alias
that merely re-bound an already-imported `omnibase_infra.topics` `SUFFIX_*`
registry constant. This deletes those aliases and references the central
registry constants directly at the usage sites.

The ticket text says "TopicBase enum", but the genuine central registry for
these infra topics is the `SUFFIX_*` set in `omnibase_infra.topics`
(`src/omnibase_infra/topics/platform_topic_suffixes.py`, re-exported via
`topics/__init__.py`). No `TopicBase` members were invented.

### Constants moved (4)

| File | Alias deleted | Now references |
|------|---------------|----------------|
| `node_baselines_batch_compute/handlers/handler_baselines_batch_compute.py` | `_TOPIC_BASELINES_COMPUTED` | `SUFFIX_BASELINES_COMPUTED` |
| `node_reward_binder_effect/handlers/handler_reward_binder.py` | `_TOPIC_REWARD_ASSIGNED` | `SUFFIX_OMNIMEMORY_REWARD_ASSIGNED` |
| `node_reward_binder_effect/handlers/handler_reward_binder.py` | `_TOPIC_POLICY_STATE_UPDATED` | `SUFFIX_OMNIMEMORY_POLICY_STATE_UPDATED` |
| `node_gmail_intent_poller_effect/handlers/handler_gmail_intent_poll.py` | `_GMAIL_INTENT_TOPIC` | `SUFFIX_GMAIL_INTENT_RECEIVED` |

The `reward_binder` unit + integration tests imported the deleted handler
aliases; they now import the `SUFFIX_*` constants from `omnibase_infra.topics`.

### Second commit — mandatory node-migration vendor sync

The `node-migration-sync` gate (pre-commit `onex-check-node-migration-sync` +
`.github/workflows/node-migration-sync.yml`) compares the vendored migration
tree under `docker/migrations/forward/nodes/` against the omnimarket `dev` tip.
That tree had **pre-existing drift** independent of this change (reproduced on a
clean `dev` checkout). Per the gate's design every infra PR must carry the
vendoring, so the second commit runs `scripts/sync-node-migrations.sh`; the 3
vendored files are byte-identical to `omnimarket src/omnimarket/nodes/<node>/migrations/*.sql`.

## dod_evidence

- **Scoped tests:** `uv run pytest -q tests/unit/nodes/node_reward_binder_effect tests/integration/nodes/test_node_reward_binder_effect.py tests/unit/nodes/node_baselines_batch_compute tests/unit/nodes/node_gmail_intent_poller_effect` → **98 passed, 2 skipped** (Kafka not available locally).
- **Full unit suite:** `uv run pytest -q -m unit -n auto` → **21546 passed, 22 skipped**. The only 2 reported failures were timing-based perf tests in `tests/unit/runtime/test_policy_registry_performance.py` (flaky under `-n auto` CPU contention); they pass serially (18 passed) and are unrelated to topics.
- **mypy:** `uv run mypy src/omnibase_infra/nodes/node_baselines_batch_compute src/omnibase_infra/nodes/node_reward_binder_effect src/omnibase_infra/nodes/node_gmail_intent_poller_effect --strict` → **Success: no issues found in 31 source files**.
- **lint/format:** `uv run ruff format` + `uv run ruff check --fix` clean.
- **pre-commit:** all hooks pass on the changed files (incl. Topic Naming Lint, AI-slop, ONEX architecture validation, node-migration-sync).

Evidence-Source: OCC#3377
Evidence-Ticket: OMN-7334
