### PR TITLE
fix(OMN-13762): patch npm bundled deps to clear runtime-image Trivy CRITICAL/HIGH

### DIFF
--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -311,8 +311,8 @@ COPY workspace/sibling-vcs-provenance.json /workspace/sibling-vcs-provenance.jso
 #
 # The shell conditional on BUILD_SOURCE is evaluated at build time so only one
 # branch ever runs; the other branch's install artifacts never enter the image.
-ARG OMNIBASE_COMPAT_REF="v0.5.4"
-ARG OMNIBASE_COMPAT_SOURCE="https://github.com/OmniNode-ai/omnibase_compat/archive/v0.5.4.tar.gz"
+ARG OMNIBASE_COMPAT_REF="v0.5.5"
+ARG OMNIBASE_COMPAT_SOURCE="https://github.com/OmniNode-ai/omnibase_compat/archive/v0.5.5.tar.gz"
 # Pin to the onex_change_control v0.5.3 release tag.
 ARG ONEX_CHANGE_CONTROL_REF=v0.5.3
 # OMN-12195: default branch is dev, not main — use dev to avoid stale SHA from
@@ -645,6 +645,50 @@ RUN set -eu; \
         @anthropic-ai/claude-code@2.1.181 \
         @anthropic-ai/claude-code-linux-x64@2.1.181; \
     npm cache clean --force
+
+# ============================================================================
+# Security: patch npm's bundled Node dependencies (OMN-13762)
+# ============================================================================
+# Node 20 from NodeSource ships npm 10.8.2, whose bundled copies under
+# /usr/lib/node_modules/npm/node_modules/ are flagged CRITICAL/HIGH by Trivy
+# (severity CRITICAL,HIGH, ignore-unfixed):
+#   cross-spawn 7.0.3  -> CVE-2024-21538                 (fixed 7.0.5)
+#   glob        10.4.2 -> CVE-2025-64756                 (fixed 10.5.0/11.1.0)
+#   minimatch   9.0.5  -> CVE-2026-26996/27903/27904     (fixed >=9.0.7 / 10.2.x)
+#   tar         6.2.1  -> CVE-2026-23745/23950/24842/
+#                         26960/29786/31802              (fixed 7.5.11)
+#
+# Remediation is two-step because these are *bundled inside npm itself*:
+#   1. Upgrade npm to 11.18.0 (exact pin — reproducible + satisfies
+#      scripts/check_dockerfile_pins.py; npm@<tag> is rejected). npm 11 already
+#      bundles the patched cross-spawn 7.0.6.
+#   2. Overwrite npm's OWN bundled copies of the four flagged packages with the
+#      patched releases. `npm install -g <pkg>@x` installs a SEPARATE global
+#      package and leaves npm's bundled vulnerable copy in place (Trivy would
+#      still flag it), so instead `npm pack` each patched release and extract it
+#      directly over the bundled copy under $(npm root -g)/npm/node_modules.
+#      Exact versions keep the image reproducible (npm pack is not an
+#      `npm install -g` global-CLI install, so it is outside the pin-check).
+# The Node CLI itself is retained — it backs runtime coding-agent delegation
+# (node_coding_agent_invoke_effect); only the vulnerable bundled deps are bumped.
+RUN set -eu; \
+    npm install -g npm@11.18.0; \
+    npm cache clean --force; \
+    NPM_MODULES="$(npm root -g)/npm/node_modules"; \
+    tmp="$(mktemp -d)"; \
+    for spec in cross-spawn@7.0.6 glob@13.0.6 minimatch@10.2.5 tar@7.5.19; do \
+        pkg="${spec%@*}"; \
+        npm pack "$spec" --pack-destination "$tmp" >/dev/null; \
+        tb="$(ls "$tmp/${pkg}"-*.tgz)"; \
+        rm -rf "${NPM_MODULES:?}/${pkg}"; \
+        mkdir -p "${NPM_MODULES}/${pkg}"; \
+        tar -xzf "$tb" -C "${NPM_MODULES}/${pkg}" --strip-components=1; \
+    done; \
+    rm -rf "$tmp"; \
+    for pkg in cross-spawn glob minimatch tar; do \
+        v="$(node -p "require('${NPM_MODULES}/${pkg}/package.json').version")"; \
+        echo "npm bundled ${pkg} patched to ${v}"; \
+    done
 
 # Build-time assert that both coding-agent CLIs resolved on PATH (mirrors the
 # torch/import asserts in the builder stage L388-403). A missing binary must

