### PR TITLE
feat(OMN-13762): R3 repin — core→0.46.1/spi→0.23.0 PyPI, delete git-rev overrides, pin occ immutable SHA

### DIFF
--- a/contracts/runtime/runtime_protocol.lock.json
+++ b/contracts/runtime/runtime_protocol.lock.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0.0",
-  "package_version": "0.38.3",
+  "package_version": "0.38.4",
   "protocol_count": 23,
   "protocols": {
     "ProtocolAutoWiringManifestLike": {
@@ -273,7 +273,7 @@
       "methods": {
         "describe": {
           "parameters": [],
-          "return_annotation": "ModelHandlerDescriptor"
+          "return_annotation": "<class 'omnibase_core.models.handlers.model_handler_descriptor.ModelHandlerDescriptor'>"
         },
         "execute": {
           "parameters": [
@@ -312,7 +312,7 @@
             {
               "name": "timeout_seconds",
               "kind": "POSITIONAL_OR_KEYWORD",
-              "annotation": "float",
+              "annotation": "<class 'float'>",
               "default": "30.0"
             }
           ],

--- a/docker/runners/runner-image.lock.json
+++ b/docker/runners/runner-image.lock.json
@@ -1,12 +1,12 @@
 {
   "base_image_digest": "sha256:3ba65aa20f86a0fad9df2b2c259c613df006b2e6d0bfcc8a146afb8c525a9751",
   "gh_version": "2.67.0",
-  "identity_digest": "8b47368ae6ad479a0d113429b20f5c01",
+  "identity_digest": "860245749b041598f7c04b74a0378973",
   "image_version": 5,
   "kubectl_version": "1.32.1",
   "python_version": "3.12",
   "runner_version": "2.334.0",
-  "shared_env_digest": "e0ce6a7c774f313932778ddb",
+  "shared_env_digest": "3d10d9f1c86cef1822f87916",
   "shared_env_install_args": "--frozen --all-extras --all-groups --no-install-project",
   "uv_version": "0.6.14"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,8 @@ dependencies = [
     #   omnibase-core = { git = "https://github.com/org/omnibase_core.git", rev = "SHA" }
     # Remember to switch back to PyPI versions before merging to main.
     #
-    "omnibase-core>=0.44.0,<0.47.0",
-    "omnibase-spi>=0.22.0,<0.23.0",
+    "omnibase-core>=0.46.1,<0.47.0",
+    "omnibase-spi>=0.23.0,<0.24.0",
     # ============================================================================
     # External Dependency Security Guidance
     # ============================================================================
@@ -173,24 +173,16 @@ dev = [
 
 [tool.uv]
 override-dependencies = [
-    "omnibase-core>=0.44.0,<0.47.0",
-    "omnibase-spi>=0.22.0,<0.23.0",
+    "omnibase-core>=0.46.1,<0.47.0",
+    "omnibase-spi>=0.23.0,<0.24.0",
 ]
 
 [tool.uv.sources]
-# OMN-12546 S-1b: re-point core pin to 48cf8b0be1c which carries the promoted
-# rich ModelDispatchResult + ModelDispatchOutputs + ModelDispatchMetadata +
-# ModelHandlerRef (successor of 287511f20 from OMN-13507).
-# Version stays 0.46.0 (override bound >=0.44.0,<0.47.0 unchanged).
-omnibase-core = { git = "https://github.com/OmniNode-ai/omnibase_core.git", rev = "48cf8b0be1c1f6d04d1e92c7f18ceb58c812471d" }
-# OMN-13507: pin spi to omnibase_spi dev HEAD 3c99ed45 (was branch=main @
-# b7bac176). The floating main pin resolved to a commit off omnibase_spi main
-# that has DIVERGED from dev (b7bac176 is not an ancestor of dev HEAD), so the
-# workspace-build sibling-pin check flagged the staged dev clone as drift. Pin
-# the exact dev HEAD the canonical clone tracks so the lock and the vendored
-# tree converge. spi dev is stable (no open PRs), so this pin sticks.
-omnibase-spi = { git = "https://github.com/OmniNode-ai/omnibase_spi.git", rev = "3c99ed45c5aa9e25fef17a108a40915b0a2e794c" }
-onex-change-control = { git = "https://github.com/OmniNode-ai/onex_change_control.git", branch = "main" }
+# OMN-13762 R3: pin occ to immutable main HEAD SHA (f3a04c1) so the lock is
+# reproducible from pure PyPI + immutable-rev sources; omnibase-core and
+# omnibase-spi git-rev overrides DELETED — resolved from PyPI once 0.46.1 /
+# 0.23.0 are published.
+onex-change-control = { git = "https://github.com/OmniNode-ai/onex_change_control.git", rev = "f3a04c10740c4bee68179d176a88b986daf6d57d" }
 [tool.ruff]
 target-version = "py312"
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,11 +178,11 @@ override-dependencies = [
 ]
 
 [tool.uv.sources]
-# OMN-13762 R3: pin occ to immutable main HEAD SHA (f3a04c1) so the lock is
+# OMN-13762 R3: pin occ to immutable main HEAD SHA (2dd26ad) so the lock is
 # reproducible from pure PyPI + immutable-rev sources; omnibase-core and
 # omnibase-spi git-rev overrides DELETED — resolved from PyPI once 0.46.1 /
 # 0.23.0 are published.
-onex-change-control = { git = "https://github.com/OmniNode-ai/onex_change_control.git", rev = "f3a04c10740c4bee68179d176a88b986daf6d57d" }
+onex-change-control = { git = "https://github.com/OmniNode-ai/onex_change_control.git", rev = "2dd26ade7caaa7131e532473ec9d8a207d0e77ab" }
 [tool.ruff]
 target-version = "py312"
 line-length = 88

--- a/src/omnibase_infra/runtime/version_compatibility.py
+++ b/src/omnibase_infra/runtime/version_compatibility.py
@@ -175,13 +175,13 @@ def _build_matrix_from_pyproject(
 _FALLBACK_MATRIX: list[VersionConstraint] = [
     VersionConstraint(
         package="omnibase_core",
-        min_version="0.44.0",
+        min_version="0.46.1",
         max_version="0.47.0",
     ),
     VersionConstraint(
         package="omnibase_spi",
-        min_version="0.22.0",
-        max_version="0.23.0",
+        min_version="0.23.0",
+        max_version="0.24.0",
     ),
 ]
 

--- a/tests/integration/infra/test_omn_12765_release_backmerge_identity.py
+++ b/tests/integration/infra/test_omn_12765_release_backmerge_identity.py
@@ -11,17 +11,25 @@ ROOT = Path(__file__).resolve().parents[3]
 
 
 def test_release_backmerge_preserves_proven_runtime_core_pin() -> None:
-    """The main-lane backmerge must not move off the dev runtime proof inputs."""
+    """The main-lane backmerge must carry the proven PyPI core/spi releases.
+
+    OMN-13762 R3: infra is cut off the unreleased git-rev pins (core dev HEAD
+    48cf8b0, spi 3c99ed4) onto the published PyPI releases so main can build a
+    clean, reproducible runtime image from immutable artifacts. The proven
+    runtime inputs are now the released versions, not git revs.
+    """
 
     pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
     uv_lock = (ROOT / "uv.lock").read_text(encoding="utf-8")
-    # OMN-12546 S-1b: pin advanced to core dev HEAD 48cf8b0 (successor of
-    # 287511f20 from OMN-13507) so infra imports the promoted rich dispatch
-    # model types from the proven core commit.
-    expected_core = "48cf8b0be1c1f6d04d1e92c7f18ceb58c812471d"
 
-    assert expected_core in pyproject
-    assert expected_core in uv_lock
+    # The proven runtime now pins the published PyPI releases.
+    assert "omnibase-core>=0.46.1,<0.47.0" in pyproject
+    assert "omnibase-spi>=0.23.0,<0.24.0" in pyproject
+
+    # The retired git-rev override must be gone from both manifest and lock.
+    retired_core_rev = "48cf8b0be1c1f6d04d1e92c7f18ceb58c812471d"
+    assert retired_core_rev not in pyproject
+    assert retired_core_rev not in uv_lock
 
 
 def test_release_backmerge_preserves_runner_identity_lock() -> None:
@@ -31,7 +39,8 @@ def test_release_backmerge_preserves_runner_identity_lock() -> None:
         (ROOT / "docker/runners/runner-image.lock.json").read_text(encoding="utf-8")
     )
 
-    # OMN-13664: identity regenerated after the uv dependency refresh updated
-    # the runtime shared-env inputs.
-    assert lock["identity_digest"] == "8b47368ae6ad479a0d113429b20f5c01"
-    assert lock["shared_env_digest"] == "e0ce6a7c774f313932778ddb"
+    # OMN-13762 R3: identity regenerated after relocking onto the published
+    # PyPI core 0.46.1 / spi 0.23.0 releases, which changed the runtime
+    # dependency-manifest and shared-env inputs.
+    assert lock["identity_digest"] == "860245749b041598f7c04b74a0378973"
+    assert lock["shared_env_digest"] == "3d10d9f1c86cef1822f87916"

--- a/tests/integration/test_omnibase_spi_runtime_protocol_floor.py
+++ b/tests/integration/test_omnibase_spi_runtime_protocol_floor.py
@@ -1,12 +1,14 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
-"""Integration sentinel for the omnibase-spi 0.22.0 runtime protocol floor.
+"""Integration sentinel for the omnibase-spi 0.23.0 runtime protocol floor.
 
 OMN-10169 raises the dependency floor because runtime auto-wiring imports
 ``omnibase_spi.protocols.runtime``. The fallback compatibility matrix must
 carry the same floor for installed-package environments where ``pyproject.toml``
 is not present.
+
+OMN-13762 R3 advances the floor to the published 0.23.0 PyPI release.
 """
 
 from __future__ import annotations
@@ -30,7 +32,7 @@ def _minimum_for(package: str, matrix: Sequence[VersionConstraint]) -> str:
 
 
 @pytest.mark.integration
-def test_omnibase_spi_runtime_protocols_match_0220_floor() -> None:
+def test_omnibase_spi_runtime_protocols_match_0230_floor() -> None:
     """The declared and fallback SPI floors both expose runtime protocols."""
     from omnibase_spi.protocols.runtime.protocol_handler_ownership_query import (
         ProtocolHandlerOwnershipQuery,
@@ -39,7 +41,7 @@ def test_omnibase_spi_runtime_protocols_match_0220_floor() -> None:
         ProtocolHandlerResolver,
     )
 
-    assert _minimum_for("omnibase_spi", VERSION_MATRIX) == "0.22.0"
-    assert _minimum_for("omnibase_spi", _FALLBACK_MATRIX) == "0.22.0"
+    assert _minimum_for("omnibase_spi", VERSION_MATRIX) == "0.23.0"
+    assert _minimum_for("omnibase_spi", _FALLBACK_MATRIX) == "0.23.0"
     assert hasattr(ProtocolHandlerResolver, "__class_getitem__")
     assert hasattr(ProtocolHandlerOwnershipQuery, "__class_getitem__")

--- a/tests/unit/cli/test_validate_contracts_mode.py
+++ b/tests/unit/cli/test_validate_contracts_mode.py
@@ -34,9 +34,11 @@ def _clean_effect_contract(name: str = "node_foo_effect") -> dict[str, Any]:
             "routing_strategy": "operation_match",
             "handlers": [
                 {
-                    "routing_key": "foo.run",
-                    "handler_key": "handle_foo_run",
-                    "priority": 0,
+                    "operation": "foo.run",
+                    "handler": {
+                        "name": "HandlerFooRun",
+                        "module": "foo.bar.handlers",
+                    },
                 }
             ],
         },

--- a/uv.lock
+++ b/uv.lock
@@ -9,8 +9,8 @@ resolution-markers = [
 
 [manifest]
 overrides = [
-    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=48cf8b0be1c1f6d04d1e92c7f18ceb58c812471d" },
-    { name = "omnibase-spi", git = "https://github.com/OmniNode-ai/omnibase_spi.git?rev=3c99ed45c5aa9e25fef17a108a40915b0a2e794c" },
+    { name = "omnibase-core", specifier = ">=0.46.1,<0.47.0" },
+    { name = "omnibase-spi", specifier = ">=0.23.0,<0.24.0" },
 ]
 
 [[package]]
@@ -2084,7 +2084,7 @@ wheels = [
 [[package]]
 name = "omnibase-core"
 version = "0.46.1"
-source = { git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=48cf8b0be1c1f6d04d1e92c7f18ceb58c812471d#48cf8b0be1c1f6d04d1e92c7f18ceb58c812471d" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blake3" },
     { name = "click" },
@@ -2098,6 +2098,10 @@ dependencies = [
     { name = "ruamel-yaml" },
     { name = "tree-sitter" },
     { name = "tree-sitter-python" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/2a/fe53acd14f2feeea5faf5b6df5fa0ba088e001d6f733f57f7477d95e6b2f/omnibase_core-0.46.1.tar.gz", hash = "sha256:d10b6cfc82436a5ad67ca35951d2e095dfb408a8bcb661c85374ad321f2c69e4", size = 8992716, upload-time = "2026-06-30T21:10:23.4Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/f1/b8516eec6b8587fa2f446279545ef1626e04a3a1c82f1f491d9b8db31832/omnibase_core-0.46.1-py3-none-any.whl", hash = "sha256:01551cd2ac4009fb758c71edd1201be8a02406731132965fe782436849dfdfc9", size = 6351486, upload-time = "2026-06-30T21:10:20.427Z" },
 ]
 
 [[package]]
@@ -2199,8 +2203,8 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.20.0,<5.0.0" },
     { name = "mcp", specifier = ">=1.25.0,<2.0.0" },
     { name = "neo4j", specifier = ">=5.15.0,<7.0.0" },
-    { name = "omnibase-core", git = "https://github.com/OmniNode-ai/omnibase_core.git?rev=48cf8b0be1c1f6d04d1e92c7f18ceb58c812471d" },
-    { name = "omnibase-spi", git = "https://github.com/OmniNode-ai/omnibase_spi.git?rev=3c99ed45c5aa9e25fef17a108a40915b0a2e794c" },
+    { name = "omnibase-core", specifier = ">=0.46.1,<0.47.0" },
+    { name = "omnibase-spi", specifier = ">=0.23.0,<0.24.0" },
     { name = "opentelemetry-api", specifier = ">=1.27.0,<2.0.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.27.0,<2.0.0" },
     { name = "opentelemetry-instrumentation", specifier = ">=0.48b0,<0.64" },
@@ -2238,7 +2242,7 @@ dev = [
     { name = "kafka-python", specifier = ">=2.0.2,<4.0.0" },
     { name = "locust", specifier = ">=2.31.8,<3.0.0" },
     { name = "mypy", specifier = ">=1.13.0,<3.0.0" },
-    { name = "onex-change-control", git = "https://github.com/OmniNode-ai/onex_change_control.git?branch=main" },
+    { name = "onex-change-control", git = "https://github.com/OmniNode-ai/onex_change_control.git?rev=2dd26ade7caaa7131e532473ec9d8a207d0e77ab" },
     { name = "pre-commit", specifier = ">=4.3.0,<5.0.0" },
     { name = "pytest", specifier = ">=8.4.0,<10.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.25.0,<1.5.0" },
@@ -2257,18 +2261,22 @@ dev = [
 
 [[package]]
 name = "omnibase-spi"
-version = "0.22.0"
-source = { git = "https://github.com/OmniNode-ai/omnibase_spi.git?rev=3c99ed45c5aa9e25fef17a108a40915b0a2e794c#3c99ed45c5aa9e25fef17a108a40915b0a2e794c" }
+version = "0.23.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "omnibase-core" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/00/f69dbf0f4206a47fa64f409f0de76b2a1b4fee82ccc1f19b167893dad065/omnibase_spi-0.23.0.tar.gz", hash = "sha256:ac841935986dc871e96f38442bb4249fbdeb0189761838813f6efa23a2f598c6", size = 1132804, upload-time = "2026-06-30T21:42:58.523Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/e4/bc8bc1ea42897ea8e8caf09cff94c82610ed824066db986793f9030722b2/omnibase_spi-0.23.0-py3-none-any.whl", hash = "sha256:c3ad4e9b2aa46697442407adfd633d3d8bc96ae2ad0c115b6dc0d8ef3b11ea5f", size = 743058, upload-time = "2026-06-30T21:42:57.132Z" },
+]
 
 [[package]]
 name = "onex-change-control"
-version = "0.5.0"
-source = { git = "https://github.com/OmniNode-ai/onex_change_control.git?branch=main#2741a4096e2eaa48ce516a374b9765beda908073" }
+version = "0.5.1"
+source = { git = "https://github.com/OmniNode-ai/onex_change_control.git?rev=2dd26ade7caaa7131e532473ec9d8a207d0e77ab#2dd26ade7caaa7131e532473ec9d8a207d0e77ab" }
 dependencies = [
     { name = "colorama" },
     { name = "omnibase-core" },


### PR DESCRIPTION
## Summary

OMN-13762 step 5 — R3 real-release remediation for omnibase_infra:

- **omnibase-core**: `>=0.44.0,<0.47.0` (git rev `48cf8b0`) → `>=0.46.1,<0.47.0` (PyPI)
- **omnibase-spi**: `>=0.22.0,<0.23.0` (git rev `3c99ed4`) → `>=0.23.0,<0.24.0` (PyPI)
- **onex-change-control**: `branch=main` → immutable rev `2dd26ade7caaa7131e532473ec9d8a207d0e77ab` (OCC main HEAD)
- **[tool.uv.sources]** git-rev entries for core + spi **DELETED**
- `[tool.uv] override-dependencies` updated to match new bounds
- `uv.lock` refresh is intentionally pending — the PR is **RED until core 0.46.1 + spi 0.23.0 publish to PyPI** (upstream OMN-13762 steps 3 + 4)

## Why

The prod runtime image has been built from git-rev pins to unreleased dev commits (core@48cf8b0, spi@3c99ed4). This PR cuts infra to real PyPI releases so the main branch can build a clean, reproducible runtime image from immutable published artifacts.

## Evidence

Evidence-Source: OCC#3384
Evidence-Ticket: OMN-13762

## dod_evidence

- `dod-infra-r3-pypi-repin`: PASS — pyproject.toml carries correct PyPI pins; git-rev overrides for core + spi deleted; occ pinned to immutable SHA 2dd26ad
- `dod-infra-dev-promotable-to-main`: PASS — infra dev 190 ahead / 4 behind main; dev is a clean promotion source once this PR merges

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version requirements to newer supported releases.
  * Aligned dependency pinning with fixed versions for more predictable installs.
  * Switched one external source reference from a moving branch to a specific revision for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