--- a/tests/unit/docker/test_runtime_dependency_pins.py
+++ b/tests/unit/docker/test_runtime_dependency_pins.py
@@ -41,11 +41,15 @@ def test_omnibase_compat_pin_includes_delegation_wire_contracts(
     # c1a878f chore: release v0.4.0 (pin as of OMN-12421 baseline)
     # 4d887307 fix(OMN-12245): release delegation escalation DTOs (pin as of OMN-12421 advance)
     # v0.5.4  release tag -> 11325233b202449a216b5c862084be3b5e0cae2c
+    # v0.5.5  release tag -> c0fc71681d046e840e0997c04bd26176785a2992 (OMN-13762):
+    #          delegation DTO set is identical to v0.5.4 (verified against the
+    #          v0.5.5 archive tarball — src/omnibase_compat/contracts/delegation/).
     _DELEGATION_WIRE_VERIFIED_REFS = {
         "3e34ab94fad0a9db1c3b59f0e100c5da659b0792",
         "c1a878f1339d396a7f11dee42ea9f0e30fb9c1d1",
         "4d887307aae34d9d40d389ba91070cb411ce3df5",
         "v0.5.4",
+        "v0.5.5",
     }
     assert ref in _DELEGATION_WIRE_VERIFIED_REFS, (
         f"OMNIBASE_COMPAT_SOURCE pin {ref!r} is not in the verified set of refs "


### PR DESCRIPTION
## OMN-13762 — clear Trivy so the clean-main runtime image can push to ECR

The clean-main runtime image (core 0.46.1 / spi 0.23.0 / infra 0.38.4) **builds** fine but its ECR push is **skipped** because `build-and-push-runtime.yml`'s `Run Trivy vulnerability scanner` step (severity CRITICAL,HIGH, exit-code 1, ignore-unfixed) fails on freshly-disclosed CVEs in the **npm-bundled** Node deps that ship with Node 20 (NodeSource npm 10.8.2), under `/usr/lib/node_modules/npm/node_modules/`:

| Package | Bundled | CVE(s) | Fixed |
|---|---|---|---|
| cross-spawn | 7.0.3 | CVE-2024-21538 | 7.0.5 |
| glob | 10.4.2 | CVE-2025-64756 | 10.5.0 / 11.1.0 |
| minimatch | 9.0.5 | CVE-2026-26996 / 27903 / 27904 | ≥9.0.7 / 10.2.x |
| tar | 6.2.1 | CVE-2026-23745 / 23950 / 24842 / 26960 / 29786 / 31802 | 7.5.11 |

Reference failing build: run `28485775117` (Build=success, Trivy=failure, Push=skipped).

### Fix (remediate, not suppress)
`docker/Dockerfile.runtime` runtime stage, after the codex/claude CLI install:
1. Upgrade npm to **11.18.0** (exact pin — `scripts/check_dockerfile_pins.py` rejects dist-tags).
2. Overwrite npm's **own bundled copies** of the four flagged packages with patched releases via `npm pack` + extract over `$(npm root -g)/npm/node_modules` (cross-spawn 7.0.6, glob 13.0.6, minimatch 10.2.5, tar 7.5.19). A plain `npm install -g <pkg>@x` installs a *separate* global package and leaves npm's bundled vulnerable copy in place — Trivy would still flag it.

The Node CLI is **retained** (backs `node_coding_agent_invoke_effect` runtime delegation); only the vulnerable bundled deps are bumped. No `.trivyignore`, no skip token.

**Secondary:** bump `OMNIBASE_COMPAT_REF`/`SOURCE` `v0.5.4` → `v0.5.5` (published tag `e5f665d`) so the image uses published compat.

### Evidence
- All patched versions confirmed published on the npm registry and ≥ each Trivy fixed-version.
- `scripts/check_dockerfile_pins.py` passes (36 pip + 5 npm entries).
- Trivy pass is verified on the post-merge `build-and-push-runtime.yml` run against `main` (this is a Dockerfile change; the scan runs on the built image, not in this PR).

dod_evidence: OMN-13762 — Trivy remediation of runtime-image npm-bundled CVEs; ECR push unblocked on the main rebuild.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the app’s runtime environment with security-related dependency patches.
  * Improved package compatibility in the release build by using a newer supported component version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Evidence-Source: OCC#3391
Evidence-Ticket: OMN-13762